### PR TITLE
fix(rollup): remove broken "is it vite?" check

### DIFF
--- a/.changeset/serious-carpets-float.md
+++ b/.changeset/serious-carpets-float.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/rollup': patch
+---
+
+Remove outdated "is it Vite?" check. Fixes #38.

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -133,13 +133,5 @@ export default function wywInJS({
     getOwnPropertyDescriptor(target, prop) {
       return Object.getOwnPropertyDescriptor(target, prop as keyof Plugin);
     },
-
-    ownKeys() {
-      // Rollup doesn't ask config about its own keys, so it is Vite.
-
-      throw new Error(
-        'You are trying to use @wyw-in-js/rollup with Vite. Please use @wyw-in-js/vite instead.'
-      );
-    },
   });
 }


### PR DESCRIPTION
## Motivation

See #38

## Summary

The check is no longer needed since it was added when the Vite plugin was just introduced in Linaria.