### PR TITLE
Update feature flags docs with useWeakRefInEval

### DIFF
--- a/apps/website/pages/feature-flags.mdx
+++ b/apps/website/pages/feature-flags.mdx
@@ -71,5 +71,16 @@ Please note that the default value of `useBabelConfigs` will be changed to `fals
 
 # `useWeakRefInEval` Feature
 
-The `useWeakRefInEval` feature is enabled by default. If it is enabled, WyW-in-JS will use WeakRef in Module evalutation. WeakRef is a memory optimisation but can cause `EvalError: Module X is disposed` erorrs in some cases. See: https://github.com/callstack/linaria/issues/1352.
+The `useWeakRefInEval` feature is enabled by default. With it on, WyW-in-JS wraps evaluated modules in `WeakRef` to reduce memory usage during long-running builds. Garbage collection can reclaim these weak references in some environments, which may surface as `EvalError: Module X is disposed` when a disposed module is accessed again. If you encounter that error pattern, disable this flag to keep strong references (at the cost of higher memory usage).
 
+See: [callstack/linaria#1352](https://github.com/callstack/linaria/issues/1352).
+
+### Disable example
+
+```js
+{
+  features: {
+    useWeakRefInEval: false,
+  },
+}
+```


### PR DESCRIPTION
## Motivation

`useWeakRefInEval`  feature flag was added in this PR but is not in the docs https://github.com/Anber/wyw-in-js/pull/71

## Summary

N/A just docs change

## Test plan

N/A just docs change