### PR TITLE
fix(transform): handle named function expressions

### DIFF
--- a/.changeset/fix-named-function-expression.md
+++ b/.changeset/fix-named-function-expression.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Fix missing CSS emission for tags inside named function expressions (e.g. `export const a = function a() { return css\`\`; }`).
+

--- a/packages/transform/src/__tests__/__fixtures__/test-css-processor.js
+++ b/packages/transform/src/__tests__/__fixtures__/test-css-processor.js
@@ -1,0 +1,41 @@
+const { TaggedTemplateProcessor } = require('@wyw-in-js/processor-utils');
+
+class CssProcessor extends TaggedTemplateProcessor {
+  get asSelector() {
+    return this.className;
+  }
+
+  get value() {
+    return this.astService.stringLiteral(this.className);
+  }
+
+  addInterpolation(_node, _precedingCss, source) {
+    throw new Error(
+      `css tag cannot handle '${source}' as an interpolated value`
+    );
+  }
+
+  doEvaltimeReplacement() {
+    this.replacer(this.value, false);
+  }
+
+  doRuntimeReplacement() {
+    this.replacer(this.value, false);
+  }
+
+  extractRules(_valueCache, cssText, loc) {
+    const selector = `.${this.className}`;
+
+    return {
+      [selector]: {
+        cssText,
+        className: this.className,
+        displayName: this.displayName,
+        start: loc?.start ?? null,
+      },
+    };
+  }
+}
+
+module.exports = { default: CssProcessor };
+

--- a/packages/transform/src/__tests__/getTagProcessor.named-function-expression.test.ts
+++ b/packages/transform/src/__tests__/getTagProcessor.named-function-expression.test.ts
@@ -1,0 +1,96 @@
+import path from 'path';
+
+import * as babel from '@babel/core';
+
+import type { StrictOptions } from '@wyw-in-js/shared';
+
+import { applyProcessors } from '../utils/getTagProcessor';
+
+const processorPath = path.resolve(
+  __dirname,
+  '__fixtures__',
+  'test-css-processor.js'
+);
+
+describe('getTagProcessor', () => {
+  it('emits CSS for named function expressions', () => {
+    const code = `
+      import { css } from '@linaria/atomic';
+
+      export const a = function a() {
+        return css\`
+          color: red;
+        \`;
+      };
+
+      export const b = function () {
+        return css\`
+          font-size: 20px;
+        \`;
+      };
+
+      a();
+      b();
+    `;
+
+    const fileContext = {
+      filename: path.join(__dirname, 'named-function-expression.js'),
+      root: __dirname,
+    };
+
+    const options: Pick<
+      StrictOptions,
+      | 'classNameSlug'
+      | 'displayName'
+      | 'extensions'
+      | 'evaluate'
+      | 'tagResolver'
+    > = {
+      displayName: false,
+      evaluate: true,
+      extensions: ['.js'],
+      tagResolver: (source, imported) => {
+        if (source !== '@linaria/atomic' || imported !== 'css') {
+          return null;
+        }
+
+        return processorPath;
+      },
+    };
+
+    const cssText: string[] = [];
+
+    babel.transformSync(code, {
+      filename: fileContext.filename,
+      babelrc: false,
+      configFile: false,
+      sourceType: 'module',
+      plugins: [
+        () => ({
+          visitor: {
+            Program(programPath) {
+              applyProcessors(
+                programPath,
+                fileContext,
+                options,
+                (processor) => {
+                  processor.build(new Map());
+                  processor.artifacts.forEach((artifact) => {
+                    if (artifact[0] !== 'css') return;
+                    const [rules] = artifact[1];
+                    Object.values(rules).forEach((rule) => {
+                      cssText.push(rule.cssText);
+                    });
+                  });
+                }
+              );
+            },
+          },
+        }),
+      ],
+    });
+
+    expect(cssText.join('\n')).toContain('color: red');
+    expect(cssText.join('\n')).toContain('font-size: 20px');
+  });
+});

--- a/packages/transform/src/utils/getTagProcessor.ts
+++ b/packages/transform/src/utils/getTagProcessor.ts
@@ -373,7 +373,7 @@ function isTagReferenced(path: NodePath): boolean {
       const id = parent.get('id');
       // FIXME: replace with id.isReferencedIdentifier()
       if (id.isIdentifier()) {
-        const { referencePaths } = path.scope.getBinding(id.node.name) || {
+        const { referencePaths } = id.scope.getBinding(id.node.name) || {
           referencePaths: [],
         };
 


### PR DESCRIPTION
Fixes #83.

Named function expressions like `export const a = function a() { return css``; }` could end up marked as unreferenced due to scope binding resolution, causing CSS to be dropped. This change resolves references against the variable declarator binding instead.

Commands:
- pnpm -C wyw-in-js --filter @wyw-in-js/transform lint
- pnpm -C wyw-in-js --filter @wyw-in-js/transform test