### PR TITLE
feat(webpack-loader): export LoaderOptions

### DIFF
--- a/.changeset/afraid-countries-walk.md
+++ b/.changeset/afraid-countries-walk.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/webpack-loader": patch
+---
+
+feat: export LoaderOptions

--- a/packages/webpack-loader/src/index.ts
+++ b/packages/webpack-loader/src/index.ts
@@ -21,12 +21,13 @@ export { WYWinJSDebugPlugin } from './WYWinJSDebugPlugin';
 
 const outputCssLoader = require.resolve('./outputCssLoader');
 
-type Loader = RawLoaderDefinitionFunction<{
+export type LoaderOptions = {
   cacheProvider?: string | ICache;
   extension?: string;
   preprocessor?: Preprocessor;
   sourceMap?: boolean;
-}>;
+};
+type Loader = RawLoaderDefinitionFunction<LoaderOptions>;
 
 const cache = new TransformCacheCollection();
 


### PR DESCRIPTION
## Motivation

Exports `LoaderOptions` type from `@wyw-in-js/webpack-loader`, fixes #28.