### PR TITLE
fix(shared): crash while resolving esm-only package

### DIFF
--- a/.changeset/empty-poets-kick.md
+++ b/.changeset/empty-poets-kick.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/shared': patch
+---
+
+Fix crash while resolving esm-only package. Fixes #43


### PR DESCRIPTION
## Motivation

See #43 

## Summary

`require` can't resolve ESM-only packages. We can use the `resolve` package here, but it does not solve all cases because `pkgName` can be an alias and should be resolved by a bundler. However, we can't use `resolve` from a bundler because it is async. The good news is that in that specific case, we can just ignore those packages. For now.