### PR TITLE
feat(transform): scoped keyframes

### DIFF
--- a/.changeset/nine-vans-drive.md
+++ b/.changeset/nine-vans-drive.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': minor
+---
+
+Keyframes are now scoped by default. This behaviour can be changed by `:global()`: `@keyframes :global(bar) {…}`, `animation-name: :global(bar);`.

--- a/packages/transform/src/transform/generators/__tests__/createStylisProcessor.test.ts
+++ b/packages/transform/src/transform/generators/__tests__/createStylisProcessor.test.ts
@@ -26,7 +26,15 @@ describe('createStylisPreprocessor', () => {
   });
 
   describe('keyframes', () => {
-    it('should add suffix', () => {
+    it('should add suffix to @keyframes', () => {
+      expect(
+        compileRule('@keyframes bar { from { color: red } }')
+      ).toMatchInlineSnapshot(
+        `"@-webkit-keyframes bar-foo{from{color:red;}}@keyframes bar-foo{from{color:red;}}"`
+      );
+    });
+
+    it('should add suffix to animation', () => {
       expect(
         compileRule(
           '& { animation: bar 0s forwards; } @keyframes bar { from { color: red } }'
@@ -36,14 +44,42 @@ describe('createStylisPreprocessor', () => {
       );
     });
 
-    it('should ignore global', () => {
+    it('should add suffix to animation-name', () => {
       expect(
         compileRule(
-          '@keyframes :global(bar) { from { color: red } } & { animation: :global(bar) 0s forwards; }'
+          '& { animation-name: bar; } @keyframes bar { from { color: red } }'
         )
       ).toMatchInlineSnapshot(
-        `"@-webkit-keyframes bar{from{color:red;}}@keyframes bar{from{color:red;}}.foo{animation:bar 0s forwards;}"`
+        `".foo{animation-name:bar-foo;}@-webkit-keyframes bar-foo{from{color:red;}}@keyframes bar-foo{from{color:red;}}"`
       );
+    });
+
+    it('should ignore unknown keyframes', () => {
+      expect(compileRule('& { animation-name: bar; }')).toMatchInlineSnapshot(
+        `".foo{animation-name:bar;}"`
+      );
+    });
+
+    describe('should unwrap global', () => {
+      it('in @keyframes', () => {
+        expect(
+          compileRule('@keyframes :global(bar) { from { color: red } }')
+        ).toMatchInlineSnapshot(
+          `"@-webkit-keyframes bar{from{color:red;}}@keyframes bar{from{color:red;}}"`
+        );
+      });
+
+      it('in animation', () => {
+        expect(
+          compileRule('& { animation: :global(bar) 0s forwards; }')
+        ).toMatchInlineSnapshot(`".foo{animation:bar 0s forwards;}"`);
+      });
+
+      it('in animation-name', () => {
+        expect(
+          compileRule('& { animation-name: :global(bar); }')
+        ).toMatchInlineSnapshot(`".foo{animation-name:bar;}"`);
+      });
     });
   });
 });


### PR DESCRIPTION
## Motivation

Originally in Linaria, keyframes were scoped. This behaviour was broken during migration to Stylis@4.

## Summary

The old behaviour has been restored. Also, support for the `:global` selector in keyframes has been added.

## Test plan

A few new tests were added.
