### PR TITLE
fix(vite): avoid manual optimizeDeps calls on Vite 7 (#164)

### DIFF
--- a/.changeset/vite-avoid-optimize-deps.md
+++ b/.changeset/vite-avoid-optimize-deps.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/vite': patch
+---
+
+Avoid manually calling `optimizeDeps()` from the plugin resolve path when Vite returns a missing optimized-deps entry. This prevents Vite 7 deprecation spam and reduces dev server startup overhead.


### PR DESCRIPTION
Fixes #164.

Background: [`callstack/linaria#1358`](https://github.com/callstack/linaria/pull/1358) added `optimizeDeps()` when Vite resolves to an optimized-deps path that doesn’t exist yet. On Vite 7 this API is deprecated and can spam warnings.

This PR keeps the original intent (avoid ENOENT for optimized deps) but removes manual `optimizeDeps()` calls:
- If Vite resolves to an optimized dep file that isn’t on disk yet, wait for Vite’s deps optimizer (`depsOptimizer.scanProcessing` + per-dep `processing`).
- If it’s still missing and the path is under `cacheDir`, fall back to resolving the original module path via `syncResolve`.

Tests:
- Adds unit coverage for waiting on deps optimizer, plus regression for missing cache entries.

Changeset:
- Patch bump for `@wyw-in-js/vite`.