### PR TITLE
fix(transform): avoid invalid PURE annotation (#74)

### DIFF
--- a/.changeset/fix-rollup-pure-annotation.md
+++ b/.changeset/fix-rollup-pure-annotation.md
@@ -1,0 +1,7 @@
+---
+'@wyw-in-js/transform': patch
+'@wyw-in-js/vite': patch
+---
+
+Fix Rollup/Vite warnings about `/*#__PURE__*/` annotations emitted for extracted template expressions.
+

--- a/packages/transform/src/__tests__/utils/__snapshots__/extractExpression.test.ts.snap
+++ b/packages/transform/src/__tests__/utils/__snapshots__/extractExpression.test.ts.snap
@@ -1,9 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`extractExpression does not emit PURE annotation for extracted function expressions 1`] = `
+"const _exp = () => (props: {
+  bgColor: string;
+}) => props.bgColor;
+function foo() {
+  return _exp();
+}"
+`;
+
 exports[`extractExpression should extract expression 1`] = `
 "let a = 1;
 let b = 2;
-const _exp = /*#__PURE__*/() => a + b;
+const _exp = () => a + b;
 function foo() {
   return _exp();
 }"
@@ -12,7 +21,7 @@ function foo() {
 exports[`extractExpression should hoist functions 1`] = `
 "let a = "foo";
 let fn = obj => obj.className ?? '';
-const _exp = /*#__PURE__*/() => a + fn({
+const _exp = () => a + fn({
   className: 'bar'
 });
 function foo() {
@@ -23,7 +32,7 @@ function foo() {
 exports[`extractExpression should ignore types 1`] = `
 "let a = "foo";
 let fn = (obj: Props) => obj.className ?? '';
-const _exp = /*#__PURE__*/() => a + fn({
+const _exp = () => a + fn({
   className: 'bar'
 });
 function foo() {
@@ -36,7 +45,7 @@ function foo() {
 `;
 
 exports[`extractExpression should inline values and remove bindings 1`] = `
-"const _exp = /*#__PURE__*/() => 3;
+"const _exp = () => 3;
 function foo() {
   return _exp();
 }"
@@ -46,7 +55,7 @@ exports[`extractExpression should rename identifier if it already exists in the 
 "const a = 42;
 let _a = 1;
 let b = 2;
-const _exp = /*#__PURE__*/() => _a + b;
+const _exp = () => _a + b;
 function foo() {
   return _exp();
 }"

--- a/packages/transform/src/__tests__/utils/extractExpression.test.ts
+++ b/packages/transform/src/__tests__/utils/extractExpression.test.ts
@@ -63,7 +63,20 @@ describe('extractExpression', () => {
     `;
 
     expect(code).toMatchSnapshot();
+    expect(code).not.toContain('/*#__PURE__*/');
     expect(bindings).toEqual(['_exp', 'a', 'b', 'foo']);
+  });
+
+  it('does not emit PURE annotation for extracted function expressions', () => {
+    const { bindings, code } = runWithoutEval`
+      function foo() {
+        return /* extract */((props: { bgColor: string }) => props.bgColor);
+      }
+    `;
+
+    expect(code).toMatchSnapshot();
+    expect(code).not.toContain('/*#__PURE__*/');
+    expect(bindings).toEqual(['_exp', 'foo']);
   });
 
   it('should rename identifier if it already exists in the root', () => {
@@ -79,6 +92,7 @@ describe('extractExpression', () => {
     `;
 
     expect(code).toMatchSnapshot();
+    expect(code).not.toContain('/*#__PURE__*/');
     expect(bindings).toEqual(['_a', '_exp', 'a', 'b', 'foo']);
   });
 
@@ -93,6 +107,7 @@ describe('extractExpression', () => {
     `;
 
     expect(code).toMatchSnapshot();
+    expect(code).not.toContain('/*#__PURE__*/');
     expect(bindings).toEqual(['_exp', 'foo']);
   });
 
@@ -108,6 +123,7 @@ describe('extractExpression', () => {
     `;
 
     expect(code).toMatchSnapshot();
+    expect(code).not.toContain('/*#__PURE__*/');
     expect(bindings).toEqual(['_exp', 'a', 'fn', 'foo']);
   });
 
@@ -124,6 +140,7 @@ describe('extractExpression', () => {
     `;
 
     expect(code).toMatchSnapshot();
+    expect(code).not.toContain('/*#__PURE__*/');
     expect(bindings).toEqual(['_exp', 'a', 'fn', 'foo']);
   });
 });

--- a/packages/transform/src/utils/__tests__/__snapshots__/collectTemplateDependencies.test.ts.snap
+++ b/packages/transform/src/utils/__tests__/__snapshots__/collectTemplateDependencies.test.ts.snap
@@ -4,7 +4,7 @@ exports[`collectTemplateDependencies hoist chain of statements 1`] = `
 "import str from "module";
 let arg = str;
 let variable = arg + "2";
-const _exp = /*#__PURE__*/() => variable;
+const _exp = () => variable;
 function fn() {
   {
     const template = tag\`\${_exp()}\`;
@@ -14,10 +14,10 @@ function fn() {
 
 exports[`collectTemplateDependencies hoist expressions 1`] = `
 "import x from "module";
-const _exp = /*#__PURE__*/() => 42;
-const _exp2 = /*#__PURE__*/() => "test";
-const _exp3 = /*#__PURE__*/() => () => "result";
-const _exp4 = /*#__PURE__*/() => 21 * x;
+const _exp = () => 42;
+const _exp2 = () => "test";
+const _exp3 = () => () => "result";
+const _exp4 = () => 21 * x;
 function fn() {
   const template = tag\`\${_exp()}\${_exp2()}\${_exp3()}\${_exp4()}\`;
 }"
@@ -30,14 +30,14 @@ let {
 } = {
   variable: result
 };
-const _exp = /*#__PURE__*/() => variable;
+const _exp = () => variable;
 function fn() {
   const template = tag\`\${_exp()}\`;
 }"
 `;
 
 exports[`collectTemplateDependencies hoistExpression with object 1`] = `
-"const _exp = /*#__PURE__*/() => ({
+"const _exp = () => ({
   variable: "test"
 }).variable;
 function fn() {
@@ -57,7 +57,7 @@ exports[`collectTemplateDependencies non-hoistable expression 1`] = `
 exports[`collectTemplateDependencies should hoist expressions after imports 1`] = `
 "import { styled } from '@linaria/react';
 import slugify from '../__fixtures__/slugify';
-const _exp = /*#__PURE__*/() => slugify('test');
+const _exp = () => slugify('test');
 export const Title = styled.h1\`
   &:before {
     content: "\${_exp()}"

--- a/packages/transform/src/utils/collectTemplateDependencies.ts
+++ b/packages/transform/src/utils/collectTemplateDependencies.ts
@@ -50,7 +50,7 @@ function staticEval(
 }
 
 const expressionDeclarationTpl = statement(
-  'const %%expId%% = /*#__PURE__*/ () => %%expression%%',
+  'const %%expId%% = () => %%expression%%',
   {
     preserveComments: true,
   }


### PR DESCRIPTION
Fixes Rollup/Vite warnings where a `/*#__PURE__*/` annotation emitted for extracted template expressions cannot be interpreted and gets stripped.

Changes:
- Stop emitting `/*#__PURE__*/` for extracted expression wrappers generated by `extractExpression`.
- Add regression coverage to ensure we don't reintroduce PURE in this path.
- Patch changeset for `@wyw-in-js/transform` (and `@wyw-in-js/vite` to propagate the fix).

Checks:
- `pnpm turbo run lint --filter @wyw-in-js/transform`
- `pnpm turbo run test --filter @wyw-in-js/transform`