### PR TITLE
fix(transform): fix animation name suffixer

### DIFF
--- a/.changeset/quiet-zoos-hang.md
+++ b/.changeset/quiet-zoos-hang.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/transform': patch
+'wyw-in-js': patch
+---
+
+Fix an issue when some animation names are not suffixed.

--- a/packages/transform/src/transform/generators/__tests__/createStylisProcessor.test.ts
+++ b/packages/transform/src/transform/generators/__tests__/createStylisProcessor.test.ts
@@ -45,12 +45,22 @@ describe('createStylisPreprocessor', () => {
     });
 
     it('should add suffix to animation-name', () => {
+      // Usage before definition
       expect(
         compileRule(
           '& { animation-name: bar; } @keyframes bar { from { color: red } }'
         )
       ).toMatchInlineSnapshot(
         `".foo{animation-name:bar-foo;}@-webkit-keyframes bar-foo{from{color:red;}}@keyframes bar-foo{from{color:red;}}"`
+      );
+
+      // Usage after definition
+      expect(
+        compileRule(
+          '@keyframes bar { from { color: red } } & { animation-name: bar; }'
+        )
+      ).toMatchInlineSnapshot(
+        `"@-webkit-keyframes bar-foo{from{color:red;}}@keyframes bar-foo{from{color:red;}}.foo{animation-name:bar-foo;}"`
       );
     });
 
@@ -79,6 +89,24 @@ describe('createStylisPreprocessor', () => {
         expect(
           compileRule('& { animation-name: :global(bar); }')
         ).toMatchInlineSnapshot(`".foo{animation-name:bar;}"`);
+      });
+
+      it('in @keyframes and animation-name simultaneously', () => {
+        expect(
+          compileRule(
+            '@keyframes :global(bar) { from { color: red } } & { animation-name: :global(bar); }'
+          )
+        ).toMatchInlineSnapshot(
+          `"@-webkit-keyframes bar{from{color:red;}}@keyframes bar{from{color:red;}}.foo{animation-name:bar;}"`
+        );
+
+        expect(
+          compileRule(
+            '& { animation-name: :global(bar); } @keyframes :global(bar) { from { color: red } }'
+          )
+        ).toMatchInlineSnapshot(
+          `".foo{animation-name:bar;}@-webkit-keyframes bar{from{color:red;}}@keyframes bar{from{color:red;}}"`
+        );
       });
     });
   });


### PR DESCRIPTION
## Motivation

Suffixer didn't work when keyframes were defined before usages.

## Summary

Fixed.

## Test plan

A couple of new tests were added.