### PR TITLE
fix(transform): preserve module instance across partial eval (#99)

### DIFF
--- a/.changeset/fix-eval-shared-initializers.md
+++ b/.changeset/fix-eval-shared-initializers.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Fix `evaluate: true` export caching so additional export requests don’t combine exports from different module executions.
+

--- a/packages/transform/src/__tests__/__fixtures__/issue-99/main.ts
+++ b/packages/transform/src/__tests__/__fixtures__/issue-99/main.ts
@@ -1,0 +1,8 @@
+import { css } from 'test-css-processor';
+import { getSymbol, getSymbolAgain } from './symbol';
+
+export const text = css`
+  color: ${getSymbol() === getSymbolAgain() ? 'green' : 'red'};
+`;
+
+export const _usage = [text];

--- a/packages/transform/src/__tests__/__fixtures__/issue-99/preload.ts
+++ b/packages/transform/src/__tests__/__fixtures__/issue-99/preload.ts
@@ -1,0 +1,9 @@
+import { css } from 'test-css-processor';
+import { getSymbol } from './symbol';
+
+export const preload = css`
+  color: ${getSymbol() ? 'green' : 'red'};
+`;
+
+export const _usage = [preload];
+

--- a/packages/transform/src/__tests__/__fixtures__/issue-99/symbol.ts
+++ b/packages/transform/src/__tests__/__fixtures__/issue-99/symbol.ts
@@ -1,0 +1,5 @@
+export const symbol = Symbol();
+
+export const getSymbol = () => symbol;
+export const getSymbolAgain = () => symbol;
+

--- a/packages/transform/src/__tests__/issue-99.symbol-identity.test.ts
+++ b/packages/transform/src/__tests__/issue-99.symbol-identity.test.ts
@@ -1,0 +1,132 @@
+import fs from 'fs';
+import path from 'path';
+
+import { TransformCacheCollection } from '../cache';
+import { transformSync } from '../transform';
+
+const resolveWithExtensions = (candidate: string) => {
+  if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+    return candidate;
+  }
+
+  const extensions = ['.ts', '.tsx', '.js', '.jsx', '.cjs', '.mjs'];
+  for (const ext of extensions) {
+    const withExt = `${candidate}${ext}`;
+    if (fs.existsSync(withExt) && fs.statSync(withExt).isFile()) {
+      return withExt;
+    }
+  }
+
+  return null;
+};
+
+it('keeps shared module initializers stable across multiple export requests', () => {
+  const fixturesRoot = path.resolve(__dirname, '__fixtures__', 'issue-99');
+  const preloadFile = path.join(fixturesRoot, 'preload.ts');
+  const entryFile = path.join(fixturesRoot, 'main.ts');
+  const processorFile = path.resolve(
+    __dirname,
+    '__fixtures__',
+    'test-css-processor.js'
+  );
+
+  const preloadCode = fs.readFileSync(preloadFile, 'utf8');
+  const code = fs.readFileSync(entryFile, 'utf8');
+
+  const cache = new TransformCacheCollection();
+
+  transformSync(
+    {
+      cache,
+      options: {
+        filename: preloadFile,
+        root: fixturesRoot,
+        pluginOptions: {
+          configFile: false,
+          tagResolver: (source, tag) => {
+            if (source === 'test-css-processor' && tag === 'css') {
+              return processorFile;
+            }
+
+            return null;
+          },
+          babelOptions: {
+            babelrc: false,
+            configFile: false,
+            presets: [
+              ['@babel/preset-env', { loose: true }],
+              '@babel/preset-react',
+              '@babel/preset-typescript',
+            ],
+          },
+        },
+      },
+    },
+    preloadCode,
+    (what, importer) => {
+      if (what === 'test-css-processor') {
+        return processorFile;
+      }
+
+      if (what.startsWith('.') || path.isAbsolute(what)) {
+        const resolved = resolveWithExtensions(
+          path.resolve(path.dirname(importer), what)
+        );
+        if (resolved) {
+          return resolved;
+        }
+      }
+
+      throw new Error(`Unable to resolve ${JSON.stringify(what)}`);
+    }
+  );
+
+  const result = transformSync(
+    {
+      cache,
+      options: {
+        filename: entryFile,
+        root: fixturesRoot,
+        pluginOptions: {
+          configFile: false,
+          tagResolver: (source, tag) => {
+            if (source === 'test-css-processor' && tag === 'css') {
+              return processorFile;
+            }
+
+            return null;
+          },
+          babelOptions: {
+            babelrc: false,
+            configFile: false,
+            presets: [
+              ['@babel/preset-env', { loose: true }],
+              '@babel/preset-react',
+              '@babel/preset-typescript',
+            ],
+          },
+        },
+      },
+    },
+    code,
+    (what, importer) => {
+      if (what === 'test-css-processor') {
+        return processorFile;
+      }
+
+      if (what.startsWith('.') || path.isAbsolute(what)) {
+        const resolved = resolveWithExtensions(
+          path.resolve(path.dirname(importer), what)
+        );
+        if (resolved) {
+          return resolved;
+        }
+      }
+
+      throw new Error(`Unable to resolve ${JSON.stringify(what)}`);
+    }
+  );
+
+  expect(result.cssText).toContain('green');
+  expect(result.cssText).not.toContain('red');
+});

--- a/packages/transform/src/transform/Entrypoint.ts
+++ b/packages/transform/src/transform/Entrypoint.ts
@@ -126,19 +126,9 @@ export class Entrypoint extends BaseEntrypoint {
     services: Services,
     name: string,
     only: string[],
-    loadedCode: string | undefined,
-    options?: {
-      skipCacheOnlyMerge?: boolean;
-    }
+    loadedCode: string | undefined
   ): Entrypoint {
-    const created = Entrypoint.create(
-      services,
-      null,
-      name,
-      only,
-      loadedCode,
-      options
-    );
+    const created = Entrypoint.create(services, null, name, only, loadedCode);
     invariant(created !== 'loop', 'loop detected');
 
     return created;
@@ -161,10 +151,7 @@ export class Entrypoint extends BaseEntrypoint {
     parent: ParentEntrypoint | null,
     name: string,
     only: string[],
-    loadedCode: string | undefined,
-    options?: {
-      skipCacheOnlyMerge?: boolean;
-    }
+    loadedCode: string | undefined
   ): Entrypoint | 'loop' {
     const { cache, eventEmitter } = services;
     return eventEmitter.perf('createEntrypoint', () => {
@@ -181,8 +168,7 @@ export class Entrypoint extends BaseEntrypoint {
           : null,
         name,
         only,
-        loadedCode,
-        options
+        loadedCode
       );
 
       if (status !== 'cached') {
@@ -198,10 +184,7 @@ export class Entrypoint extends BaseEntrypoint {
     parent: ParentEntrypoint | null,
     name: string,
     only: string[],
-    loadedCode: string | undefined,
-    options?: {
-      skipCacheOnlyMerge?: boolean;
-    }
+    loadedCode: string | undefined
   ): ['loop' | 'created' | 'cached', Entrypoint] {
     const { cache } = services;
 
@@ -218,9 +201,7 @@ export class Entrypoint extends BaseEntrypoint {
     const exports = cached?.exports;
     const evaluatedOnly = cached?.evaluatedOnly ?? [];
 
-    const shouldMergeOnly = !options?.skipCacheOnlyMerge;
-    const mergedOnly =
-      cached?.only && shouldMergeOnly ? mergeOnly(cached.only, only) : only;
+    const mergedOnly = cached?.only ? mergeOnly(cached.only, only) : only;
 
     if (cached?.evaluated) {
       cached.log('is already evaluated with', cached.evaluatedOnly);


### PR DESCRIPTION
Fixes #99.

- Ensures partial eval does not combine exports from different executions of the same module when additional exports are requested later.
- Adds a regression test for shared initializer identity (Symbol singleton) across multiple export requests.
- Removes unused `skipCacheOnlyMerge` option.

Validation:
- `@wyw-in-js/transform`: tests + lint passed.
- Downstream validation passed (no generated CSS changes observed).