### PR TITLE
fix(webpack-loader): avoid rsbuild HMR CSS lag

### DIFF
--- a/.changeset/fix-rspack-hmr.md
+++ b/.changeset/fix-rspack-hmr.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/webpack-loader': patch
+---
+
+Fix Rsbuild/Rspack dev HMR where extracted CSS updates could apply one edit behind.
+

--- a/apps/website/pages/bundlers/rspack.mdx
+++ b/apps/website/pages/bundlers/rspack.mdx
@@ -1,0 +1,51 @@
+# Usage with Rspack / Rsbuild
+
+Rspack-based bundlers (including Rsbuild) can use WyW-in-JS through the webpack loader compatibility layer.
+
+### Installation
+
+```sh
+# npm
+npm i -D @wyw-in-js/webpack-loader
+# yarn
+yarn add --dev @wyw-in-js/webpack-loader
+# pnpm
+pnpm add -D @wyw-in-js/webpack-loader
+# bun
+bun add -d @wyw-in-js/webpack-loader
+```
+
+### Rsbuild configuration
+
+```ts
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginBabel } from '@rsbuild/plugin-babel';
+
+export default defineConfig({
+  plugins: [
+    pluginReact(),
+    pluginBabel({
+      babelLoaderOptions: (_, { addPresets }) => {
+        addPresets([['@babel/preset-react', { runtime: 'automatic' }]]);
+      },
+    }),
+  ],
+  tools: {
+    bundlerChain: (chain, { CHAIN_ID }) => {
+      chain.module
+        .rule(CHAIN_ID.RULE.JS)
+        .use(CHAIN_ID.USE.SWC)
+        .after(CHAIN_ID.USE.BABEL)
+        .loader('@wyw-in-js/webpack-loader');
+    },
+  },
+});
+```
+
+### HMR note
+
+Some Rspack setups may rebuild the generated CSS module before the JS loader finishes updating the in-memory CSS cache, which can make style updates appear “one edit behind”.
+
+WyW-in-JS avoids this by adding an internal version query to the injected CSS import when HMR is enabled, so the CSS module is invalidated on every CSS change.
+

--- a/packages/webpack-loader/src/__tests__/cache-provider.test.ts
+++ b/packages/webpack-loader/src/__tests__/cache-provider.test.ts
@@ -7,6 +7,10 @@ jest.mock('@wyw-in-js/shared', () => ({
 
 jest.mock('@wyw-in-js/transform', () => ({
   __esModule: true,
+  createFileReporter: () => ({
+    emitter: { single: jest.fn() },
+    onDone: jest.fn(),
+  }),
   TransformCacheCollection: function TransformCacheCollection() {},
   transform: (...args: unknown[]) => transformMock(...args),
 }));

--- a/packages/webpack-loader/src/__tests__/hmr-version.test.ts
+++ b/packages/webpack-loader/src/__tests__/hmr-version.test.ts
@@ -1,0 +1,94 @@
+const transformMock = jest.fn();
+
+jest.mock('@wyw-in-js/shared', () => ({
+  __esModule: true,
+  logger: jest.fn(),
+}));
+
+jest.mock('@wyw-in-js/transform', () => ({
+  __esModule: true,
+  createFileReporter: () => ({
+    emitter: { single: jest.fn() },
+    onDone: jest.fn(),
+  }),
+  TransformCacheCollection: function TransformCacheCollection() {},
+  transform: (...args: unknown[]) => transformMock(...args),
+}));
+
+describe('webpack-loader HMR CSS versioning', () => {
+  beforeEach(() => {
+    transformMock.mockReset();
+  });
+
+  it('adds a CSS version param to wyw query when hot', async () => {
+    const { default: webpackLoader } = await import('../index');
+    const resourcePath = '/abs/entry.jsx';
+
+    const run = async (cssText: string, hot: boolean) => {
+      transformMock.mockResolvedValueOnce({
+        code: 'module.exports = 1;',
+        sourceMap: null,
+        cssText,
+        cssSourceMapText: '',
+        dependencies: [],
+      });
+
+      let emittedRequest = '';
+
+      await new Promise<void>((resolve, reject) => {
+        webpackLoader.call(
+          {
+            hot,
+            addDependency: jest.fn(),
+            async: jest.fn(),
+            callback: (err: Error | null, code?: string) => {
+              if (err) {
+                reject(err);
+                return;
+              }
+
+              const match = String(code).match(/require\(([^)]+)\);/);
+              if (!match) {
+                reject(new Error('Expected loader to emit a require() call'));
+                return;
+              }
+
+              emittedRequest = JSON.parse(match[1].trim());
+              resolve();
+            },
+            context: process.cwd(),
+            emitWarning: jest.fn(),
+            getDependencies: () => [],
+            getOptions: () => ({}),
+            getResolve: () =>
+              jest.fn(
+                (
+                  _ctx: string,
+                  _token: string,
+                  cb: (err: any, res: any) => void
+                ) => cb(null, null)
+              ),
+            resourcePath,
+            rootContext: process.cwd(),
+            utils: {
+              contextify: (_ctx: string, request: string) => request,
+            },
+          } as any,
+          'module.exports = 1;',
+          null
+        );
+      });
+
+      return emittedRequest;
+    };
+
+    const hotReq1 = await run('.title{color:red}', true);
+    const hotReq2 = await run('.title{color:blue}', true);
+    const coldReq = await run('.title{color:green}', false);
+
+    expect(hotReq1).toMatch(/[?&]v=/);
+    expect(hotReq2).toMatch(/[?&]v=/);
+    expect(hotReq1).not.toEqual(hotReq2);
+    expect(coldReq).not.toMatch(/[?&]v=/);
+  });
+});


### PR DESCRIPTION
Fixes #55.

- Avoids a 1-edit-behind CSS update in Rsbuild/Rspack dev HMR by adding an internal version query to the injected CSS import when HMR is enabled.
- Adds unit coverage for HMR query versioning.
- Adds docs page for Rspack/Rsbuild.

Checks:
- bun run --filter @wyw-in-js/webpack-loader lint
- bun run --filter @wyw-in-js/webpack-loader test
- rsbuild dev (manual) / rsbuild build (manual)