### PR TITLE
Sanitize esbuild filter flags for Go regex compatibility

### DIFF
--- a/.changeset/sanitize-esbuild-filter.md
+++ b/.changeset/sanitize-esbuild-filter.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/esbuild': patch
+---
+
+Sanitize esbuild plugin filter RegExp flags for Go regex compatibility and warn when unsupported flags are ignored.

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -39,7 +39,8 @@
     "build:esm": "babel src --out-dir esm --out-file-extension .mjs --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:types": "tsc --project ./tsconfig.lib.json --baseUrl . --rootDir ./src",
-    "lint": "eslint --ext .js,.ts ."
+    "lint": "eslint --ext .js,.ts .",
+    "test": "jest --config ./jest.config.js"
   },
   "types": "types/index.d.ts"
 }

--- a/packages/esbuild/src/__tests__/filter.test.ts
+++ b/packages/esbuild/src/__tests__/filter.test.ts
@@ -1,0 +1,55 @@
+import type { PluginBuild } from 'esbuild';
+
+import wywInJS from '../index';
+
+const createBuild = (): PluginBuild => {
+  return {
+    onLoad: jest.fn(),
+    onResolve: jest.fn(),
+    onEnd: jest.fn(),
+    resolve: jest.fn().mockResolvedValue({ errors: [], path: '' }),
+    initialOptions: {},
+  } as unknown as PluginBuild;
+};
+
+const getOnLoadFilter = (build: PluginBuild): RegExp => {
+  const call = (build.onLoad as jest.Mock).mock.calls.find(
+    ([options]) => !('namespace' in options)
+  );
+  if (!call) {
+    throw new Error('Expected onLoad registration for main filter.');
+  }
+  return call[0].filter as RegExp;
+};
+
+describe('esbuild filter normalization', () => {
+  it('sanitizes unsupported flags and warns', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const build = createBuild();
+
+    wywInJS({ filter: /\.styles\.ts$/gu }).setup(build);
+
+    const filter = getOnLoadFilter(build);
+    expect(filter.flags).toBe('');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('unsupported RegExp flags');
+    expect(message).toContain('g');
+    expect(message).toContain('u');
+
+    warnSpy.mockRestore();
+  });
+
+  it('keeps supported flags without warning', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const build = createBuild();
+
+    wywInJS({ filter: /\.styles\.ts$/ims }).setup(build);
+
+    const filter = getOnLoadFilter(build);
+    expect(filter.flags.split('').sort().join('')).toBe('ims');
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize RegExp flags for esbuild onLoad filters and warn when unsupported flags are ignored
- add regression tests for filter normalization
- add a patch changeset for `@wyw-in-js/esbuild`

## Testing
- `pnpm -w turbo run lint --filter @wyw-in-js/esbuild`
- `pnpm -w turbo run test --filter @wyw-in-js/esbuild`
