### PR TITLE
fix(transform): avoid evaluating unused imports

### DIFF
--- a/.changeset/shaker-unused-imports.md
+++ b/.changeset/shaker-unused-imports.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Avoid retaining unused import specifiers during shaking so eval doesn't load unrelated deps.


### PR DESCRIPTION
## Summary
- drop unused import specifiers during shaker pruning to avoid eval of unrelated deps
- add shaker tests for function + const export patterns
- add changeset for @wyw-in-js/transform patch

## Testing
- pnpm turbo run test --filter @wyw-in-js/transform
- pnpm turbo run test --filter @wyw-in-js/e2e-vite

## Manual repro
- verified Vite dev in [issues/159/repro](https://github.com/eramdam/wyw-in-js-react-aria-repro/) with both export patterns (function/const)