### PR TITLE
feat(transform): pass source file path to tag resolver

### DIFF
--- a/.changeset/twenty-toys-exist.md
+++ b/.changeset/twenty-toys-exist.md
@@ -1,0 +1,7 @@
+---
+'@wyw-in-js/transform': minor
+'@wyw-in-js/shared': minor
+'wyw-in-js': minor
+---
+
+Pass source file path to custom tag resolvers

--- a/packages/shared/src/options/types.ts
+++ b/packages/shared/src/options/types.ts
@@ -85,7 +85,11 @@ export type StrictOptions = {
     filename: string
   ) => Partial<VmContext>;
   rules: EvalRule[];
-  tagResolver?: (source: string, tag: string) => string | null;
+  tagResolver?: (
+    source: string,
+    tag: string,
+    sourceFile: string
+  ) => string | null;
   variableNameConfig?: 'var' | 'dashes' | 'raw';
   variableNameSlug?: string | VariableNameFn;
 };

--- a/packages/transform/src/utils/getTagProcessor.ts
+++ b/packages/transform/src/utils/getTagProcessor.ts
@@ -146,12 +146,12 @@ function getProcessorFromFile(processorPath: string): ProcessorClass | null {
 
 export function getProcessorForImport(
   { imported, source }: IImport,
-  filename: string | null | undefined,
+  filename: string,
   options: Pick<StrictOptions, 'tagResolver'>
 ): [ProcessorClass | null, TagSource] {
   const tagResolver = options.tagResolver ?? (() => null);
 
-  const customFile = tagResolver(source, imported);
+  const customFile = tagResolver(source, imported, filename);
   const processor = customFile
     ? getProcessorFromFile(customFile)
     : getProcessorFromPackage(source, imported, filename);
@@ -395,7 +395,7 @@ const getNextIndex = (state: IFileContext) => {
 export function getDefinedProcessors(
   imports: IImport[],
   path: NodePath<Program>,
-  filename: string | null | undefined,
+  filename: string,
   options: Pick<StrictOptions, 'tagResolver'>
 ): DefinedProcessors {
   const cache = getTraversalCache<DefinedProcessors, NodePath<Program>>(
@@ -517,7 +517,7 @@ export function applyProcessors(
   const definedProcessors = getDefinedProcessors(
     imports,
     path,
-    fileContext.filename,
+    fileContext.filename!,
     options
   );
 


### PR DESCRIPTION
Fixes #139

### Implementation details

I have allowed myself the freedom of using a non-null assertion on `fileContext.filename` without much investigation because such assertions are already made before calling `applyProcessors` in both places where it is used:

https://github.com/Anber/wyw-in-js/blob/a549a16fcebe6fc8a7c77b2de1b769dd81520375/packages/transform/src/plugins/preeval.ts#L39

https://github.com/Anber/wyw-in-js/blob/a549a16fcebe6fc8a7c77b2de1b769dd81520375/packages/transform/src/plugins/babel-transform.ts#L52