### PR TITLE
ci: add Node 24, drop Node 18

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
         include:
           - os: windows-latest
             node-version: 20.x


### PR DESCRIPTION
- drop Node 18 from the CI matrix (EOL)
- add Node 24 to ubuntu matrix alongside 20.x and 22.x
- keep Windows runner on 20.x