### PR TITLE
chore: label only issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,13 +2,11 @@ name: labeler
 on:
   issues:
     types: [opened, edited, reopened]
-  pull_request:
-    types: [opened, edited, reopened, ready_for_review, synchronize]
 
 jobs:
   labeler:
     runs-on: ubuntu-latest
-    name: label issues and pull requests
+    name: Label issues
     steps:
       - name: check-out-repository
         uses: actions/checkout@v2
@@ -18,4 +16,4 @@ jobs:
         env:
           ACTIONS_STEP_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
         with:
-          github-token: ${{ secrets.ANBER_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently the workflow runs for issues & PRs. However, functionality for PRs is unused while it fails on PRs from contributors:

<img width="933" alt="image" src="https://github.com/Anber/wyw-in-js/assets/14183168/ce46a1a2-60d5-4779-ad92-e96e71be5b2e">
