### PR TITLE
fix(shared): ship @types/debug for TS consumers (#86)

### DIFF
--- a/.changeset/fix-shared-debug-types.md
+++ b/.changeset/fix-shared-debug-types.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/shared": patch
+---
+
+Fix TypeScript consumer builds by shipping `@types/debug` as a dependency (public `.d.ts` imports `debug`).

--- a/bun.lock
+++ b/bun.lock
@@ -270,6 +270,7 @@
       "name": "@wyw-in-js/shared",
       "version": "0.8.1",
       "dependencies": {
+        "@types/debug": "^4.1.9",
         "debug": "^4.3.4",
         "find-up": "^5.0.0",
         "minimatch": "^9.0.3",
@@ -277,7 +278,6 @@
       "devDependencies": {
         "@babel/types": "^7.23.5",
         "@types/babel__core": "^7.20.5",
-        "@types/debug": "^4.1.9",
         "@types/node": "^16.18.55",
         "@wyw-in-js/babel-config": "workspace:*",
         "@wyw-in-js/eslint-config": "workspace:*",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,6 +2,7 @@
   "name": "@wyw-in-js/shared",
   "version": "0.8.1",
   "dependencies": {
+    "@types/debug": "^4.1.9",
     "debug": "^4.3.4",
     "find-up": "^5.0.0",
     "minimatch": "^9.0.3"
@@ -9,7 +10,6 @@
   "devDependencies": {
     "@babel/types": "^7.23.5",
     "@types/babel__core": "^7.20.5",
-    "@types/debug": "^4.1.9",
     "@types/node": "^16.18.55",
     "@wyw-in-js/babel-config": "workspace:*",
     "@wyw-in-js/eslint-config": "workspace:*",

--- a/packages/shared/src/__tests__/dependencies.test.ts
+++ b/packages/shared/src/__tests__/dependencies.test.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+describe('@wyw-in-js/shared dependencies', () => {
+  it('should ship @types/debug for TypeScript consumers', () => {
+    const dirname = path.dirname(fileURLToPath(import.meta.url));
+    const pkgJsonPath = path.join(dirname, '..', '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+
+    expect(pkg.dependencies?.['@types/debug']).toBeTruthy();
+    expect(pkg.devDependencies?.['@types/debug']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #86 TS7016 for consumers when `@wyw-in-js/shared` public `.d.ts` imports `debug`.

- Move `@types/debug` to `dependencies` so it’s available transitively.
- Add a small regression test to ensure the dependency stays shipped.
- Add a patch changeset for `@wyw-in-js/shared`.