### PR TITLE
fix(rollup): serialize transform for rolldown

### DIFF
--- a/.changeset/fix-rollup-rolldown-flakiness.md
+++ b/.changeset/fix-rollup-rolldown-flakiness.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/rollup': patch
+---
+
+Serialize `transform()` calls by default to avoid flakiness with bundlers that execute Rollup plugin hooks concurrently (e.g. tsdown/rolldown).
+

--- a/apps/website/pages/bundlers/rollup.mdx
+++ b/apps/website/pages/bundlers/rollup.mdx
@@ -35,6 +35,18 @@ export default {
 };
 ```
 
+### Concurrency (tsdown/rolldown)
+
+Some Rollup-compatible bundlers may execute plugin hooks concurrently (e.g. tsdown/rolldown). To keep evaluation deterministic, `@wyw-in-js/rollup` serializes `transform()` calls by default.
+
+If you are sure your bundler runs transforms sequentially, you can opt out:
+
+```js
+wyw({
+  serializeTransform: false,
+});
+```
+
 ### Keeping CSS comments
 
 Stylis strips CSS comments by default. To preserve them (for example, `/*rtl:ignore*/`), pass `keepComments`:

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -32,4 +32,16 @@ export default {
 };
 ```
 
+### Concurrency (tsdown/rolldown)
+
+Some Rollup-compatible bundlers may execute plugin hooks concurrently (e.g. tsdown/rolldown). To keep evaluation deterministic, `@wyw-in-js/rollup` serializes `transform()` calls by default.
+
+To opt out, pass:
+
+```js
+wyw({
+  serializeTransform: false,
+});
+```
+
 To get details about supported options by the plugin, please check [documentation](https://wyw-in-js.dev/bundlers/rollup).

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -40,7 +40,8 @@
     "build:esm": "babel src --out-dir esm --out-file-extension .mjs --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:lib": "cross-env NODE_ENV=legacy babel src --out-dir lib --extensions '.js,.jsx,.ts,.tsx' --source-maps --delete-dir-on-start",
     "build:types": "tsc --project ./tsconfig.lib.json --baseUrl . --rootDir ./src",
-    "lint": "eslint --ext .js,.ts ."
+    "lint": "eslint --ext .js,.ts .",
+    "test": "bun test src"
   },
   "types": "types/index.d.ts"
 }

--- a/packages/rollup/src/__tests__/serialize-transform.test.ts
+++ b/packages/rollup/src/__tests__/serialize-transform.test.ts
@@ -1,0 +1,81 @@
+const transformMock = jest.fn();
+
+let activeTransforms = 0;
+let maxActiveTransforms = 0;
+
+const createLogger = () => {
+  const log = (() => {}) as any;
+  log.extend = () => log;
+  return log;
+};
+
+jest.mock('@wyw-in-js/shared', () => ({
+  __esModule: true,
+  logger: createLogger(),
+  slugify: () => 'slug',
+  syncResolve: () => null,
+}));
+
+jest.mock('@wyw-in-js/transform', () => ({
+  __esModule: true,
+  getFileIdx: () => 'file',
+  TransformCacheCollection: function TransformCacheCollection() {},
+  transform: (...args: unknown[]) => transformMock(...args),
+}));
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+describe('@wyw-in-js/rollup serializeTransform', () => {
+  beforeEach(() => {
+    transformMock.mockReset();
+    activeTransforms = 0;
+    maxActiveTransforms = 0;
+
+    transformMock.mockImplementation(async () => {
+      activeTransforms += 1;
+      maxActiveTransforms = Math.max(maxActiveTransforms, activeTransforms);
+      await sleep(25);
+      activeTransforms -= 1;
+      return {
+        code: 'export const x = 1;',
+        cssText: '.a{color:red}',
+        sourceMap: null,
+      };
+    });
+  });
+
+  const createContext = () =>
+    ({
+      resolve: jest.fn(async (what: string) => ({ id: what, external: false })),
+      warn: jest.fn(),
+    }) as any;
+
+  it('serializes concurrent transform() calls by default', async () => {
+    const { default: wywInJS } = await import('../index');
+    const plugin = wywInJS();
+    const ctx = createContext();
+
+    await Promise.all([
+      plugin.transform!.call(ctx, 'export {}', '/abs/a.ts'),
+      plugin.transform!.call(ctx, 'export {}', '/abs/b.ts'),
+    ]);
+
+    expect(maxActiveTransforms).toBe(1);
+  });
+
+  it('allows opting out', async () => {
+    const { default: wywInJS } = await import('../index');
+    const plugin = wywInJS({ serializeTransform: false });
+    const ctx = createContext();
+
+    await Promise.all([
+      plugin.transform!.call(ctx, 'export {}', '/abs/a.ts'),
+      plugin.transform!.call(ctx, 'export {}', '/abs/b.ts'),
+    ]);
+
+    expect(maxActiveTransforms).toBe(2);
+  });
+});

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -21,6 +21,7 @@ type RollupPluginOptions = {
   keepComments?: boolean | RegExp;
   prefixer?: boolean;
   preprocessor?: Preprocessor;
+  serializeTransform?: boolean;
   sourceMap?: boolean;
 } & Partial<PluginOptions>;
 
@@ -30,6 +31,7 @@ export default function wywInJS({
   keepComments,
   prefixer,
   preprocessor,
+  serializeTransform = true,
   sourceMap,
   ...rest
 }: RollupPluginOptions = {}): Plugin {
@@ -37,6 +39,27 @@ export default function wywInJS({
   const cssLookup: { [key: string]: string } = {};
   const cache = new TransformCacheCollection();
   const emptyConfig = {};
+  let transformQueue = Promise.resolve();
+
+  const runSerialized = async <T>(fn: () => Promise<T>): Promise<T> => {
+    if (!serializeTransform) {
+      return fn();
+    }
+
+    let release: () => void;
+    const previous = transformQueue;
+    transformQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    await previous;
+
+    try {
+      return await fn();
+    } finally {
+      release!();
+    }
+  };
 
   const plugin: Plugin = {
     name: 'wyw-in-js',
@@ -51,84 +74,86 @@ export default function wywInJS({
       code: string,
       id: string
     ): Promise<{ code: string; map: Result['sourceMap'] } | undefined> {
-      // Do not transform ignored and generated files
-      if (!filter(id) || id in cssLookup) return;
+      return runSerialized(async () => {
+        // Do not transform ignored and generated files
+        if (!filter(id) || id in cssLookup) return;
 
-      const log = logger.extend('rollup').extend(getFileIdx(id));
+        const log = logger.extend('rollup').extend(getFileIdx(id));
 
-      log('init %s', id);
+        log('init %s', id);
 
-      const asyncResolve = async (
-        what: string,
-        importer: string,
-        stack: string[]
-      ) => {
-        const resolved = await this.resolve(what, importer);
-        if (resolved) {
-          if (resolved.external) {
-            // If module is marked as external, Rollup will not resolve it,
-            // so we need to resolve it ourselves with default resolver
-            const resolvedId = syncResolve(what, importer, stack);
+        const asyncResolve = async (
+          what: string,
+          importer: string,
+          stack: string[]
+        ) => {
+          const resolved = await this.resolve(what, importer);
+          if (resolved) {
+            if (resolved.external) {
+              // If module is marked as external, Rollup will not resolve it,
+              // so we need to resolve it ourselves with default resolver
+              const resolvedId = syncResolve(what, importer, stack);
+              log("resolve: ✅ '%s'@'%s -> %O\n%s", what, importer, resolved);
+              return resolvedId;
+            }
+
             log("resolve: ✅ '%s'@'%s -> %O\n%s", what, importer, resolved);
+
+            // Vite adds param like `?v=667939b3` to cached modules
+            const resolvedId = resolved.id.split('?')[0];
+
+            if (resolvedId.startsWith('\0')) {
+              // \0 is a special character in Rollup that tells Rollup to not include this in the bundle
+              // https://rollupjs.org/guide/en/#outputexports
+              return null;
+            }
+
             return resolvedId;
           }
 
-          log("resolve: ✅ '%s'@'%s -> %O\n%s", what, importer, resolved);
+          log("resolve: ❌ '%s'@'%s", what, importer);
+          throw new Error(`Could not resolve ${what}`);
+        };
 
-          // Vite adds param like `?v=667939b3` to cached modules
-          const resolvedId = resolved.id.split('?')[0];
+        const transformServices = {
+          options: {
+            filename: id,
+            pluginOptions: rest,
+            prefixer,
+            keepComments,
+            preprocessor,
+            root: process.cwd(),
+          },
+          cache,
+          emitWarning: (message: string) => this.warn(message),
+        };
 
-          if (resolvedId.startsWith('\0')) {
-            // \0 is a special character in Rollup that tells Rollup to not include this in the bundle
-            // https://rollupjs.org/guide/en/#outputexports
-            return null;
-          }
+        const result = await transform(
+          transformServices,
+          code,
+          asyncResolve,
+          emptyConfig
+        );
 
-          return resolvedId;
+        if (!result.cssText) return;
+
+        let { cssText } = result;
+
+        const slug = slugify(cssText);
+        const filename = `${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`;
+
+        if (sourceMap && result.cssSourceMapText) {
+          const map = Buffer.from(result.cssSourceMapText).toString('base64');
+          cssText += `/*# sourceMappingURL=data:application/json;base64,${map}*/`;
         }
 
-        log("resolve: ❌ '%s'@'%s", what, importer);
-        throw new Error(`Could not resolve ${what}`);
-      };
+        cssLookup[filename] = cssText;
 
-      const transformServices = {
-        options: {
-          filename: id,
-          pluginOptions: rest,
-          prefixer,
-          keepComments,
-          preprocessor,
-          root: process.cwd(),
-        },
-        cache,
-        emitWarning: (message: string) => this.warn(message),
-      };
+        result.code += `\nimport ${JSON.stringify(filename)};\n`;
 
-      const result = await transform(
-        transformServices,
-        code,
-        asyncResolve,
-        emptyConfig
-      );
-
-      if (!result.cssText) return;
-
-      let { cssText } = result;
-
-      const slug = slugify(cssText);
-      const filename = `${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`;
-
-      if (sourceMap && result.cssSourceMapText) {
-        const map = Buffer.from(result.cssSourceMapText).toString('base64');
-        cssText += `/*# sourceMappingURL=data:application/json;base64,${map}*/`;
-      }
-
-      cssLookup[filename] = cssText;
-
-      result.code += `\nimport ${JSON.stringify(filename)};\n`;
-
-      /* eslint-disable-next-line consistent-return */
-      return { code: result.code, map: result.sourceMap };
+        /* eslint-disable-next-line consistent-return */
+        return { code: result.code, map: result.sourceMap };
+      });
     },
   };
 


### PR DESCRIPTION
Rolldown/tsdown can execute Rollup plugin hooks concurrently, which can cause nondeterministic eval results.

Changes:
- Serialize `transform()` calls by default in `@wyw-in-js/rollup` via an internal queue.
- Add `serializeTransform` option to opt out if desired.
- Add unit test ensuring no overlap by default and overlap when opted out.
- Document the behavior in Rollup docs/README.
- Changeset for `@wyw-in-js/rollup` (patch).

Closes #54

Tested:
- `bun run --filter @wyw-in-js/rollup lint`
- `bun run --filter @wyw-in-js/rollup test`
- `bun x turbo run build:types --filter @wyw-in-js/rollup`