### PR TITLE
fix(vite): Fix CSS replacement in Vite HMR

### DIFF
--- a/.changeset/gold-bags-fry.md
+++ b/.changeset/gold-bags-fry.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/vite': patch
+---
+
+Fix CSS updation during Vite HMR where the new change wouldn't get correctly applied

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -2,7 +2,6 @@
   "name": "@wyw-in-js/vite",
   "version": "0.5.0",
   "dependencies": {
-    "@rollup/pluginutils": "^5.0.4",
     "@wyw-in-js/shared": "workspace:*",
     "@wyw-in-js/transform": "workspace:*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,9 +597,6 @@ importers:
 
   packages/vite:
     dependencies:
-      '@rollup/pluginutils':
-        specifier: ^5.0.4
-        version: 5.0.4(rollup@3.29.4)
       '@wyw-in-js/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
Also remove dependency on @rollup/plugin-utils

<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

This PR fixes an [issue](https://github.com/mui/material-ui/issues/41628) related to Vite plugin originally opened on Pigment CSS repo.
<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

This change avoids the usage of css content slug in the filename and keeps the css filename unique just by using the path of the original js/ts file and using `wyw-in-js` prefix before the extension.
Using slug had an issue where if you removed a css property from your css definition, it would get applied in a new `style` tag during dev mode. Thus also keeping the old css in place which would result in overall css being applied from both old and new css content.

The fix instead keeps using the same filename regardless of the content and just pings the FE to reload the latest CSS content which it replaces in the existing `style` tag instead of adding a new one.

I also removed the explicit dependency of @rollup/plugin-utils since `vite` already re-exports those.

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->

Tested locally using this [repo](https://github.com/o-alexandrov/pigment-css-hmr-bug) for the bug reproduction and fix.

