### PR TITLE
feat(transform): replace object spread with Proxy in getTagProcessor

### DIFF
--- a/.changeset/stale-stingrays-judge.md
+++ b/.changeset/stale-stingrays-judge.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Found out that an object spread can be extremely slow. getTagProcessor now works 10 times faster.

--- a/packages/transform/src/transform/Entrypoint.helpers.ts
+++ b/packages/transform/src/transform/Entrypoint.helpers.ts
@@ -89,6 +89,7 @@ function buildConfigs(
 
   const commonOptions = {
     ast: true,
+    compact: true,
     filename: name,
     inputSourceMap: options.inputSourceMap,
     root: options.root,

--- a/packages/transform/src/transform/Entrypoint.helpers.ts
+++ b/packages/transform/src/transform/Entrypoint.helpers.ts
@@ -89,7 +89,6 @@ function buildConfigs(
 
   const commonOptions = {
     ast: true,
-    compact: true,
     filename: name,
     inputSourceMap: options.inputSourceMap,
     root: options.root,

--- a/packages/transform/src/utils/getTagProcessor.ts
+++ b/packages/transform/src/utils/getTagProcessor.ts
@@ -315,8 +315,7 @@ function getBuilderForIdentifier(
     });
   };
 
-  const astService = {
-    ...t,
+  const importHelpers = {
     addDefaultImport: (importedSource: string, nameHint?: string) =>
       addDefault(path, importedSource, { nameHint }),
     addNamedImport: (
@@ -325,6 +324,18 @@ function getBuilderForIdentifier(
       nameHint: string = name
     ) => addNamed(path, name, importedSource, { nameHint }),
   };
+
+  type AstService = typeof t & typeof importHelpers;
+
+  const astService = new Proxy<AstService>(t as AstService, {
+    get(target, prop, receiver) {
+      if (prop in importHelpers) {
+        return importHelpers[prop as keyof typeof importHelpers];
+      }
+
+      return Reflect.get(target, prop, receiver);
+    },
+  });
 
   return (...args: BuilderArgs) =>
     new Processor(


### PR DESCRIPTION
## Motivation

I found out that an object spread can be extremely slow. Even slower than AST traverse and file operations. `getTagProcessor` now works 10 times faster.