### PR TITLE
fix(webpack-loader): support object cacheProvider (#107)

### DIFF
--- a/.changeset/fix-webpack-loader-cache-provider.md
+++ b/.changeset/fix-webpack-loader-cache-provider.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/webpack-loader': patch
+---
+
+Fix `cacheProvider` object instances so extracted CSS is read from the same cache instance by the internal output loader.
+

--- a/packages/webpack-loader/src/__tests__/cache-provider.test.ts
+++ b/packages/webpack-loader/src/__tests__/cache-provider.test.ts
@@ -1,0 +1,132 @@
+const transformMock = jest.fn();
+
+jest.mock('@wyw-in-js/shared', () => ({
+  __esModule: true,
+  logger: jest.fn(),
+}));
+
+jest.mock('@wyw-in-js/transform', () => ({
+  __esModule: true,
+  TransformCacheCollection: function TransformCacheCollection() {},
+  transform: (...args: unknown[]) => transformMock(...args),
+}));
+
+class TestCache {
+  cache = new Map<string, string>();
+
+  dependenciesCache = new Map<string, string[]>();
+
+  get(key: string) {
+    return Promise.resolve(this.cache.get(key) ?? '');
+  }
+
+  getDependencies(key: string) {
+    return Promise.resolve(this.dependenciesCache.get(key) ?? []);
+  }
+
+  set(key: string, value: string) {
+    this.cache.set(key, value);
+    return Promise.resolve();
+  }
+
+  setDependencies(key: string, value: string[]) {
+    this.dependenciesCache.set(key, value);
+    return Promise.resolve();
+  }
+}
+
+describe('webpack-loader cacheProvider', () => {
+  beforeEach(() => {
+    transformMock.mockReset();
+  });
+
+  it('passes object cacheProvider via cacheProviderId so outputCssLoader reads from same instance', async () => {
+    const cacheProvider = new TestCache();
+
+    transformMock.mockResolvedValue({
+      code: 'module.exports = 1;',
+      sourceMap: null,
+      cssText: '.title{color:red}',
+      cssSourceMapText: '',
+      dependencies: [],
+    });
+
+    const { default: webpackLoader } = await import('../index');
+    const { default: outputCssLoader } = await import('../outputCssLoader');
+
+    const resourcePath = '/abs/entry.jsx';
+    let emittedRequest = '';
+
+    await new Promise<void>((resolve, reject) => {
+      webpackLoader.call(
+        {
+          addDependency: jest.fn(),
+          async: jest.fn(),
+          callback: (err: Error | null, code?: string) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+
+            const match = String(code).match(/require\(([^)]+)\);/);
+            if (!match) {
+              reject(new Error('Expected loader to emit a require() call'));
+              return;
+            }
+
+            emittedRequest = match[1].trim();
+
+            resolve();
+          },
+          context: process.cwd(),
+          emitWarning: jest.fn(),
+          getDependencies: () => [],
+          getOptions: () => ({ cacheProvider }),
+          getResolve: () =>
+            jest.fn(
+              (
+                _ctx: string,
+                _token: string,
+                cb: (err: any, res: any) => void
+              ) => cb(null, null)
+            ),
+          resourcePath,
+          rootContext: process.cwd(),
+          utils: {
+            contextify: (_ctx: string, request: string) => request,
+          },
+        } as any,
+        'module.exports = 1;',
+        null
+      );
+    });
+
+    const request = JSON.parse(emittedRequest);
+    const query = request.split('?', 2)[1].split('!', 1)[0];
+    const params = new URLSearchParams(query);
+    const cacheProviderId = params.get('cacheProviderId');
+
+    expect(cacheProviderId).toBeTruthy();
+
+    await new Promise<void>((resolve, reject) => {
+      outputCssLoader.call({
+        addDependency: jest.fn(),
+        async: jest.fn(),
+        callback: (err: Error | null, css?: string) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          expect(css).toContain('.title{color:red}');
+          resolve();
+        },
+        getOptions: () => ({
+          cacheProvider: params.get('cacheProvider') || undefined,
+          cacheProviderId: cacheProviderId ?? undefined,
+        }),
+        resourcePath,
+      } as any);
+    });
+  });
+});

--- a/packages/webpack-loader/src/index.ts
+++ b/packages/webpack-loader/src/index.ts
@@ -15,7 +15,7 @@ import { transform, TransformCacheCollection } from '@wyw-in-js/transform';
 
 import { sharedState } from './WYWinJSDebugPlugin';
 import type { ICache } from './cache';
-import { getCacheInstance } from './cache';
+import { getCacheInstance, registerCacheProvider } from './cache';
 
 export { WYWinJSDebugPlugin } from './WYWinJSDebugPlugin';
 
@@ -141,6 +141,10 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
 
           try {
             const cacheInstance = await getCacheInstance(cacheProvider);
+            const cacheProviderId =
+              cacheProvider && typeof cacheProvider === 'object'
+                ? registerCacheProvider(cacheInstance)
+                : '';
 
             await cacheInstance.set(this.resourcePath, cssText);
 
@@ -151,7 +155,9 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
 
             const request = `${outputFileName}!=!${outputCssLoader}?cacheProvider=${encodeURIComponent(
               typeof cacheProvider === 'string' ? cacheProvider : ''
-            )}!${this.resourcePath}`;
+            )}&cacheProviderId=${encodeURIComponent(cacheProviderId)}!${
+              this.resourcePath
+            }`;
             const stringifiedRequest = JSON.stringify(
               this.utils.contextify(this.context || this.rootContext, request)
             );

--- a/packages/webpack-loader/src/outputCssLoader.ts
+++ b/packages/webpack-loader/src/outputCssLoader.ts
@@ -4,13 +4,19 @@ import type { ICache } from './cache';
 import { getCacheInstance } from './cache';
 
 export default async function outputCssLoader(
-  this: webpack.LoaderContext<{ cacheProvider: string | ICache | undefined }>
+  this: webpack.LoaderContext<{
+    cacheProvider: string | ICache | undefined;
+    cacheProviderId?: string | undefined;
+  }>
 ) {
   this.async();
-  const { cacheProvider } = this.getOptions();
+  const { cacheProvider, cacheProviderId } = this.getOptions();
 
   try {
-    const cacheInstance = await getCacheInstance(cacheProvider);
+    const cacheInstance = await getCacheInstance(
+      cacheProvider,
+      cacheProviderId
+    );
 
     const result = await cacheInstance.get(this.resourcePath);
     const dependencies =


### PR DESCRIPTION
Fixes #107.

When `cacheProvider` is passed as an object instance, the main loader was writing extracted CSS into that instance, but `outputCssLoader` could only receive a string query param and ended up reading from a different cache, producing empty CSS.

Changes:
- Register object cache providers in-process and pass a `cacheProviderId` to `outputCssLoader` so both loaders use the same instance.
- Keep existing `cacheProvider: string` (module path) and default behavior unchanged.
- Add a regression test for the object-instance case.
- Add a patch changeset for `@wyw-in-js/webpack-loader`.

Checks:
- `bun run --filter @wyw-in-js/webpack-loader test`
- `bun run --filter @wyw-in-js/webpack-loader lint`