### PR TITLE
feat(esbuild): filter option that allows to process only specific files

### DIFF
--- a/.changeset/quick-bulldogs-lick.md
+++ b/.changeset/quick-bulldogs-lick.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/esbuild': patch
+'@wyw-in-js/website': patch
+---
+
+The new `filter` options for the esbuild plugin that allows to process only specific files, e.g. `.styles.ts`.

--- a/apps/website/pages/bundlers/esbuild.mdx
+++ b/apps/website/pages/bundlers/esbuild.mdx
@@ -16,6 +16,7 @@ const prod = process.env.NODE_ENV === 'production';
 
 esbuild
   .build({
+    filter: /\.(js|jsx|ts|tsx)$/,
     entryPoints: ['src/index.ts'],
     outdir: 'dist',
     bundle: true,

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -19,6 +19,7 @@ import {
 
 type EsbuildPluginOptions = {
   esbuildOptions?: TransformOptions;
+  filter?: RegExp | string;
   preprocessor?: Preprocessor;
   sourceMap?: boolean;
 } & Partial<PluginOptions>;
@@ -29,6 +30,7 @@ export default function wywInJS({
   sourceMap,
   preprocessor,
   esbuildOptions,
+  filter = /\.(js|jsx|ts|tsx)$/,
   ...rest
 }: EsbuildPluginOptions = {}): Plugin {
   let options = esbuildOptions;
@@ -73,7 +75,10 @@ export default function wywInJS({
         };
       });
 
-      build.onLoad({ filter: /\.(js|jsx|ts|tsx)$/ }, async (args) => {
+      const filterRegexp =
+        typeof filter === 'string' ? new RegExp(filter) : filter;
+
+      build.onLoad({ filter: filterRegexp }, async (args) => {
         const rawCode = readFileSync(args.path, 'utf8');
         const { ext, name: filename } = parse(args.path);
         const loader = ext.replace(/^\./, '') as Loader;


### PR DESCRIPTION
## Motivation

A well-maintained code base can have styles only in specific files (e.g., `Button.styles.ts`). By default, wyw processes all files in an attempt to find styles for extraction. The new option `filter` allows to limit such useless work.

## Summary

For now, `filter` has been introduced only for `esbuild`.