### PR TITLE
fix: add missed executable

### DIFF
--- a/.changeset/sweet-brooms-doubt.md
+++ b/.changeset/sweet-brooms-doubt.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/cli': patch
+---
+
+Executable for CLI has been missed.

--- a/packages/cli/bin/wyw-in-js.js
+++ b/packages/cli/bin/wyw-in-js.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+/* eslint-disable import/no-unresolved */
+
+module.exports = require('../lib/wyw-in-js');


### PR DESCRIPTION
## Motivation

CLI didn't install the bin file. Fixed.

