### PR TITLE
fix(transform): support array destructuring exports (#106)

### DIFF
--- a/.changeset/array-destructuring-exports.md
+++ b/.changeset/array-destructuring-exports.md
@@ -1,0 +1,4 @@
+'@wyw-in-js/transform': patch
+---
+
+Fix export detection for array destructuring declarations (e.g. `export const [B] = ...`).

--- a/packages/transform/src/transform/generators/__tests__/explodeReexports.array-pattern.test.ts
+++ b/packages/transform/src/transform/generators/__tests__/explodeReexports.array-pattern.test.ts
@@ -1,0 +1,116 @@
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import * as babel from '@babel/core';
+
+import { loadWywOptions } from '../../helpers/loadWywOptions';
+import { withDefaultServices } from '../../helpers/withDefaultServices';
+import { Entrypoint } from '../../Entrypoint';
+import type { IEntrypointDependency } from '../../Entrypoint.types';
+import { getExports } from '../getExports';
+import { explodeReexports } from '../explodeReexports';
+
+import {
+  expectIteratorReturnResult,
+  expectIteratorYieldResult,
+} from './helpers';
+
+describe('explodeReexports: ArrayPattern', () => {
+  it('rewrites `export *` to named reexports including array-destructured exports', () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-issue-106-'));
+    const fileA = join(root, 'a.ts');
+    const fileB = join(root, 'b.ts');
+
+    writeFileSync(
+      fileA,
+      ['export const A = 100;', 'export const [B] = [200];', ''].join('\n')
+    );
+
+    writeFileSync(
+      fileB,
+      ["export * from './a';", '', 'export const className = 42;', ''].join(
+        '\n'
+      )
+    );
+
+    const pluginOptions = loadWywOptions({
+      configFile: false,
+      babelOptions: {
+        babelrc: false,
+        configFile: false,
+        presets: [
+          ['@babel/preset-env', { loose: true }],
+          '@babel/preset-typescript',
+        ],
+      },
+    });
+
+    const services = withDefaultServices({
+      babel,
+      options: { root, filename: fileB, pluginOptions },
+    });
+
+    const entrypointB = Entrypoint.createRoot(
+      services,
+      fileB,
+      ['*'],
+      undefined
+    );
+    const action = entrypointB.createAction(
+      'explodeReexports',
+      undefined,
+      null
+    );
+    const gen = explodeReexports.call(action);
+
+    const initial = gen.next();
+    expectIteratorYieldResult(initial);
+    expect(initial.value[0]).toBe('resolveImports');
+
+    const resolvedImports: IEntrypointDependency[] = [
+      {
+        source: './a',
+        only: [],
+        resolved: fileA,
+      },
+    ];
+
+    const afterResolve = gen.next(resolvedImports);
+    expectIteratorYieldResult(afterResolve);
+    expect(afterResolve.value[0]).toBe('getExports');
+
+    const entrypointA = afterResolve.value[1];
+    const getExportsAction = entrypointA.createAction(
+      'getExports',
+      undefined,
+      null
+    );
+    const getExportsGen = getExports.call(getExportsAction);
+    const exportsResult = getExportsGen.next();
+    expectIteratorReturnResult(exportsResult);
+
+    const done = gen.next(exportsResult.value);
+    expectIteratorReturnResult(done, undefined);
+
+    const reexported = new Set<string>();
+    babel.traverse(entrypointB.loadedAndParsed.ast!, {
+      ExportNamedDeclaration(exportPath) {
+        const { source } = exportPath.node;
+        if (!source || !babel.types.isStringLiteral(source)) return;
+        if (source.value !== './a') return;
+
+        exportPath.node.specifiers.forEach((specifier) => {
+          if (
+            babel.types.isExportSpecifier(specifier) &&
+            babel.types.isIdentifier(specifier.exported)
+          ) {
+            reexported.add(specifier.exported.name);
+          }
+        });
+      },
+    });
+
+    expect(Array.from(reexported).sort()).toEqual(['A', 'B'].sort());
+  });
+});

--- a/packages/transform/src/transform/generators/__tests__/getExports.array-pattern.test.ts
+++ b/packages/transform/src/transform/generators/__tests__/getExports.array-pattern.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import * as babel from '@babel/core';
+
+import { loadWywOptions } from '../../helpers/loadWywOptions';
+import { withDefaultServices } from '../../helpers/withDefaultServices';
+import { Entrypoint } from '../../Entrypoint';
+import { getExports } from '../getExports';
+
+import { expectIteratorReturnResult } from './helpers';
+
+describe('getExports: ArrayPattern', () => {
+  it('returns binding identifiers exported via array destructuring', () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-issue-106-'));
+    const filename = join(root, 'a.ts');
+
+    writeFileSync(
+      filename,
+      [
+        'export const A = 100;',
+        'export const [B] = [200];',
+        'export const [, C] = [0, 300];',
+        'export const [{ D }] = [{ D: 400 }];',
+        'export const [...rest] = [500, 600];',
+        '',
+      ].join('\n')
+    );
+
+    const pluginOptions = loadWywOptions({
+      configFile: false,
+      babelOptions: {
+        babelrc: false,
+        configFile: false,
+        presets: [
+          ['@babel/preset-env', { loose: true }],
+          '@babel/preset-typescript',
+        ],
+      },
+    });
+
+    const services = withDefaultServices({
+      babel,
+      options: { root, filename, pluginOptions },
+    });
+
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      filename,
+      ['*'],
+      undefined
+    );
+    const action = entrypoint.createAction('getExports', undefined, null);
+    const gen = getExports.call(action);
+
+    const result = gen.next();
+    expectIteratorReturnResult(result);
+    expect(result.value.sort()).toEqual(['A', 'B', 'C', 'D', 'rest'].sort());
+  });
+});

--- a/packages/transform/src/utils/collectExportsAndImports.ts
+++ b/packages/transform/src/utils/collectExportsAndImports.ts
@@ -310,6 +310,29 @@ function exportFromVariableDeclarator(
     );
   }
 
+  if (id.isArrayPattern()) {
+    // It is `export const [a, , b, ...rest] = arr;`
+    const exported = new Set<string>();
+    id.traverse({
+      Identifier(identifier) {
+        if (identifier.isBindingIdentifier()) {
+          exported.add(identifier.node.name);
+        }
+      },
+    });
+
+    if (exported.size === 0) {
+      return {};
+    }
+
+    const result: Exports = {};
+    exported.forEach((name) => {
+      result[name] = init;
+    });
+
+    return result;
+  }
+
   // What else it can be?
   debug('exportFromVariableDeclarator: unknown type of id %o', id.node.type);
 


### PR DESCRIPTION
Fixes #106.

`collectExportsAndImports` now detects exports declared via array destructuring (e.g. `export const [B] = ...`), so downstream logic like `getExports` / `explodeReexports` no longer drops them.

- Add ArrayPattern support in `exportFromVariableDeclarator`
- Add unit tests for `getExports` and `explodeReexports`
- Add changeset (patch) for `@wyw-in-js/transform`

Validation:
- `pnpm -w turbo run test lint --filter @wyw-in-js/transform`