### PR TITLE
docs(bundlers): document prefixer option (#77)

### DIFF
--- a/.changeset/document-prefixer-option.md
+++ b/.changeset/document-prefixer-option.md
@@ -1,0 +1,11 @@
+---
+"@wyw-in-js/bun": patch
+"@wyw-in-js/esbuild": patch
+"@wyw-in-js/nextjs": patch
+"@wyw-in-js/rollup": patch
+"@wyw-in-js/vite": patch
+"@wyw-in-js/webpack-loader": patch
+---
+
+Document the `prefixer: false` option to disable vendor prefixing in bundler plugins.
+

--- a/apps/website/pages/bundlers/bun.mdx
+++ b/apps/website/pages/bundlers/bun.mdx
@@ -44,6 +44,16 @@ wyw({
 });
 ```
 
+### Disabling vendor prefixing
+
+Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:
+
+```js
+wyw({
+  prefixer: false,
+});
+```
+
 ### Keeping CSS comments
 
 WyW can preserve CSS comments (for example, `/*rtl:ignore*/`) via `keepComments`.

--- a/apps/website/pages/bundlers/esbuild.mdx
+++ b/apps/website/pages/bundlers/esbuild.mdx
@@ -73,6 +73,16 @@ wyw({
 });
 ```
 
+### Disabling vendor prefixing
+
+Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:
+
+```js
+wyw({
+  prefixer: false,
+});
+```
+
 ### Keeping CSS comments
 
 Stylis strips CSS comments by default. To preserve them (for example, `/*rtl:ignore*/`), pass `keepComments`:

--- a/apps/website/pages/bundlers/nextjs.mdx
+++ b/apps/website/pages/bundlers/nextjs.mdx
@@ -46,6 +46,27 @@ module.exports = withWyw(
 );
 ```
 
+### Disabling vendor prefixing
+
+Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:
+
+```js
+// next.config.js
+const { withWyw } = require('@wyw-in-js/nextjs');
+
+module.exports = withWyw(
+  {},
+  {
+    loaderOptions: {
+      prefixer: false,
+    },
+    turbopackLoaderOptions: {
+      prefixer: false,
+    },
+  }
+);
+```
+
 ### Notes
 
 - The plugin emits styles as `*.wyw-in-js.module.css` so imports are allowed from any module.

--- a/apps/website/pages/bundlers/rollup.mdx
+++ b/apps/website/pages/bundlers/rollup.mdx
@@ -47,6 +47,16 @@ wyw({
 });
 ```
 
+### Disabling vendor prefixing
+
+Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:
+
+```js
+wyw({
+  prefixer: false,
+});
+```
+
 ### Keeping CSS comments
 
 Stylis strips CSS comments by default. To preserve them (for example, `/*rtl:ignore*/`), pass `keepComments`:

--- a/apps/website/pages/bundlers/vite.mdx
+++ b/apps/website/pages/bundlers/vite.mdx
@@ -89,6 +89,17 @@ Notes:
 - The `<link>` tag is injected on each HTML transform; CSS HMR does not “re-inject” the link on the client without a
   page reload (which is fine for avoiding initial FOUC).
 
+### Disabling vendor prefixing
+
+Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:
+
+```js
+export default defineConfig(() => ({
+  // ...
+  plugins: [wyw({ prefixer: false })],
+}));
+```
+
 ### Keeping CSS comments
 
 Stylis strips CSS comments by default. To preserve them (for example, `/*rtl:ignore*/`), pass `keepComments`:

--- a/apps/website/pages/bundlers/webpack.mdx
+++ b/apps/website/pages/bundlers/webpack.mdx
@@ -34,6 +34,30 @@ If you import assets with resource queries (e.g. `./arrow.svg?svgUse`), WyW-in-J
 
 For cases where evaluated code needs a value from such imports, configure `importLoaders` in your WyW config (see `/configuration`).
 
+### Disabling vendor prefixing
+
+Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.js/,
+        use: [
+          {
+            loader: '@wyw-in-js/webpack-loader',
+            options: {
+              prefixer: false,
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
 ### Keeping CSS comments
 
 Stylis strips CSS comments by default. To preserve them (for example, `/*rtl:ignore*/`), pass `keepComments`:

--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -40,4 +40,14 @@ wyw({
 });
 ```
 
+## Disabling vendor prefixing
+
+Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:
+
+```js
+wyw({
+  prefixer: false,
+});
+```
+
 To get details about supported options by the plugin, please check [documentation](https://wyw-in-js.dev/bundlers/bun).

--- a/packages/esbuild/README.md
+++ b/packages/esbuild/README.md
@@ -59,6 +59,16 @@ may run both before esbuild and again during WyW's internal Babel stage. Prefer 
 
 This is an opt-in feature and may increase build times, so it's recommended to keep `filter` narrow.
 
+## Disabling vendor prefixing
+
+Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:
+
+```js
+wyw({
+  prefixer: false,
+});
+```
+
 ## Transforming libraries in `node_modules`
 
 By default, the esbuild plugin skips transforming files from `node_modules` for performance.

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -48,3 +48,5 @@ Use `loaderOptions` to pass options through to `@wyw-in-js/webpack-loader`.
 
 Use `turbopackLoaderOptions` to pass JSON-serializable options to `@wyw-in-js/turbopack-loader` (use `configFile` for
 function-based config).
+
+To disable vendor prefixing (Stylis prefixer), set `prefixer: false` in `loaderOptions` and/or `turbopackLoaderOptions`.

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -44,4 +44,14 @@ wyw({
 });
 ```
 
+## Disabling vendor prefixing
+
+Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:
+
+```js
+wyw({
+  prefixer: false,
+});
+```
+
 To get details about supported options by the plugin, please check [documentation](https://wyw-in-js.dev/bundlers/rollup).

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -42,6 +42,16 @@ wyw({
 });
 ```
 
+## Disabling vendor prefixing
+
+Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:
+
+```js
+wyw({
+  prefixer: false,
+});
+```
+
 ## `import.meta.env` during evaluation
 
 WyW-in-JS evaluates part of your code at build time to extract styles. The Vite plugin injects Vite's `import.meta.env` values

--- a/packages/vite/src/__tests__/prefixer.test.ts
+++ b/packages/vite/src/__tests__/prefixer.test.ts
@@ -1,0 +1,122 @@
+import path from 'path';
+
+const transformMock = jest.fn();
+
+const createLogger = () => {
+  const log = (() => undefined) as unknown as ((...args: unknown[]) => void) & {
+    extend: (...args: unknown[]) => unknown;
+  };
+
+  log.extend = () => log;
+  return log;
+};
+
+jest.mock('@wyw-in-js/shared', () => ({
+  __esModule: true,
+  logger: createLogger(),
+  syncResolve: jest.fn(),
+}));
+
+jest.mock('vite', () => ({
+  __esModule: true,
+  createFilter: () => () => true,
+  loadEnv: jest.fn(() => ({})),
+}));
+
+jest.mock('@wyw-in-js/transform', () => ({
+  __esModule: true,
+  createFileReporter: () => ({
+    emitter: { single: jest.fn() },
+    onDone: jest.fn(),
+  }),
+  getFileIdx: () => '1',
+  TransformCacheCollection: class TransformCacheCollection {},
+  transform: (...args: unknown[]) => transformMock(...args),
+}));
+
+const getCssFilename = (id: string) =>
+  path
+    .normalize(`${id.replace(/\.[jt]sx?$/, '')}.wyw-in-js.css`)
+    .replace(/\\/g, path.posix.sep);
+
+describe('vite prefixer option', () => {
+  beforeEach(() => {
+    transformMock.mockReset();
+    transformMock.mockResolvedValue({
+      code: 'export {}',
+      sourceMap: null,
+      cssText: undefined,
+      dependencies: [],
+    });
+  });
+
+  it('uses prefixer by default (forwards prefixer to transform)', async () => {
+    transformMock.mockImplementation(async (services: any) => {
+      expect(services.options.prefixer).toBeUndefined();
+      return {
+        code: 'export {}',
+        sourceMap: null,
+        cssText: '.foo{display:-webkit-box;display:flex;}',
+        dependencies: [],
+      };
+    });
+
+    const { default: wywInJS } = await import('../index');
+    const plugin = wywInJS();
+
+    const root = '/project';
+    const entryFile = '/project/src/main.js';
+    const cssFilename = getCssFilename(entryFile);
+
+    plugin.configResolved({
+      root,
+      mode: 'development',
+      command: 'build',
+      base: '/',
+    } as any);
+
+    const result = await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'export {}',
+      entryFile
+    );
+
+    expect(result?.code).toContain(cssFilename);
+    expect(plugin.load?.(cssFilename)).toContain('-webkit-');
+  });
+
+  it('disables prefixer when prefixer is false', async () => {
+    transformMock.mockImplementation(async (services: any) => {
+      expect(services.options.prefixer).toBe(false);
+      return {
+        code: 'export {}',
+        sourceMap: null,
+        cssText: '.foo{display:flex;}',
+        dependencies: [],
+      };
+    });
+
+    const { default: wywInJS } = await import('../index');
+    const plugin = wywInJS({ prefixer: false });
+
+    const root = '/project';
+    const entryFile = '/project/src/main.js';
+    const cssFilename = getCssFilename(entryFile);
+
+    plugin.configResolved({
+      root,
+      mode: 'development',
+      command: 'build',
+      base: '/',
+    } as any);
+
+    const result = await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'export {}',
+      entryFile
+    );
+
+    expect(result?.code).toContain(cssFilename);
+    expect(plugin.load?.(cssFilename)).not.toContain('-webkit-');
+  });
+});

--- a/packages/webpack-loader/README.md
+++ b/packages/webpack-loader/README.md
@@ -33,4 +33,22 @@ module.exports = {
 };
 ```
 
+## Disabling vendor prefixing
+
+Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:
+
+```js
+module.exports = {
+  test: /\.js$/,
+  use: [
+    {
+      loader: '@wyw-in-js/webpack-loader',
+      options: {
+        prefixer: false,
+      },
+    },
+  ],
+};
+```
+
 To get details about supported options by the plugin, please check [documentation](https://wyw-in-js.dev/bundlers/webpack).


### PR DESCRIPTION
Closes #77.

- Document `prefixer: false` across bundler adapters (Vite/Rollup/Webpack/Esbuild/Bun/Next.js)
- Add Vite regression test to assert `prefixer` is forwarded to `@wyw-in-js/transform`
- Add changeset for the documentation update

Commands:
- `bun run --filter @wyw-in-js/vite lint`
- `bun run --filter @wyw-in-js/vite test`
- `bun run --filter @wyw-in-js/vite build:types`
