### PR TITLE
feat(transform): allow non-usage of WeakRef in Module conditionally

### DIFF
--- a/.changeset/weak-yaks-call.md
+++ b/.changeset/weak-yaks-call.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Allow conditional usage of WeakRef in Module evalutation through a new feature flag `useWeakRefInEval`

--- a/packages/shared/src/options/types.ts
+++ b/packages/shared/src/options/types.ts
@@ -58,6 +58,7 @@ type AllFeatureFlags = {
   happyDOM: FeatureFlag;
   softErrors: FeatureFlag;
   useBabelConfigs: FeatureFlag;
+  useWeakRefInEval: FeatureFlag;
 };
 
 export type FeatureFlags<

--- a/packages/transform/src/__tests__/module.test.ts
+++ b/packages/transform/src/__tests__/module.test.ts
@@ -25,6 +25,7 @@ const options: StrictOptions = {
     happyDOM: true,
     softErrors: false,
     useBabelConfigs: true,
+    useWeakRefInEval: true,
   },
   highPriorityPlugins: [],
   overrideContext: (context) => ({

--- a/packages/transform/src/__tests__/shaker.test.ts
+++ b/packages/transform/src/__tests__/shaker.test.ts
@@ -26,6 +26,7 @@ const run = (only: string[]) => (code: TemplateStringsArray) => {
         happyDOM: false,
         softErrors: false,
         useBabelConfigs: false,
+        useWeakRefInEval: true,
       },
       highPriorityPlugins: [],
       onlyExports: only,

--- a/packages/transform/src/transform/helpers/loadWywOptions.ts
+++ b/packages/transform/src/transform/helpers/loadWywOptions.ts
@@ -55,6 +55,7 @@ export function loadWywOptions(
     happyDOM: true,
     softErrors: false,
     useBabelConfigs: true,
+    useWeakRefInEval: true,
   };
 
   const options: StrictOptions = {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

This PR tries to address this [issue](https://github.com/callstack/linaria/issues/1352) conditionally when it occurs too frequently. This is not a proper fix but a work around at the cost of memory consumption. 

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

This works by introducing a new feature flag `useWeakRefInEval` that is true by default. If someone wants, they can set it to `false` in their `wyw-in-js` config to disable the usage of `WeakRef`.

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->

I tested locally in a fairly moderate example Pigment CSS repo. I can add tests on guidance.