### PR TITLE
fix(transform): remove constant violations with their bindings

### DIFF
--- a/.changeset/two-zoos-smoke.md
+++ b/.changeset/two-zoos-smoke.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Sometimes, usages of variables survive the shaker even when their bindings are removed. Fixed.

--- a/packages/transform/src/__tests__/__snapshots__/shaker.test.ts.snap
+++ b/packages/transform/src/__tests__/__snapshots__/shaker.test.ts.snap
@@ -15,3 +15,16 @@ exports.__wywPreval = {
   _exp: _exp
 };"
 `;
+
+exports[`shaker should remove enum 1`] = `
+""use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.__wywPreval = void 0;
+const _exp2 = /*#__PURE__*/() => "t2nn9pk";
+const __wywPreval = exports.__wywPreval = {
+  _exp2: _exp2
+};"
+`;

--- a/packages/transform/src/__tests__/shaker.test.ts
+++ b/packages/transform/src/__tests__/shaker.test.ts
@@ -52,4 +52,22 @@ describe('shaker', () => {
 
     expect(code).toMatchSnapshot();
   });
+
+  it('should remove enum', () => {
+    const code = run(['__wywPreval'])`
+      "use strict";
+
+      var PanelKinds;
+      (function (PanelKinds) {
+        PanelKinds["DEFAULT"] = "default";
+        PanelKinds["TRANSPARENT"] = "transparent";
+      })(PanelKinds = exports.PanelKinds || (exports.PanelKinds = {}));
+      const _exp2 = /*#__PURE__*/() => "t2nn9pk";
+      export const __wywPreval = {
+        _exp2: _exp2,
+      };
+    `;
+
+    expect(code).toMatchSnapshot();
+  });
 });

--- a/packages/transform/src/plugins/shaker.ts
+++ b/packages/transform/src/plugins/shaker.ts
@@ -395,6 +395,7 @@ export default function shakerPlugin(
               binding.path.isVariableDeclarator() &&
               !forDeleting.includes(binding.path.get('id'))
             ) {
+              forDeleting.push(...binding.constantViolations);
               forDeleting.push(binding.path.get('id'));
               changed = true;
             }


### PR DESCRIPTION
## Motivation

In some cases, Shaker keeps usages of variables alive even though their bindings are removed. 

## Test plan

One new test was added.