### PR TITLE
fix(shared): process.env is undefined on non-node runtime issue

### DIFF
--- a/packages/shared/src/findPackageJSON.ts
+++ b/packages/shared/src/findPackageJSON.ts
@@ -10,7 +10,7 @@ export function findPackageJSON(
   filename: string | null | undefined
 ) {
   // Jest's resolver does not work properly with `moduleNameMapper` when `paths` are defined
-  const isJest = Boolean(process.env.JEST_WORKER_ID);
+  const isJest = Boolean(globalThis.process?.env?.JEST_WORKER_ID);
   const skipPathsOptions = isJest && !pkgName.startsWith('.');
 
   try {

--- a/packages/shared/src/findPackageJSON.ts
+++ b/packages/shared/src/findPackageJSON.ts
@@ -1,6 +1,4 @@
 import { dirname, isAbsolute } from 'path';
-import * as process from 'process';
-
 import findUp from 'find-up';
 
 const cache = new Map<string, string | undefined>();


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

#92

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

- Access `process` from `globalThis` to support non-node runtime
- Add null check to `process.env`

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->

1. Reproduce #92 on https://github.com/AsukaCHikaru/wyw-in-js-vite-env-issue
2. Execute `npm run build` on this PR
3. Copy `packages/shared/lib/findPackageJSON.js` to `node_modules/.deno/@wyw-in-js+shared@0.5.3/node_modules/@wyw-in-js/shared/lib/findPackageJSON.js`
4. Execute `deno task dev` and access `localhost:5173`
