### PR TITLE
fix(transform): allow TS declare class fields

### DIFF
--- a/.changeset/allow-declare-fields.md
+++ b/.changeset/allow-declare-fields.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Fix Babel TypeScript transform crashing on `declare` class fields by ensuring `allowDeclareFields` is enabled when using the TypeScript preset/plugin.
+

--- a/packages/transform/src/__tests__/declare-fields.test.ts
+++ b/packages/transform/src/__tests__/declare-fields.test.ts
@@ -1,0 +1,83 @@
+import * as babel from '@babel/core';
+
+import { loadWywOptions } from '../transform/helpers/loadWywOptions';
+import { Entrypoint } from '../transform/Entrypoint';
+import { prepareCode } from '../transform/generators/transform';
+import { withDefaultServices } from '../transform/helpers/withDefaultServices';
+
+describe('declare class fields', () => {
+  const testCases = [
+    {
+      name: 'top-level preset',
+      babelOptions: {
+        presets: ['@babel/preset-typescript'],
+      },
+    },
+    {
+      name: 'overrides preset',
+      babelOptions: {
+        overrides: [
+          {
+            test: /\.tsx?$/,
+            presets: ['@babel/preset-typescript'],
+          },
+        ],
+      },
+    },
+    {
+      name: 'env preset',
+      babelOptions: {
+        plugins: ['@babel/plugin-syntax-typescript'],
+        env: {
+          'wyw-in-js': {
+            presets: ['@babel/preset-typescript'],
+          },
+        },
+      },
+    },
+  ] as const;
+
+  testCases.forEach(({ name, babelOptions }) => {
+    it(`does not crash TypeScript transform (${name})`, () => {
+      const pluginOptions = loadWywOptions({
+        configFile: false,
+        babelOptions: {
+          babelrc: false,
+          configFile: false,
+          ...babelOptions,
+        },
+      });
+
+      const filename = `${__dirname}/declare-fields.ts`;
+      const sourceCode = `
+        export class X {
+          declare foo: string;
+        }
+      `;
+
+      const services = withDefaultServices({
+        babel,
+        options: {
+          root: __dirname,
+          filename,
+          pluginOptions,
+        },
+      });
+
+      const entrypoint = Entrypoint.createRoot(
+        services,
+        filename,
+        ['__wywPreval'],
+        sourceCode
+      );
+
+      if (entrypoint.ignored) {
+        throw new Error('Entrypoint is ignored');
+      }
+
+      expect(() =>
+        prepareCode(services, entrypoint, entrypoint.loadedAndParsed.ast)
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/transform/src/shaker.ts
+++ b/packages/transform/src/shaker.ts
@@ -49,7 +49,9 @@ export const shaker: Evaluator = (
 
   if (
     evalConfig.filename?.endsWith('.ts') ||
-    evalConfig.filename?.endsWith('.tsx')
+    evalConfig.filename?.endsWith('.tsx') ||
+    evalConfig.filename?.endsWith('.mts') ||
+    evalConfig.filename?.endsWith('.cts')
   ) {
     const hasTypescriptPlugin = evalConfig.plugins?.some(
       (i) => getPluginKey(i) === 'transform-typescript'
@@ -65,7 +67,7 @@ export const shaker: Evaluator = (
       ]);
 
       if (plugin) {
-        plugins.push(plugin);
+        plugins.push([plugin, { allowDeclareFields: true }]);
       }
     }
   }


### PR DESCRIPTION
Fixes #84.

- Automatically enables `allowDeclareFields` for TypeScript preset/plugin when processing TS/TSX (incl. overrides/env cases).
- Adds regression test covering top-level, overrides, and env configs.

Commands:
- pnpm -C wyw-in-js --filter @wyw-in-js/transform lint
- pnpm -C wyw-in-js --filter @wyw-in-js/transform test