### PR TITLE
fix(transform): keep shorthand bindings alive (#94)

### DIFF
--- a/.changeset/fix-shaker-object-shorthand.md
+++ b/.changeset/fix-shaker-object-shorthand.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Fix shaker removing referenced bindings when dropping unused exports (e.g. object shorthand `{ fallback }`).

--- a/packages/transform/src/__tests__/shaker.test.ts
+++ b/packages/transform/src/__tests__/shaker.test.ts
@@ -210,4 +210,26 @@ describe('shaker', () => {
     expect(code).not.toContain('getStaticData');
     expect(code).not.toContain('import(');
   });
+
+  it('should keep bindings referenced via object shorthand', () => {
+    const code = run(['Spring'])`
+      export function spring() {
+        return 'spring';
+      }
+
+      export function fallback(fallback) {
+        return 'fallback';
+      }
+
+      export const Spring = {
+        fallback,
+        create: spring,
+      };
+    `;
+
+    expect(code).toContain('exports.Spring');
+    expect(code).toContain('function spring');
+    expect(code).toContain('function fallback');
+    expect(code).not.toContain('exports.fallback');
+  });
 });


### PR DESCRIPTION
Fixes #94.

The shaker could drop an exported binding even when it was still referenced by a kept export via object shorthand (e.g. `export const Spring = { fallback }`), resulting in `ReferenceError` at eval time.

Changes:
- Prefer non-`param` bindings for export nodes (avoid function-parameter shadowing like `function fallback(fallback) {}`).
- When an export wrapper is dead but its declaration is still referenced, strip only the `export` wrapper and keep the declaration.
- Add regression test for the shorthand case.

Checks:
- `pnpm -w turbo run lint --filter @wyw-in-js/transform`
- `pnpm -w turbo run test --filter @wyw-in-js/transform`