### PR TITLE
feat(vite): add ssrDevCss for SSR dev FOUC (#78)

### DIFF
--- a/.changeset/add-vite-ssr-dev-css.md
+++ b/.changeset/add-vite-ssr-dev-css.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/vite": patch
+---
+
+Add an opt-in `ssrDevCss` mode to avoid SSR dev FOUC by serving aggregated CSS and injecting a stylesheet link in transformed HTML.

--- a/apps/website/pages/bundlers/vite.mdx
+++ b/apps/website/pages/bundlers/vite.mdx
@@ -39,6 +39,39 @@ The injected object is available as `__wyw_import_meta_env` and includes:
 
 If you need to override values, you can provide your own `overrideContext` option and set `__wyw_import_meta_env` explicitly.
 
+### SSR dev FOUC (styles after hydration)
+
+When using Vite SSR in **dev** mode (`middlewareMode` + `ssrLoadModule`), the server-rendered HTML may not include the
+generated WyW CSS. The page then renders unstyled until the client runtime loads the CSS after hydration (FOUC).
+
+To avoid this, enable `ssrDevCss` to make the plugin:
+
+- collect generated CSS in memory,
+- expose it as a virtual stylesheet (`/_wyw-in-js/ssr.css` by default),
+- inject `<link rel="stylesheet">` via `transformIndexHtml()`.
+
+```js
+export default defineConfig(() => ({
+  // ...
+  plugins: [wyw({ ssrDevCss: true }), react()],
+}));
+```
+
+You can customize the URL via `ssrDevCssPath`:
+
+```js
+plugins: [wyw({ ssrDevCss: true, ssrDevCssPath: '/_wyw-in-js/ssr.css' }), react()],
+```
+
+This is **dev-only** and does not change production builds.
+
+Notes:
+
+- The served stylesheet is the raw WyW output (before Vite's CSS pipeline), so some edge cases like `url(...)` rewriting
+  may behave differently.
+- The `<link>` tag is injected on each HTML transform; CSS HMR does not “re-inject” the link on the client without a
+  page reload (which is fine for avoiding initial FOUC).
+
 ### Keeping CSS comments
 
 Stylis strips CSS comments by default. To preserve them (for example, `/*rtl:ignore*/`), pass `keepComments`:

--- a/packages/vite/src/__tests__/ssr-dev-css.test.ts
+++ b/packages/vite/src/__tests__/ssr-dev-css.test.ts
@@ -1,0 +1,137 @@
+const transformMock = jest.fn();
+
+jest.mock('vite', () => ({
+  __esModule: true,
+  createFilter: () => () => true,
+  loadEnv: jest.fn(() => ({})),
+}));
+
+jest.mock('@wyw-in-js/transform', () => ({
+  __esModule: true,
+  createFileReporter: () => ({
+    emitter: { single: jest.fn() },
+    onDone: jest.fn(),
+  }),
+  getFileIdx: () => '1',
+  TransformCacheCollection: class TransformCacheCollection {},
+  transform: (...args: unknown[]) => transformMock(...args),
+}));
+
+describe('vite SSR dev CSS', () => {
+  beforeEach(() => {
+    transformMock.mockReset();
+  });
+
+  it('injects a stylesheet link when ssrDevCss is enabled (serve)', async () => {
+    const { default: wywInJS } = await import('../index');
+    const plugin = wywInJS({ ssrDevCss: true });
+
+    plugin.configResolved?.({
+      root: process.cwd(),
+      mode: 'development',
+      command: 'serve',
+      base: '/',
+    } as any);
+
+    const result = plugin.transformIndexHtml?.('<html></html>') as any;
+
+    expect(result).toMatchObject({
+      tags: [
+        {
+          tag: 'link',
+          attrs: { rel: 'stylesheet' },
+        },
+      ],
+    });
+    expect(result.tags[0].attrs.href).toContain('/_wyw-in-js/ssr.css');
+  });
+
+  it('does not inject in build mode', async () => {
+    const { default: wywInJS } = await import('../index');
+    const plugin = wywInJS({ ssrDevCss: true });
+
+    plugin.configResolved?.({
+      root: process.cwd(),
+      mode: 'production',
+      command: 'build',
+      base: '/',
+    } as any);
+
+    expect(plugin.transformIndexHtml?.('<html></html>')).toBeUndefined();
+  });
+
+  it('serves aggregated CSS via middleware', async () => {
+    const { default: wywInJS } = await import('../index');
+    const plugin = wywInJS({ ssrDevCss: true });
+
+    plugin.configResolved?.({
+      root: process.cwd(),
+      mode: 'development',
+      command: 'serve',
+      base: '/',
+    } as any);
+
+    let middleware: ((req: any, res: any, next: () => void) => void) | null =
+      null;
+    plugin.configureServer?.({
+      middlewares: {
+        use: (fn: any) => {
+          middleware = fn;
+        },
+      },
+    } as any);
+
+    transformMock
+      .mockResolvedValueOnce({
+        code: 'export const x = 1;',
+        sourceMap: null,
+        cssText: '.b{color:red;}',
+        cssSourceMapText: null,
+        dependencies: [],
+      })
+      .mockResolvedValueOnce({
+        code: 'export const y = 2;',
+        sourceMap: null,
+        cssText: '.a{color:blue;}',
+        cssSourceMapText: null,
+        dependencies: [],
+      });
+
+    const resolve = jest.fn();
+    await plugin.transform?.call(
+      { resolve, warn: jest.fn() } as any,
+      'console.log("b")',
+      '/root/src/b.tsx'
+    );
+    await plugin.transform?.call(
+      { resolve, warn: jest.fn() } as any,
+      'console.log("a")',
+      '/root/src/a.tsx'
+    );
+
+    expect(middleware).toBeTruthy();
+
+    const res: any = {
+      statusCode: 0,
+      headers: {},
+      setHeader: (name: string, value: string) => {
+        res.headers[name.toLowerCase()] = value;
+      },
+      end: (body = '') => {
+        res.body = body;
+      },
+    };
+
+    middleware!({ url: '/_wyw-in-js/ssr.css?v=1', headers: {} }, res, () => {
+      throw new Error('next() should not be called for matching path');
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toBe('text/css; charset=utf-8');
+    expect(res.body).toContain('.a{color:blue;}');
+    expect(res.body).toContain('.b{color:red;}');
+    expect(res.body.indexOf('.a{color:blue;}')).toBeLessThan(
+      res.body.indexOf('.b{color:red;}')
+    );
+  });
+});


### PR DESCRIPTION
Adds an opt-in dev-only workaround for Vite SSR dev FOUC (styles only appear after hydration).

When `ssrDevCss: true` is enabled in `@wyw-in-js/vite`:
- generated CSS is aggregated in memory,
- served via a virtual route (default `/_wyw-in-js/ssr.css`),
- and injected into SSR HTML via `transformIndexHtml()`.

Notes:
- The served stylesheet is raw WyW output (before Vite's CSS pipeline), so edge cases like URL rewriting may differ.
- CSS link injection happens during HTML transform; updating the link client-side without reload is out of scope.

Includes unit tests, docs update, and a patch changeset for `@wyw-in-js/vite`.