### PR TITLE
fix(transform): canonicalize multi-keyword display

### DIFF
--- a/.changeset/fix-display-multi-keyword.md
+++ b/.changeset/fix-display-multi-keyword.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Normalize multi-keyword `display` values (e.g. `flex inline`) before Stylis prefixing to avoid malformed CSS output.


### PR DESCRIPTION
Fix Stylis prefixer producing malformed CSS for multi-keyword `display` values (CSS Display Module syntax).

- Canonicalize equivalent combinations to legacy single-keyword forms (e.g. `inline flex` → `inline-flex`, `block flow` → `block`, `inline table` → `inline-table`).
- For non-collapsible multi-keyword forms that start with `flex`/`grid` (e.g. `flex list-item`), reorder tokens to avoid Stylis prefixer output like `display:-webkit-boxdisplay...`.
- Add regression tests for flex/grid/flow/table/flow-root/list-item, !important, and prefixer:false.

Closes #142.