### PR TITLE
feat(processor-utils): Add `index` to ClassNameSlugVars

### DIFF
--- a/.changeset/few-dolphins-unite.md
+++ b/.changeset/few-dolphins-unite.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/processor-utils': minor
+'@wyw-in-js/shared': minor
+---
+
+Add `index` to ClassNameSlugVars

--- a/apps/website/pages/configuration.mdx
+++ b/apps/website/pages/configuration.mdx
@@ -130,7 +130,7 @@ You may also use a function to define the slug. The function will be evaluated a
 
 Would generate the class name `.absdjfsdf__42__header`.
 
-Last argument `args` is an object that contains following properties: `title`, `hash`, `dir`, `ext`, `file`, `name`. These properties
+Last argument `args` is an object that contains following properties: `title`, `hash`, `idx`, `dir`, `ext`, `file`, `name`. These properties
 are useful when you want to generate your own hash:
 
 ```js

--- a/packages/processor-utils/src/utils/getClassNameAndSlug.ts
+++ b/packages/processor-utils/src/utils/getClassNameAndSlug.ts
@@ -33,6 +33,7 @@ export default function getClassNameAndSlug(
   const slugVars: ClassNameSlugVars = {
     hash: slug,
     title: displayName,
+    index: idx,
     file: relativeFilename,
     ext,
     name: basename(relativeFilename, ext),

--- a/packages/shared/src/options/types.ts
+++ b/packages/shared/src/options/types.ts
@@ -12,6 +12,7 @@ export type ClassNameSlugVars = {
   ext: string;
   file: string;
   hash: string;
+  index: number;
   name: string;
   title: string;
 };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

we use `index` in default `slugify` but not available for custom `classNameSlug`, this change expose `index` so we can achieve the same as default behaviour, we need it as we need to build it from another folder for website while the `relativeFilename` is different, so I have to normalise it to be the same as build from the lib

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
