### PR TITLE
fix(esbuild): mjs extensions in esm build

### DIFF
--- a/.changeset/angry-pugs-sparkle.md
+++ b/.changeset/angry-pugs-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/esbuild': patch
+---
+
+Use mjs extensions in esm build of esbuild.

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -17,7 +17,7 @@
     "node": ">=16.0.0"
   },
   "exports": {
-    "import": "./esm/index.js",
+    "import": "./esm/index.mjs",
     "require": "./lib/index.js",
     "types": "./types/index.d.ts"
   },
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "esm/index.js",
+  "module": "esm/index.mjs",
   "peerDependencies": {
     "esbuild": ">=0.12.0"
   },
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "scripts": {
-    "build:esm": "babel src --out-dir esm --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
+    "build:esm": "babel src --out-dir esm --out-file-extension .mjs --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:types": "tsc --project ./tsconfig.lib.json --baseUrl . --rootDir ./src",
     "lint": "eslint --ext .js,.ts ."


### PR DESCRIPTION
## Motivation

ESM should have `mjs` as a file extension.