### PR TITLE
perf(transform): avoid evaluator supersede storms (#68)

### DIFF
--- a/.changeset/fix-vite-evaluator-perf.md
+++ b/.changeset/fix-vite-evaluator-perf.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/transform": patch
+---
+
+Avoid repeated evaluator re-runs for large, statically evaluatable modules by promoting them to wildcard `only` on first entrypoint creation.

--- a/examples/vite-react-refresh/.gitignore
+++ b/examples/vite-react-refresh/.gitignore
@@ -1,0 +1,3 @@
+src/__perf__/
+perf-debug/
+

--- a/examples/vite-react-refresh/index.perf.html
+++ b/examples/vite-react-refresh/index.perf.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WyW perf repro</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/__perf__/entry.tsx"></script>
+  </body>
+</html>
+

--- a/examples/vite-react-refresh/package.json
+++ b/examples/vite-react-refresh/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "gen:perf": "node ./perf/generate.mjs",
+    "build:perf": "node ./perf/generate.mjs 500 && vite build --config vite.perf.config.ts"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.3",

--- a/examples/vite-react-refresh/perf/generate.mjs
+++ b/examples/vite-react-refresh/perf/generate.mjs
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import path from 'path';
+
+const root = path.resolve(import.meta.dirname, '..');
+const perfDir = path.join(root, 'src', '__perf__');
+const consumersDir = path.join(perfDir, 'consumers');
+
+const args = process.argv.slice(2);
+const exportsCount = Number(args[0] ?? '500');
+
+if (!Number.isFinite(exportsCount) || exportsCount <= 0) {
+  throw new Error(`Invalid exportsCount: ${exportsCount}`);
+}
+
+fs.rmSync(perfDir, { force: true, recursive: true });
+fs.mkdirSync(consumersDir, { recursive: true });
+
+const bigLines = [];
+bigLines.push(`// Auto-generated. Do not edit manually.`);
+bigLines.push(`// Exports: ${exportsCount}`);
+bigLines.push('');
+for (let i = 0; i < exportsCount; i += 1) {
+  bigLines.push(`export const color${i} = '#${(i % 0xffffff)
+    .toString(16)
+    .padStart(6, '0')}';`);
+}
+bigLines.push('');
+fs.writeFileSync(path.join(perfDir, 'big.ts'), `${bigLines.join('\n')}\n`);
+
+const indexLines = [];
+indexLines.push(`// Auto-generated. Do not edit manually.`);
+indexLines.push('');
+
+for (let i = 0; i < exportsCount; i += 1) {
+  const fileBase = `mod${i}`;
+  const relImport = `./consumers/${fileBase}`;
+
+  indexLines.push(`import '${relImport}';`);
+
+  const modLines = [];
+  modLines.push(`// Auto-generated. Do not edit manually.`);
+  modLines.push(`import { css } from '@wyw-in-js/template-tag-syntax';`);
+  modLines.push(`import { color${i} } from '../big';`);
+  modLines.push('');
+  modLines.push(`export const cls${i} = css\`color: \${color${i}};\`;`);
+  modLines.push('');
+
+  fs.writeFileSync(
+    path.join(consumersDir, `${fileBase}.tsx`),
+    `${modLines.join('\n')}\n`
+  );
+}
+
+fs.writeFileSync(path.join(perfDir, 'index.ts'), `${indexLines.join('\n')}\n`);
+
+const entryLines = [];
+entryLines.push(`import React from 'react';`);
+entryLines.push(`import ReactDOM from 'react-dom/client';`);
+entryLines.push(`import './index';`);
+entryLines.push('');
+entryLines.push(`const App = () => <div>perf</div>;`);
+entryLines.push('');
+entryLines.push(
+  `ReactDOM.createRoot(document.getElementById('root')!).render(<App />);`
+);
+entryLines.push('');
+
+fs.writeFileSync(path.join(perfDir, 'entry.tsx'), `${entryLines.join('\n')}\n`);
+

--- a/examples/vite-react-refresh/vite.perf.config.ts
+++ b/examples/vite-react-refresh/vite.perf.config.ts
@@ -1,0 +1,19 @@
+import react from '@vitejs/plugin-react';
+import wyw from '@wyw-in-js/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: 'index.perf.html',
+    },
+  },
+  plugins: [
+    react(),
+    wyw({
+      debug: { dir: 'perf-debug', print: true },
+      include: ['src/__perf__/**/*.{ts,tsx}'],
+    }),
+  ],
+});
+

--- a/packages/transform/src/__tests__/module.test.ts
+++ b/packages/transform/src/__tests__/module.test.ts
@@ -40,7 +40,7 @@ const filename = path.resolve(__dirname, './__fixtures__/test.js');
 const createServices = (partial: Partial<Services>): Services => {
   const loadAndParseFn: LoadAndParseFn = (services, name, loadedCode) => ({
     get ast() {
-      return services.babel.parseSync(loadedCode ?? '')!;
+      return services.babel.parseSync(loadedCode ?? '', { filename: name })!;
     },
     code: loadedCode!,
     evaluator: jest.fn(),

--- a/packages/transform/src/transform/__tests__/entrypoint-helpers.ts
+++ b/packages/transform/src/transform/__tests__/entrypoint-helpers.ts
@@ -52,7 +52,19 @@ export const createServices: () => Services = () => ({
   babel,
   cache: new TransformCacheCollection(),
   loadAndParseFn: jest.fn<ReturnType<LoadAndParseFn>, []>(() => ({
-    ast: {} as File,
+    ast: {
+      type: 'File',
+      program: {
+        type: 'Program',
+        sourceType: 'module',
+        body: [
+          {
+            type: 'ExpressionStatement',
+            expression: { type: 'NumericLiteral', value: 0 },
+          },
+        ],
+      },
+    } as File,
     code: '',
     evaluator: jest.fn(),
     evalConfig: {},

--- a/packages/transform/src/transform/isStaticallyEvaluatableModule.ts
+++ b/packages/transform/src/transform/isStaticallyEvaluatableModule.ts
@@ -1,0 +1,286 @@
+import type {
+  Expression,
+  ImportDeclaration,
+  ExportNamedDeclaration,
+  File,
+  Statement,
+  VariableDeclaration,
+  VariableDeclarator,
+} from '@babel/types';
+import {
+  isArrayExpression,
+  isArrowFunctionExpression,
+  isAssignmentExpression,
+  isAwaitExpression,
+  isBinaryExpression,
+  isBigIntLiteral,
+  isBooleanLiteral,
+  isCallExpression,
+  isClassDeclaration,
+  isClassExpression,
+  isConditionalExpression,
+  isEmptyStatement,
+  isExportAllDeclaration,
+  isExportDefaultDeclaration,
+  isExportNamedDeclaration,
+  isExpression,
+  isExpressionStatement,
+  isFunctionDeclaration,
+  isFunctionExpression,
+  isIdentifier,
+  isImportDeclaration,
+  isImportSpecifier,
+  isLogicalExpression,
+  isNewExpression,
+  isNullLiteral,
+  isNumericLiteral,
+  isObjectExpression,
+  isObjectMethod,
+  isObjectProperty,
+  isParenthesizedExpression,
+  isSequenceExpression,
+  isSpreadElement,
+  isStringLiteral,
+  isTaggedTemplateExpression,
+  isTemplateLiteral,
+  isTSAsExpression,
+  isTSInstantiationExpression,
+  isTSNonNullExpression,
+  isTSSatisfiesExpression,
+  isUnaryExpression,
+  isUpdateExpression,
+  isYieldExpression,
+} from '@babel/types';
+
+function isTypeOnlyImport(statement: ImportDeclaration): boolean {
+  if (statement.importKind === 'type') {
+    return true;
+  }
+
+  return statement.specifiers.every(
+    (specifier) =>
+      isImportSpecifier(specifier) && specifier.importKind === 'type'
+  );
+}
+
+function isTypeOnlyReExport(statement: ExportNamedDeclaration): boolean {
+  if (!statement.source) {
+    return false;
+  }
+
+  return statement.exportKind === 'type';
+}
+
+function unwrapExpression(expr: Expression): Expression {
+  let current: Expression = expr;
+
+  for (;;) {
+    if (isTSAsExpression(current)) {
+      current = current.expression;
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    if (isTSSatisfiesExpression(current)) {
+      current = current.expression;
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    if (isTSNonNullExpression(current)) {
+      current = current.expression;
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    if (isTSInstantiationExpression(current)) {
+      current = current.expression;
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    if (isParenthesizedExpression(current)) {
+      current = current.expression;
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    return current;
+  }
+}
+
+function isSafeExpression(expr: Expression): boolean {
+  const unwrapped = unwrapExpression(expr);
+
+  if (
+    isStringLiteral(unwrapped) ||
+    isNumericLiteral(unwrapped) ||
+    isBooleanLiteral(unwrapped) ||
+    isNullLiteral(unwrapped) ||
+    isBigIntLiteral(unwrapped)
+  ) {
+    return true;
+  }
+
+  if (isArrowFunctionExpression(unwrapped) || isFunctionExpression(unwrapped)) {
+    return true;
+  }
+
+  if (isIdentifier(unwrapped)) {
+    return (
+      unwrapped.name === 'undefined' ||
+      unwrapped.name === 'NaN' ||
+      unwrapped.name === 'Infinity'
+    );
+  }
+
+  if (isTemplateLiteral(unwrapped)) {
+    return unwrapped.expressions.every(
+      (item) => isExpression(item) && isSafeExpression(item)
+    );
+  }
+
+  if (isUnaryExpression(unwrapped)) {
+    return isSafeExpression(unwrapped.argument as Expression);
+  }
+
+  if (isBinaryExpression(unwrapped) || isLogicalExpression(unwrapped)) {
+    return (
+      isSafeExpression(unwrapped.left as Expression) &&
+      isSafeExpression(unwrapped.right as Expression)
+    );
+  }
+
+  if (isConditionalExpression(unwrapped)) {
+    return (
+      isSafeExpression(unwrapped.test) &&
+      isSafeExpression(unwrapped.consequent) &&
+      isSafeExpression(unwrapped.alternate)
+    );
+  }
+
+  if (isArrayExpression(unwrapped)) {
+    return unwrapped.elements.every((item) => {
+      if (item === null) return true;
+      if (isSpreadElement(item)) return false;
+      return isSafeExpression(item);
+    });
+  }
+
+  if (isObjectExpression(unwrapped)) {
+    return unwrapped.properties.every((prop) => {
+      if (isSpreadElement(prop)) {
+        return false;
+      }
+
+      if (isObjectMethod(prop)) {
+        return !prop.computed;
+      }
+
+      if (isObjectProperty(prop)) {
+        if (prop.computed) {
+          return false;
+        }
+
+        return isExpression(prop.value) && isSafeExpression(prop.value);
+      }
+
+      return false;
+    });
+  }
+
+  if (
+    isCallExpression(unwrapped) ||
+    isNewExpression(unwrapped) ||
+    isTaggedTemplateExpression(unwrapped) ||
+    isAwaitExpression(unwrapped) ||
+    isYieldExpression(unwrapped) ||
+    isUpdateExpression(unwrapped) ||
+    isAssignmentExpression(unwrapped) ||
+    isSequenceExpression(unwrapped)
+  ) {
+    return false;
+  }
+
+  return false;
+}
+
+function isSafeDeclarator(declarator: VariableDeclarator): boolean {
+  if (!declarator.init) {
+    return true;
+  }
+
+  return isSafeExpression(declarator.init);
+}
+
+function isSafeVariableDeclaration(decl: VariableDeclaration): boolean {
+  return decl.declarations.every(isSafeDeclarator);
+}
+
+function isSafeStatement(statement: Statement): boolean {
+  if (isImportDeclaration(statement)) {
+    return isTypeOnlyImport(statement);
+  }
+
+  if (isExportAllDeclaration(statement)) {
+    return false;
+  }
+
+  if (isExportNamedDeclaration(statement)) {
+    if (!statement.declaration) {
+      return !statement.source || isTypeOnlyReExport(statement);
+    }
+
+    if (isFunctionDeclaration(statement.declaration)) {
+      return true;
+    }
+
+    if (isClassDeclaration(statement.declaration)) {
+      return false;
+    }
+
+    if (statement.declaration.type === 'VariableDeclaration') {
+      return isSafeVariableDeclaration(statement.declaration);
+    }
+
+    return false;
+  }
+
+  if (isExportDefaultDeclaration(statement)) {
+    const decl = statement.declaration;
+    if (
+      isFunctionDeclaration(decl) ||
+      isFunctionExpression(decl) ||
+      isArrowFunctionExpression(decl) ||
+      isClassExpression(decl) ||
+      isClassDeclaration(decl)
+    ) {
+      return false;
+    }
+
+    return isSafeExpression(decl as Expression);
+  }
+
+  if (statement.type === 'VariableDeclaration') {
+    return isSafeVariableDeclaration(statement);
+  }
+
+  if (isFunctionDeclaration(statement)) {
+    return true;
+  }
+
+  if (isEmptyStatement(statement)) {
+    return true;
+  }
+
+  if (isExpressionStatement(statement)) {
+    // Directives (like "use strict") are safe.
+    return isStringLiteral(statement.expression);
+  }
+
+  return false;
+}
+
+export function isStaticallyEvaluatableModule(ast: File): boolean {
+  return ast.program.body.every(isSafeStatement);
+}


### PR DESCRIPTION
Fixes #68 a Vite performance regression where `transform:evaluator` could be re-run many times due to `only` being repeatedly widened during supersede.

- Promote `only` → `['*']` for modules that are safe to fully evaluate (static-only / no runtime exports).
- Avoid parsing ignored modules and avoid mutating incoming `only` arrays.
- Add regression test + a local perf harness under `examples/vite-react-refresh/perf`.
- Add a patch changeset for `@wyw-in-js/transform`.

Perf (local repro): evaluator time drops from ~43s to ~3.4s on a 2000-export case.