### PR TITLE
feat(bundlers): allow transforming node_modules (#124)

### DIFF
--- a/.changeset/transform-libraries-node-modules.md
+++ b/.changeset/transform-libraries-node-modules.md
@@ -1,0 +1,8 @@
+---
+'@wyw-in-js/bun': patch
+'@wyw-in-js/esbuild': patch
+'@wyw-in-js/vite': patch
+---
+
+Add `transformLibraries` option to allow transforming selected dependencies inside `node_modules` (opt-in; still recommended to narrow via filters).
+

--- a/apps/website/pages/bundlers/bun.mdx
+++ b/apps/website/pages/bundlers/bun.mdx
@@ -31,6 +31,19 @@ await Bun.build({
 });
 ```
 
+### Transforming libraries in `node_modules`
+
+By default, the Bun plugin skips transforming files from `node_modules` for performance.
+
+To transform a specific library, enable `transformLibraries` and narrow `include`/`exclude`:
+
+```js
+wyw({
+  transformLibraries: true,
+  include: [/node_modules\\/(?:@fluentui)\\//],
+});
+```
+
 ### Keeping CSS comments
 
 WyW can preserve CSS comments (for example, `/*rtl:ignore*/`) via `keepComments`.

--- a/apps/website/pages/bundlers/esbuild.mdx
+++ b/apps/website/pages/bundlers/esbuild.mdx
@@ -37,6 +37,19 @@ esbuild
   .catch(() => process.exit(1));
 ```
 
+### Transforming libraries in `node_modules`
+
+By default, the esbuild plugin skips transforming files from `node_modules` for performance.
+
+To transform a specific library, enable `transformLibraries` and narrow `filter`:
+
+```js
+wyw({
+  transformLibraries: true,
+  filter: /node_modules\\/(?:@fluentui)\\//,
+});
+```
+
 ### Keeping CSS comments
 
 Stylis strips CSS comments by default. To preserve them (for example, `/*rtl:ignore*/`), pass `keepComments`:

--- a/apps/website/pages/bundlers/vite.mdx
+++ b/apps/website/pages/bundlers/vite.mdx
@@ -27,6 +27,23 @@ export default defineConfig(() => ({
 }));
 ```
 
+### Transforming libraries in `node_modules`
+
+By default, the Vite plugin skips transforming files from `node_modules` for performance.
+
+To transform a specific library, enable `transformLibraries` and narrow `include`/`exclude`:
+
+```js
+export default defineConfig(() => ({
+  plugins: [
+    wyw({
+      transformLibraries: true,
+      include: [/node_modules\\/(?:@fluentui)\\//],
+    }),
+  ],
+}));
+```
+
 ### `import.meta.env` during evaluation
 
 WyW-in-JS evaluates a subset of your code at build time to extract styles. When that code relies on Vite's `import.meta.env.*`,

--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -27,4 +27,17 @@ await Bun.build({
 });
 ```
 
+## Transforming libraries in `node_modules`
+
+By default, the Bun plugin skips transforming files from `node_modules` for performance.
+
+To transform a specific library, enable `transformLibraries` and narrow `include`/`exclude`:
+
+```js
+wyw({
+  transformLibraries: true,
+  include: [/node_modules\\/(?:@fluentui)\\//],
+});
+```
+
 To get details about supported options by the plugin, please check [documentation](https://wyw-in-js.dev/bundlers/bun).

--- a/packages/bun/src/__tests__/transform-libraries.test.ts
+++ b/packages/bun/src/__tests__/transform-libraries.test.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const transformMock = jest.fn();
+
+jest.mock('@wyw-in-js/transform', () => ({
+  __esModule: true,
+  createFileReporter: () => ({
+    emitter: { single: jest.fn() },
+    onDone: jest.fn(),
+  }),
+  slugify: () => 'slug',
+  TransformCacheCollection: class TransformCacheCollection {},
+  transform: (...args: unknown[]) => transformMock(...args),
+}));
+
+const createBuilder = () => {
+  const handlers: Array<{ callback: any; options: any }> = [];
+
+  const builder = {
+    onEnd: jest.fn(),
+    onResolve: jest.fn(),
+    onLoad: jest.fn((options: any, callback: any) => {
+      handlers.push({ callback, options });
+    }),
+  } as any;
+
+  return { builder, handlers };
+};
+
+const getMainOnLoad = (handlers: Array<{ callback: any; options: any }>) => {
+  const call = handlers.find(({ options }) => !('namespace' in options));
+  if (!call) {
+    throw new Error('Expected main onLoad registration.');
+  }
+  return call.callback;
+};
+
+describe('bun transformLibraries', () => {
+  beforeEach(() => {
+    transformMock.mockReset();
+    transformMock.mockResolvedValue({
+      code: 'export {}',
+      cssText: '',
+      cssSourceMapText: '',
+      sourceMap: null,
+    });
+  });
+
+  it('skips node_modules by default', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-bun-124-'));
+    const file = path.join(root, 'node_modules', 'test-lib', 'index.ts');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, 'export const x = 1;', 'utf8');
+
+    const { builder, handlers } = createBuilder();
+    wywInJS().setup(builder);
+
+    const onLoad = getMainOnLoad(handlers);
+    const result = await onLoad({ path: file });
+
+    expect(result).toBeUndefined();
+    expect(transformMock).not.toHaveBeenCalled();
+  });
+
+  it('allows transforming node_modules when transformLibraries is true', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-bun-124-'));
+    const file = path.join(root, 'node_modules', 'test-lib', 'index.ts');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, 'export const x = 1;', 'utf8');
+
+    const { builder, handlers } = createBuilder();
+    wywInJS({ transformLibraries: true }).setup(builder);
+
+    const onLoad = getMainOnLoad(handlers);
+    const result = await onLoad({ path: file });
+
+    expect(transformMock).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeUndefined();
+  });
+});

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -29,6 +29,7 @@ export type BunPluginOptions = {
   prefixer?: boolean;
   preprocessor?: Preprocessor;
   sourceMap?: boolean;
+  transformLibraries?: boolean;
 } & Partial<PluginOptions>;
 
 const nodeModulesRegex = /^(?:.*[\\/])?node_modules(?:[\\/].*)?$/;
@@ -81,6 +82,7 @@ export default function wywInJS({
   exclude,
   filter = /\.[cm]?[jt]sx?$/,
   nodeModules = false,
+  transformLibraries,
   sourceMap,
   keepComments,
   prefixer,
@@ -89,6 +91,7 @@ export default function wywInJS({
 }: BunPluginOptions = {}): BunPlugin {
   const cache = new TransformCacheCollection();
   const filterFn = createFilter(include, exclude);
+  const allowNodeModules = transformLibraries ?? nodeModules;
 
   return {
     name: 'wyw-in-js',
@@ -173,7 +176,7 @@ export default function wywInJS({
           return undefined;
         }
 
-        if (!nodeModules && nodeModulesRegex.test(args.path)) {
+        if (!allowNodeModules && nodeModulesRegex.test(args.path)) {
           return undefined;
         }
 

--- a/packages/esbuild/README.md
+++ b/packages/esbuild/README.md
@@ -34,4 +34,17 @@ esbuild
   .catch(() => process.exit(1));
 ```
 
+## Transforming libraries in `node_modules`
+
+By default, the esbuild plugin skips transforming files from `node_modules` for performance.
+
+To transform a specific library, enable `transformLibraries` and narrow `filter`:
+
+```js
+wyw({
+  transformLibraries: true,
+  filter: /node_modules\\/(?:@fluentui)\\//,
+});
+```
+
 To get details about supported options by the plugin, please check [documentation](https://wyw-in-js.dev/bundlers/esbuild).

--- a/packages/esbuild/src/__tests__/transform-libraries.test.ts
+++ b/packages/esbuild/src/__tests__/transform-libraries.test.ts
@@ -1,0 +1,102 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import * as esbuild from 'esbuild';
+
+import wywInJS from '../index';
+
+const getCssText = (result: esbuild.BuildResult): string | null => {
+  const css = result.outputFiles?.find((file) => file.path.endsWith('.css'));
+  return css?.text ?? null;
+};
+
+it('transforms node_modules when transformLibraries is enabled', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-esbuild-124-'));
+  const outdir = path.join(root, 'dist');
+
+  const nmRoot = path.join(root, 'node_modules');
+  const processorStubDir = path.join(nmRoot, 'test-css-processor');
+  const libDir = path.join(nmRoot, 'test-lib');
+
+  fs.mkdirSync(processorStubDir, { recursive: true });
+  fs.mkdirSync(libDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(processorStubDir, 'package.json'),
+    JSON.stringify({
+      name: 'test-css-processor',
+      version: '1.0.0',
+      type: 'module',
+    }),
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(processorStubDir, 'index.js'),
+    `export const css = (strings) => strings.join('');\n`,
+    'utf8'
+  );
+
+  const entryFile = path.join(libDir, 'index.js');
+  fs.writeFileSync(
+    entryFile,
+    [
+      `import { css } from 'test-css-processor';`,
+      ``,
+      `export const className = css\``,
+      `  color: red;`,
+      `\`;`,
+      ``,
+      `export const _usage = [className];`,
+      ``,
+    ].join('\n'),
+    'utf8'
+  );
+
+  const processorFile = path.resolve(
+    __dirname,
+    '../../../transform/src/__tests__/__fixtures__/test-css-processor.js'
+  );
+
+  const cwd = process.cwd();
+  process.chdir(root);
+
+  try {
+    const basePluginOptions = {
+      configFile: false,
+      tagResolver: (source: string, tag: string) => {
+        if (source === 'test-css-processor' && tag === 'css') {
+          return processorFile;
+        }
+
+        return null;
+      },
+    };
+
+    const skipped = await esbuild.build({
+      entryPoints: [entryFile],
+      bundle: true,
+      format: 'esm',
+      write: false,
+      outdir,
+      plugins: [wywInJS(basePluginOptions)],
+    });
+
+    expect(getCssText(skipped)).toBeNull();
+
+    const transformed = await esbuild.build({
+      entryPoints: [entryFile],
+      bundle: true,
+      format: 'esm',
+      write: false,
+      outdir,
+      plugins: [wywInJS({ ...basePluginOptions, transformLibraries: true })],
+    });
+
+    const cssText = getCssText(transformed);
+    expect(cssText).not.toBeNull();
+    expect(cssText).toContain('red');
+  } finally {
+    process.chdir(cwd);
+  }
+});

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -30,6 +30,7 @@ type EsbuildPluginOptions = {
   prefixer?: boolean;
   preprocessor?: Preprocessor;
   sourceMap?: boolean;
+  transformLibraries?: boolean;
 } & Partial<PluginOptions>;
 
 const supportedFilterFlags = new Set(['i', 'm', 's']);
@@ -44,6 +45,7 @@ export default function wywInJS({
   preprocessor,
   esbuildOptions,
   filter = /\.(js|jsx|ts|tsx)$/,
+  transformLibraries,
   ...rest
 }: EsbuildPluginOptions = {}): Plugin {
   let options = esbuildOptions;
@@ -142,7 +144,7 @@ export default function wywInJS({
         const { ext, name: filename } = parse(args.path);
         const loader = ext.replace(/^\./, '') as Loader;
 
-        if (nodeModulesRegex.test(args.path)) {
+        if (!transformLibraries && nodeModulesRegex.test(args.path)) {
           return {
             loader,
             contents: rawCode,

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -29,6 +29,19 @@ export default defineConfig({
 });
 ```
 
+## Transforming libraries in `node_modules`
+
+By default, the Vite plugin skips transforming files from `node_modules` for performance.
+
+To transform a specific library, enable `transformLibraries` and narrow `include`/`exclude`:
+
+```js
+wyw({
+  transformLibraries: true,
+  include: [/node_modules\\/(?:@fluentui)\\//],
+});
+```
+
 ## `import.meta.env` during evaluation
 
 WyW-in-JS evaluates part of your code at build time to extract styles. The Vite plugin injects Vite's `import.meta.env` values

--- a/packages/vite/src/__tests__/transform-libraries.test.ts
+++ b/packages/vite/src/__tests__/transform-libraries.test.ts
@@ -1,0 +1,90 @@
+const transformMock = jest.fn();
+const filterMock = jest.fn();
+
+const createLogger = () => {
+  const log = (() => undefined) as unknown as ((...args: unknown[]) => void) & {
+    extend: (...args: unknown[]) => unknown;
+  };
+
+  log.extend = () => log;
+  return log;
+};
+
+jest.mock('@wyw-in-js/shared', () => ({
+  __esModule: true,
+  logger: createLogger(),
+  syncResolve: jest.fn(),
+}));
+
+jest.mock('vite', () => ({
+  __esModule: true,
+  createFilter: (...args: unknown[]) => filterMock(...args),
+  loadEnv: jest.fn(() => ({})),
+}));
+
+jest.mock('@wyw-in-js/transform', () => ({
+  __esModule: true,
+  createFileReporter: () => ({
+    emitter: { single: jest.fn() },
+    onDone: jest.fn(),
+  }),
+  getFileIdx: () => '1',
+  TransformCacheCollection: class TransformCacheCollection {},
+  transform: (...args: unknown[]) => transformMock(...args),
+}));
+
+describe('vite transformLibraries', () => {
+  beforeEach(() => {
+    transformMock.mockReset();
+    filterMock.mockReset();
+    filterMock.mockReturnValue(() => true);
+
+    transformMock.mockResolvedValue({
+      code: 'export {}',
+      sourceMap: null,
+      cssText: undefined,
+      dependencies: [],
+    });
+  });
+
+  it('skips node_modules by default even when filter matches', async () => {
+    const { default: wywInJS } = await import('../index');
+    const plugin = wywInJS();
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'export {}',
+      '/node_modules/test-lib/index.js'
+    );
+
+    expect(transformMock).not.toHaveBeenCalled();
+  });
+
+  it('allows transforming node_modules when transformLibraries is true', async () => {
+    const { default: wywInJS } = await import('../index');
+    const plugin = wywInJS({ transformLibraries: true });
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'export {}',
+      '/node_modules/test-lib/index.js'
+    );
+
+    expect(transformMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still respects include/exclude filter', async () => {
+    filterMock.mockReturnValue(() => false);
+
+    const { default: wywInJS } = await import('../index');
+    const plugin = wywInJS({ transformLibraries: true });
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'export {}',
+      '/node_modules/test-lib/index.js'
+    );
+
+    expect(transformMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -40,6 +40,7 @@ type VitePluginOptions = {
   sourceMap?: boolean;
   ssrDevCss?: boolean;
   ssrDevCssPath?: string;
+  transformLibraries?: boolean;
 } & Partial<PluginOptions>;
 
 type OverrideContext = NonNullable<PluginOptions['overrideContext']>;
@@ -56,6 +57,7 @@ export default function wywInJS({
   preprocessor,
   ssrDevCss,
   ssrDevCssPath,
+  transformLibraries,
   ...rest
 }: VitePluginOptions = {}): Plugin {
   const filter = createFilter(include, exclude);
@@ -243,7 +245,11 @@ export default function wywInJS({
       const [id] = url.split('?', 1);
 
       // Do not transform ignored and generated files
-      if (url.includes('node_modules') || !filter(url) || id in cssLookup)
+      if (
+        (!transformLibraries && url.includes('node_modules')) ||
+        !filter(url) ||
+        id in cssLookup
+      )
         return;
 
       const log = logger.extend('vite').extend(getFileIdx(id));


### PR DESCRIPTION
## Summary
- Add `transformLibraries?: boolean` (default: `false`) to allow transforming selected `node_modules` sources.
- Implemented in `@wyw-in-js/vite`, `@wyw-in-js/esbuild`, and `@wyw-in-js/bun` (alias of existing `nodeModules`; `transformLibraries` takes precedence).
- Docs updated (package READMEs + website bundler pages).
- Includes changeset (patch) for the affected packages.

## Checks
- `bun run --filter @wyw-in-js/vite lint` + `bun run --filter @wyw-in-js/vite test`
- `bun run --filter @wyw-in-js/esbuild lint` + `bun run --filter @wyw-in-js/esbuild test`
- `bun run --filter @wyw-in-js/bun lint` + `bun run --filter @wyw-in-js/bun test`
- `bun x turbo run build:types --filter @wyw-in-js/vite --filter @wyw-in-js/esbuild --filter @wyw-in-js/bun`

Closes #124
