### PR TITLE
fix: handle undefined object in cache correctly

### DIFF
--- a/packages/transform/src/__tests__/cache.test.ts
+++ b/packages/transform/src/__tests__/cache.test.ts
@@ -192,4 +192,12 @@ describe('TransformCacheCollection', () => {
       expect(mockedReadFileSync).toHaveBeenCalledWith(leafName, 'utf8');
     });
   });
+
+  it('should be able to handle undefined values in the cache', () => {
+    const cache = new TransformCacheCollection<MockEntrypoint>();
+
+    expect(() => {
+      cache.add('entrypoints', 'empty-style.js', undefined as any);
+    }).not.toThrow();
+  });
 });

--- a/packages/transform/src/cache.ts
+++ b/packages/transform/src/cache.ts
@@ -64,7 +64,7 @@ export class TransformCacheCollection<
 
     cache.set(key, value);
 
-    if ('initialCode' in value) {
+    if (value && 'initialCode' in value) {
       this.contentHashes.set(key, hashContent(value.initialCode ?? ''));
     }
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation
Fixes: [!144](https://github.com/Anber/wyw-in-js/issues/144)
This PR addresses an issue where the cache did not correctly handle cases when an object was undefined.
<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

- Updated the cache implementation to properly handle cases where the cached object is undefined.
- Added a test in cache.test.ts to cover this scenario and ensure correct behavior.
<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan

- Added a new test in packages/transform/src/__tests__/cache.test.ts to verify that the cache correctly handles undefined objects.
- Ran the test suite to confirm that all tests pass and the new case is covered.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
