### PR TITLE
fix(shared): invalid export of interface

### DIFF
--- a/.changeset/dry-cobras-check.md
+++ b/.changeset/dry-cobras-check.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/shared": patch
+---
+
+fix(shared): invalid export of interface

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,12 +4,12 @@ export { asyncResolveFallback, syncResolve } from './asyncResolveFallback';
 export { hasEvalMeta } from './hasEvalMeta';
 export { findPackageJSON } from './findPackageJSON';
 export { isBoxedPrimitive } from './isBoxedPrimitive';
-export { IVariableContext } from './IVariableContext';
 export { enableDebug, logger } from './logger';
 export { isFeatureEnabled } from './options/isFeatureEnabled';
 export { slugify } from './slugify';
 export { ValueType } from './types';
 
+export type { IVariableContext } from './IVariableContext';
 export type {
   ClassNameSlugVars,
   ClassNameFn,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

When importing from WyW packages from within a Vite environment, the following error occurs:

```
✘ [ERROR] No matching export in "node_modules/.pnpm/@wyw-in-js+shared@0.5.4/node_modules/@wyw-in-js/shared/esm/IVariableContext.js" for import "IVariableContext"

    node_modules/.pnpm/@wyw-in-js+shared@0.5.4/node_modules/@wyw-in-js/shared/esm/index.js:6:9:
      6 │ export { IVariableContext } from './IVariableContext';
        ╵          ~~~~~~~~~~~~~~~~
```

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

It appears that `IVariableContext` is being re-exported as if it were a variable available at runtime:

https://github.com/Anber/wyw-in-js/blob/d3c2791adacd7c20e8ace2417fae5aab5fce7814/packages/shared/src/index.ts#L7

However, the [file referenced in the ESM distribution](https://unpkg.com/browse/@wyw-in-js/shared@0.5.4/esm/IVariableContext.js) doesn’t contain an export named `IVariableContext`, as interfaces are type-level constructs:

<img width="1219" alt="image" src="https://github.com/user-attachments/assets/9540d841-bf90-453c-a1ad-9aa78e6b6095">

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->

Tested locally and the issue gets resolved by this change.
