### PR TITLE
chore: setup aliases in Jest

### DIFF
--- a/configs/jest/index.js
+++ b/configs/jest/index.js
@@ -1,0 +1,1 @@
+throw new Error('Can be used only as a preset in Jest');

--- a/configs/jest/jest-preset.js
+++ b/configs/jest/jest-preset.js
@@ -1,0 +1,29 @@
+// @ts-check
+
+const path = require('path');
+const { pathsToModuleNameMapper } = require('ts-jest');
+
+const workspaceRoot = path.resolve(__dirname, '..', '..');
+
+const tsConfig = require(`${workspaceRoot}/tsconfig.aliases.json`);
+const tsPathAliases = pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
+  prefix: `<rootDir>/${path.relative(process.cwd(), workspaceRoot)}/`,
+});
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
+const jestConfig = {
+  cacheDirectory: '<rootDir>/node_modules/.cache/jest',
+  clearMocks: true,
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  moduleNameMapper: { ...tsPathAliases },
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/esm/', '/lib/', '/types/'],
+};
+
+module.exports = jestConfig;

--- a/configs/jest/package.json
+++ b/configs/jest/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@wyw-in-js/jest-preset",
+  "version": "0.0.1",
+  "license": "MIT",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "check": "echo \"Configs have been changed\""
+  }
+}

--- a/configs/jest/turbo.json
+++ b/configs/jest/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "check": {
+      "inputs": ["./*.js"],
+      "outputMode": "new-only"
+    }
+  }
+}

--- a/examples/object-syntax/jest.config.js
+++ b/examples/object-syntax/jest.config.js
@@ -1,13 +1,17 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+// @ts-check
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['**/__tests__/**/*.test.ts'],
+  displayName: 'object-syntax',
+  preset: '@wyw-in-js/jest-preset',
   transform: {
     '^.+\\.ts$': [
       'ts-jest',
       {
-        tsconfig: 'tsconfig.spec.json',
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
       },
     ],
   },

--- a/examples/object-syntax/package.json
+++ b/examples/object-syntax/package.json
@@ -15,50 +15,22 @@
     "@types/node": "^16.18.55",
     "@wyw-in-js/babel-config": "workspace:*",
     "@wyw-in-js/eslint-config": "workspace:*",
+    "@wyw-in-js/jest-preset": "workspace:*",
     "@wyw-in-js/shared": "workspace:*",
     "@wyw-in-js/transform": "workspace:*",
     "@wyw-in-js/ts-config": "workspace:*",
     "dedent": "^1.5.1"
-  },
-  "engines": {
-    "node": ">=16.0.0"
-  },
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./types/index.d.ts",
-      "import": "./esm/index.js",
-      "default": "./lib/index.js"
-    },
-    "./*": {
-      "types": "./types/*.d.ts",
-      "import": "./esm/*.js",
-      "default": "./lib/*.js"
-    }
-  },
-  "files": [
-    "esm/",
-    "lib/",
-    "processors/",
-    "types/"
-  ],
-  "license": "MIT",
-  "wyw-in-js": {
-    "tags": {
-      "makeStyles": "./lib/processors/makeStyles.js"
-    }
-  },
-  "main": "lib/index.js",
-  "module": "esm/index.js",
-  "publishConfig": {
-    "access": "public"
   },
   "scripts": {
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:types": "tsc",
     "lint": "eslint --ext .js,.ts .",
-    "test": "jest --config ./jest.config.js --rootDir src"
+    "test": "jest --config ./jest.config.js"
   },
-  "types": "types/index.d.ts"
+  "wyw-in-js": {
+    "tags": {
+      "makeStyles": "./src/processors/makeStyles.ts"
+    }
+  }
 }

--- a/examples/object-syntax/tsconfig.eslint.json
+++ b/examples/object-syntax/tsconfig.eslint.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": []
+  "include": ["./src/**/*.ts"]
 }

--- a/examples/object-syntax/tsconfig.json
+++ b/examples/object-syntax/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "extends": "@wyw-in-js/ts-config/node.json",
-  "include": ["src/**/*"],
-  "exclude": ["src/__tests__/*", "src/**/__tests__/*"],
-  "compileOnSave": true,
-  "compilerOptions": {
-    "baseUrl": "src/",
-    "module": "CommonJS",
-    "moduleResolution": "node",
-    "outDir": "types",
-    "rootDir": "src/"
-  }
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
 }

--- a/examples/object-syntax/tsconfig.lib.json
+++ b/examples/object-syntax/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./types"
+  },
+  "exclude": ["**/__tests__/*"],
+  "include": ["./src/**/*.ts"]
+}

--- a/examples/object-syntax/tsconfig.spec.json
+++ b/examples/object-syntax/tsconfig.spec.json
@@ -1,5 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts"],
-  "exclude": []
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/__tests__/*"]
 }

--- a/examples/template-tag-syntax/jest.config.js
+++ b/examples/template-tag-syntax/jest.config.js
@@ -1,13 +1,17 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+// @ts-check
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['**/__tests__/**/*.test.ts'],
+  displayName: 'template-tag-syntax',
+  preset: '@wyw-in-js/jest-preset',
   transform: {
     '^.+\\.ts$': [
       'ts-jest',
       {
-        tsconfig: 'tsconfig.spec.json',
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
       },
     ],
   },

--- a/examples/template-tag-syntax/package.json
+++ b/examples/template-tag-syntax/package.json
@@ -14,50 +14,22 @@
     "@types/node": "^16.18.55",
     "@wyw-in-js/babel-config": "workspace:*",
     "@wyw-in-js/eslint-config": "workspace:*",
+    "@wyw-in-js/jest-preset": "workspace:*",
     "@wyw-in-js/shared": "workspace:*",
     "@wyw-in-js/transform": "workspace:*",
     "@wyw-in-js/ts-config": "workspace:*",
     "dedent": "^1.5.1"
-  },
-  "engines": {
-    "node": ">=16.0.0"
-  },
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./types/index.d.ts",
-      "import": "./esm/index.js",
-      "default": "./lib/index.js"
-    },
-    "./*": {
-      "types": "./types/*.d.ts",
-      "import": "./esm/*.js",
-      "default": "./lib/*.js"
-    }
-  },
-  "files": [
-    "esm/",
-    "lib/",
-    "processors/",
-    "types/"
-  ],
-  "license": "MIT",
-  "wyw-in-js": {
-    "tags": {
-      "css": "./lib/processors/css.js"
-    }
-  },
-  "main": "lib/index.js",
-  "module": "esm/index.js",
-  "publishConfig": {
-    "access": "public"
   },
   "scripts": {
     "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:types": "tsc --project ./tsconfig.lib.json --baseUrl . --rootDir ./src",
     "lint": "eslint --ext .js,.ts .",
-    "test": "jest --config ./jest.config.js --rootDir src"
+    "test": "jest --config ./jest.config.js"
   },
-  "types": "types/index.d.ts"
+  "wyw-in-js": {
+    "tags": {
+      "css": "./src/processors/css.ts"
+    }
+  }
 }

--- a/packages/processor-utils/jest.config.js
+++ b/packages/processor-utils/jest.config.js
@@ -1,13 +1,17 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+// @ts-check
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['**/__tests__/**/*.test.ts'],
+  displayName: 'processor-utils',
+  preset: '@wyw-in-js/jest-preset',
   transform: {
     '^.+\\.ts$': [
       'ts-jest',
       {
-        tsconfig: 'tsconfig.spec.json',
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
       },
     ],
   },

--- a/packages/processor-utils/package.json
+++ b/packages/processor-utils/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^16.18.55",
     "@wyw-in-js/babel-config": "workspace:*",
     "@wyw-in-js/eslint-config": "workspace:*",
+    "@wyw-in-js/jest-preset": "workspace:*",
     "@wyw-in-js/ts-config": "workspace:*",
     "typescript": "^5.2.2"
   },
@@ -34,7 +35,7 @@
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:types": "tsc --project ./tsconfig.lib.json --baseUrl . --rootDir ./src",
     "lint": "eslint --ext .js,.ts .",
-    "test": "jest --config ./jest.config.js --rootDir src"
+    "test": "jest --config ./jest.config.js"
   },
   "types": "types/index.d.ts"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,7 @@
     "@types/debug": "^4.1.9",
     "@types/node": "^16.18.55",
     "@wyw-in-js/babel-config": "workspace:*",
+    "@wyw-in-js/jest-preset": "workspace:*",
     "@wyw-in-js/eslint-config": "workspace:*",
     "@wyw-in-js/ts-config": "workspace:*",
     "typescript": "^5.2.2"
@@ -34,7 +35,7 @@
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:types": "tsc --project ./tsconfig.lib.json --baseUrl . --rootDir ./src",
     "lint": "eslint --ext .js,.ts .",
-    "test": "jest --config ./jest.config.js --rootDir src"
+    "test": "jest --config ./jest.config.js"
   },
   "types": "types/index.d.ts"
 }

--- a/packages/transform/jest.config.js
+++ b/packages/transform/jest.config.js
@@ -1,13 +1,17 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+// @ts-check
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['**/__tests__/**/*.test.ts'],
+  displayName: 'transform',
+  preset: '@wyw-in-js/jest-preset',
   transform: {
     '^.+\\.ts$': [
       'ts-jest',
       {
-        tsconfig: 'tsconfig.spec.json',
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        isolatedModules: true,
       },
     ],
   },

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^16.18.55",
     "@wyw-in-js/babel-config": "workspace:*",
     "@wyw-in-js/eslint-config": "workspace:*",
+    "@wyw-in-js/jest-preset": "workspace:*",
     "@wyw-in-js/ts-config": "workspace:*",
     "dedent": "^1.5.1",
     "esbuild": "^0.15.16",
@@ -57,7 +58,7 @@
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:types": "tsc --project ./tsconfig.lib.json --baseUrl . --rootDir ./src",
     "lint": "eslint --ext .js,.ts .",
-    "test": "jest --config ./jest.config.js --rootDir src"
+    "test": "jest --config ./jest.config.js"
   },
   "types": "types/index.d.ts"
 }

--- a/packages/webpack-loader/jest.config.js
+++ b/packages/webpack-loader/jest.config.js
@@ -4,7 +4,7 @@
  * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
-  displayName: 'shared',
+  displayName: 'webpack-loader',
   preset: '@wyw-in-js/jest-preset',
   transform: {
     '^.+\\.ts$': [

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -9,6 +9,7 @@
     "@types/node": "^16.18.55",
     "@wyw-in-js/babel-config": "workspace:*",
     "@wyw-in-js/eslint-config": "workspace:*",
+    "@wyw-in-js/jest-preset": "workspace:*",
     "@wyw-in-js/ts-config": "workspace:*",
     "source-map": "^0.7.4",
     "webpack": "^5.76.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,8 @@ importers:
 
   configs/eslint: {}
 
+  configs/jest: {}
+
   configs/ts: {}
 
   examples/object-syntax:
@@ -129,6 +131,9 @@ importers:
       '@wyw-in-js/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint
+      '@wyw-in-js/jest-preset':
+        specifier: workspace:*
+        version: link:../../configs/jest
       '@wyw-in-js/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -172,6 +177,9 @@ importers:
       '@wyw-in-js/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint
+      '@wyw-in-js/jest-preset':
+        specifier: workspace:*
+        version: link:../../configs/jest
       '@wyw-in-js/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -212,6 +220,9 @@ importers:
       '@wyw-in-js/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint
+      '@wyw-in-js/jest-preset':
+        specifier: workspace:*
+        version: link:../../configs/jest
       '@wyw-in-js/ts-config':
         specifier: workspace:*
         version: link:../../configs/ts
@@ -246,6 +257,9 @@ importers:
       '@wyw-in-js/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint
+      '@wyw-in-js/jest-preset':
+        specifier: workspace:*
+        version: link:../../configs/jest
       '@wyw-in-js/ts-config':
         specifier: workspace:*
         version: link:../../configs/ts
@@ -337,6 +351,9 @@ importers:
       '@wyw-in-js/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint
+      '@wyw-in-js/jest-preset':
+        specifier: workspace:*
+        version: link:../../configs/jest
       '@wyw-in-js/ts-config':
         specifier: workspace:*
         version: link:../../configs/ts
@@ -371,6 +388,9 @@ importers:
       '@wyw-in-js/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint
+      '@wyw-in-js/jest-preset':
+        specifier: workspace:*
+        version: link:../../configs/jest
       '@wyw-in-js/ts-config':
         specifier: workspace:*
         version: link:../../configs/ts

--- a/tsconfig.aliases.json
+++ b/tsconfig.aliases.json
@@ -4,6 +4,7 @@
     "rootDir": ".",
     "baseUrl": ".",
     "paths": {
+      "@wyw-in-js/object-syntax": ["examples/object-syntax/src/index.ts"],
       "@wyw-in-js/processor-utils": ["packages/processor-utils/src/index.ts"],
       "@wyw-in-js/shared": ["packages/shared/src/index.ts"],
       "@wyw-in-js/transform": ["packages/transform/src/index.ts"],


### PR DESCRIPTION
## Summary

Follow up for #4. Enables TS aliases in Jest, so packages rebuilds are not needed anymore 🎉 

- Creates `@wyw-in-js/jest-preset` to store preset
- Modifies `jest.config.js` files to consume new preset
- Updates `package.json` files of examples: removes redundant fields (we don't publish these packages) and points `tags` to source
- Adds ugly fix to `packages/transform/src/utils/findPackageJSON.ts` to workaround a problem with Jest resolver (Jest issue to be reported)