### PR TITLE
fix(transform): avoid invalid PURE annotations

### DIFF
--- a/.changeset/fix-rollup-pure-annotation.md
+++ b/.changeset/fix-rollup-pure-annotation.md
@@ -1,7 +1,5 @@
 ---
 '@wyw-in-js/transform': patch
-'@wyw-in-js/vite': patch
 ---
 
-Fix Rollup/Vite warnings about `/*#__PURE__*/` annotations emitted for extracted template expressions.
-
+Avoid emitting `/*#__PURE__*/` on non-call/new expressions to prevent Rollup warnings during builds.

--- a/packages/transform/src/__tests__/__fixtures__/test-pure-annotation-arrow-processor.js
+++ b/packages/transform/src/__tests__/__fixtures__/test-pure-annotation-arrow-processor.js
@@ -1,0 +1,35 @@
+const { TaggedTemplateProcessor } = require('@wyw-in-js/processor-utils');
+
+class PureAnnotationArrowProcessor extends TaggedTemplateProcessor {
+  get asSelector() {
+    return this.className;
+  }
+
+  get value() {
+    return this.astService.stringLiteral(this.className);
+  }
+
+  addInterpolation(_node, _precedingCss, source) {
+    throw new Error(
+      `css tag cannot handle '${source}' as an interpolated value`
+    );
+  }
+
+  doEvaltimeReplacement() {
+    this.replacer(this.value, false);
+  }
+
+  doRuntimeReplacement() {
+    const arrowFn = this.astService.arrowFunctionExpression(
+      [],
+      this.astService.identifier('x')
+    );
+    this.replacer(arrowFn, true);
+  }
+
+  extractRules(_valueCache, _cssText, _loc) {
+    return {};
+  }
+}
+
+module.exports = { default: PureAnnotationArrowProcessor };

--- a/packages/transform/src/__tests__/__fixtures__/test-pure-annotation-call-processor.js
+++ b/packages/transform/src/__tests__/__fixtures__/test-pure-annotation-call-processor.js
@@ -1,0 +1,35 @@
+const { TaggedTemplateProcessor } = require('@wyw-in-js/processor-utils');
+
+class PureAnnotationCallProcessor extends TaggedTemplateProcessor {
+  get asSelector() {
+    return this.className;
+  }
+
+  get value() {
+    return this.astService.stringLiteral(this.className);
+  }
+
+  addInterpolation(_node, _precedingCss, source) {
+    throw new Error(
+      `css tag cannot handle '${source}' as an interpolated value`
+    );
+  }
+
+  doEvaltimeReplacement() {
+    this.replacer(this.value, false);
+  }
+
+  doRuntimeReplacement() {
+    const call = this.astService.callExpression(
+      this.astService.identifier('x'),
+      []
+    );
+    this.replacer(call, true);
+  }
+
+  extractRules(_valueCache, _cssText, _loc) {
+    return {};
+  }
+}
+
+module.exports = { default: PureAnnotationCallProcessor };

--- a/packages/transform/src/__tests__/getTagProcessor.pure-annotation.test.ts
+++ b/packages/transform/src/__tests__/getTagProcessor.pure-annotation.test.ts
@@ -1,0 +1,90 @@
+import path from 'path';
+
+import * as babel from '@babel/core';
+
+import type { StrictOptions } from '@wyw-in-js/shared';
+
+import { applyProcessors } from '../utils/getTagProcessor';
+
+const arrowProcessorPath = path.resolve(
+  __dirname,
+  '__fixtures__',
+  'test-pure-annotation-arrow-processor.js'
+);
+
+const callProcessorPath = path.resolve(
+  __dirname,
+  '__fixtures__',
+  'test-pure-annotation-call-processor.js'
+);
+
+const transform = (code: string, processorPath: string) => {
+  const fileContext = {
+    filename: path.join(__dirname, 'source.js'),
+    root: __dirname,
+  };
+
+  const options: Pick<
+    StrictOptions,
+    'classNameSlug' | 'displayName' | 'extensions' | 'evaluate' | 'tagResolver'
+  > = {
+    displayName: false,
+    evaluate: true,
+    extensions: ['.js'],
+    tagResolver: (source, imported) => {
+      if (source !== 'test-package' || imported !== 'css') {
+        return null;
+      }
+
+      return processorPath;
+    },
+  };
+
+  return babel.transformSync(code, {
+    filename: fileContext.filename,
+    babelrc: false,
+    configFile: false,
+    sourceType: 'module',
+    plugins: [
+      () => ({
+        visitor: {
+          Program(programPath) {
+            applyProcessors(programPath, fileContext, options, (processor) => {
+              processor.doRuntimeReplacement();
+            });
+          },
+        },
+      }),
+    ],
+  })!;
+};
+
+describe('getTagProcessor', () => {
+  it('does not emit PURE annotation for non-call/new replacements', () => {
+    const code = `
+      import { css } from 'test-package';
+
+      const a = css\`
+        color: red;
+      \`;
+    `;
+
+    const { code: result } = transform(code, arrowProcessorPath);
+
+    expect(result).not.toContain('/*#__PURE__*/');
+  });
+
+  it('emits PURE annotation for call expression replacements', () => {
+    const code = `
+      import { css } from 'test-package';
+
+      const a = css\`
+        color: red;
+      \`;
+    `;
+
+    const { code: result } = transform(code, callProcessorPath);
+
+    expect(result).toContain('/*#__PURE__*/');
+  });
+});

--- a/packages/transform/src/utils/getTagProcessor.ts
+++ b/packages/transform/src/utils/getTagProcessor.ts
@@ -250,10 +250,12 @@ function getBuilderForIdentifier(
     isPure: boolean
   ) => {
     mutate(prev, (p) => {
-      p.replaceWith(
-        typeof replacement === 'function' ? replacement(p) : replacement
-      );
-      if (isPure) {
+      const next =
+        typeof replacement === 'function' ? replacement(p) : replacement;
+
+      p.replaceWith(next);
+
+      if (isPure && (p.isCallExpression() || p.isNewExpression())) {
         p.addComment('leading', '#__PURE__');
       }
     });


### PR DESCRIPTION
Fixes https://github.com/Anber/wyw-in-js/issues/62.

Rollup/Vite warns when /*#__PURE__*/ is placed before non-call/new expressions (e.g. extracted arrow functions from styled(Component) call args). This narrows PURE emission to Call/New replacements only.

Checked:
- bun run --filter @wyw-in-js/transform test
- bun run --filter @wyw-in-js/transform lint
- Vite repro build no longer emits the PURE-position warning