### PR TITLE
feat(esbuild): optional pre-transform with Babel (#127)

### DIFF
--- a/.changeset/esbuild-babel-transform.md
+++ b/.changeset/esbuild-babel-transform.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/esbuild': patch
+---
+
+Add `babelTransform` option to apply configured `babelOptions` to source code before the esbuild/WyW pipeline (opt-in).
+

--- a/apps/website/pages/bundlers/esbuild.mdx
+++ b/apps/website/pages/bundlers/esbuild.mdx
@@ -37,6 +37,29 @@ esbuild
   .catch(() => process.exit(1));
 ```
 
+### Additional Babel transformations
+
+esbuild doesn't support chaining multiple `onLoad` transforms for the same file. If your project needs extra Babel plugins
+to run before WyW evaluation (for example, plugins that operate on TS/JSX), enable `babelTransform`:
+
+```js
+wyw({
+  babelTransform: true,
+  babelOptions: {
+    plugins: [
+      // your custom Babel plugins
+    ],
+  },
+});
+```
+
+Order: `Babel(source) → esbuild.transform() → WyW transform`.
+
+Note: `babelOptions` are still used by WyW when parsing/evaluating modules. With `babelTransform: true`, the same plugins
+may run both before esbuild and again during WyW's internal Babel stage. Prefer idempotent plugins.
+
+This is opt-in and may impact performance, so keep `filter` narrow when possible.
+
 ### Transforming libraries in `node_modules`
 
 By default, the esbuild plugin skips transforming files from `node_modules` for performance.

--- a/packages/esbuild/README.md
+++ b/packages/esbuild/README.md
@@ -34,6 +34,31 @@ esbuild
   .catch(() => process.exit(1));
 ```
 
+## Additional Babel transformations
+
+`@wyw-in-js/esbuild` runs WyW evaluation after an `esbuild.transform()` step, so some Babel plugins may not be able to
+operate on the original TS/JSX source.
+
+Enable `babelTransform` to apply `babelOptions` to the original source code before the esbuild/WyW pipeline:
+
+```js
+wyw({
+  babelTransform: true,
+  babelOptions: {
+    plugins: [
+      // your custom Babel plugins
+    ],
+  },
+});
+```
+
+Order: `Babel(source) → esbuild.transform() → WyW transform`.
+
+Note: `babelOptions` are still used by WyW when parsing/evaluating modules. With `babelTransform: true`, the same plugins
+may run both before esbuild and again during WyW's internal Babel stage. Prefer idempotent plugins.
+
+This is an opt-in feature and may increase build times, so it's recommended to keep `filter` narrow.
+
 ## Transforming libraries in `node_modules`
 
 By default, the esbuild plugin skips transforming files from `node_modules` for performance.

--- a/packages/esbuild/src/__tests__/babel-transform.test.ts
+++ b/packages/esbuild/src/__tests__/babel-transform.test.ts
@@ -1,0 +1,180 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import * as esbuild from 'esbuild';
+
+import wywInJS from '../index';
+
+const getCssText = (result: esbuild.BuildResult): string | null => {
+  const css = result.outputFiles?.find((file) => file.path.endsWith('.css'));
+  return css?.text ?? null;
+};
+
+type ProgramPath = {
+  traverse: (visitor: { JSXElement: () => void }) => void;
+  unshiftContainer: (key: 'body', nodes: unknown[]) => void;
+};
+
+type BabelTypesHelpers = {
+  arrayExpression: (elements: unknown[]) => unknown;
+  exportNamedDeclaration: (declaration: unknown) => unknown;
+  identifier: (name: string) => unknown;
+  taggedTemplateExpression: (tag: unknown, quasi: unknown) => unknown;
+  templateElement: (
+    value: { cooked: string; raw: string },
+    tail: boolean
+  ) => unknown;
+  templateLiteral: (quasis: unknown[], expressions: unknown[]) => unknown;
+  variableDeclaration: (kind: string, declarations: unknown[]) => unknown;
+  variableDeclarator: (id: unknown, init: unknown) => unknown;
+};
+
+type BabelApi = {
+  types: BabelTypesHelpers;
+};
+
+const injectCssOnJsx = (babel: BabelApi) => {
+  const t = babel.types;
+
+  return {
+    name: 'inject-css-on-jsx',
+    visitor: {
+      Program(programPath: ProgramPath) {
+        let hasJsx = false;
+        programPath.traverse({
+          JSXElement() {
+            hasJsx = true;
+          },
+        });
+
+        if (!hasJsx) {
+          return;
+        }
+
+        programPath.unshiftContainer('body', [
+          t.exportNamedDeclaration(
+            t.variableDeclaration('const', [
+              t.variableDeclarator(
+                t.identifier('className'),
+                t.taggedTemplateExpression(
+                  t.identifier('css'),
+                  t.templateLiteral(
+                    [
+                      t.templateElement(
+                        { raw: 'color: red;', cooked: 'color: red;' },
+                        true
+                      ),
+                    ],
+                    []
+                  )
+                )
+              ),
+            ])
+          ),
+          t.exportNamedDeclaration(
+            t.variableDeclaration('const', [
+              t.variableDeclarator(
+                t.identifier('_usage'),
+                t.arrayExpression([t.identifier('className')])
+              ),
+            ])
+          ),
+        ]);
+      },
+    },
+  };
+};
+
+it('can apply babelOptions to source code before esbuild/WyW transform', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-esbuild-127-'));
+  const outdir = path.join(root, 'dist');
+
+  const entryFile = path.join(root, 'main.tsx');
+
+  const nmRoot = path.join(root, 'node_modules');
+  const processorStubDir = path.join(nmRoot, 'test-css-processor');
+
+  fs.mkdirSync(processorStubDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(processorStubDir, 'package.json'),
+    JSON.stringify({
+      name: 'test-css-processor',
+      version: '1.0.0',
+      type: 'module',
+    }),
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(processorStubDir, 'index.js'),
+    `export const css = (strings) => strings.join('');\n`,
+    'utf8'
+  );
+
+  fs.writeFileSync(
+    entryFile,
+    [
+      `import { css } from 'test-css-processor';`,
+      ``,
+      `export function App() {`,
+      `  return <div />;`,
+      `}`,
+      ``,
+    ].join('\n'),
+    'utf8'
+  );
+
+  const processorFile = path.resolve(
+    __dirname,
+    '../../../transform/src/__tests__/__fixtures__/test-css-processor.js'
+  );
+
+  const cwd = process.cwd();
+  process.chdir(root);
+
+  try {
+    const basePluginOptions = {
+      configFile: false,
+      babelOptions: {
+        plugins: [injectCssOnJsx],
+        parserOpts: {
+          plugins: ['jsx', 'typescript'],
+        },
+      },
+      tagResolver: (source: string, tag: string) => {
+        if (source === 'test-css-processor' && tag === 'css') {
+          return processorFile;
+        }
+
+        return null;
+      },
+    };
+
+    const skipped = await esbuild.build({
+      entryPoints: [entryFile],
+      bundle: true,
+      format: 'esm',
+      write: false,
+      outdir,
+      plugins: [wywInJS(basePluginOptions)],
+    });
+
+    expect(getCssText(skipped)).toBeNull();
+
+    const transformed = await esbuild.build({
+      entryPoints: [entryFile],
+      bundle: true,
+      format: 'esm',
+      write: false,
+      outdir,
+      plugins: [wywInJS({ ...basePluginOptions, babelTransform: true })],
+    });
+
+    const cssText = getCssText(transformed);
+    expect(cssText).not.toBeNull();
+    expect(cssText).toContain('red');
+  } finally {
+    process.chdir(cwd);
+  }
+});


### PR DESCRIPTION
## Summary
- Add `babelTransform` (opt-in) to run configured `babelOptions` on source code before the esbuild/WyW pipeline.
- Order: `Babel(source) → esbuild.transform() → WyW transform`.
- When `babelTransform: true` and `babelOptions` is empty, it's a no-op with a one-time warning.

## Notes
- `babelOptions` are still used by WyW during parse/eval; with `babelTransform: true` the same plugins may run twice (prefer idempotent plugins).

## Tests
- `bun run --filter @wyw-in-js/esbuild lint`
- `bun run --filter @wyw-in-js/esbuild test`
- `bun run --filter @wyw-in-js/esbuild build:types`

Closes #127
