### PR TITLE
feat(vite): add preserveCssPaths option

### DIFF
--- a/.changeset/vite-preserve-css-paths.md
+++ b/.changeset/vite-preserve-css-paths.md
@@ -1,0 +1,6 @@
+---
+"@wyw-in-js/vite": patch
+---
+
+Add `preserveCssPaths` option to keep directory structure for generated `*.wyw-in-js.css` assets when using Rollup `preserveModules`.
+

--- a/apps/website/pages/bundlers/vite.mdx
+++ b/apps/website/pages/bundlers/vite.mdx
@@ -44,6 +44,27 @@ export default defineConfig(() => ({
 }));
 ```
 
+### Preserving generated CSS paths
+
+When `build.rollupOptions.output.preserveModules` is enabled, older Rollup versions (used by Vite 3/4) flatten asset names
+and drop directories for WyW-generated `*.wyw-in-js.css` files.
+
+To preserve the original directory layout for WyW CSS assets, enable `preserveCssPaths`:
+
+```js
+export default defineConfig(() => ({
+  build: {
+    rollupOptions: {
+      output: {
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+      },
+    },
+  },
+  plugins: [wyw({ preserveCssPaths: true })],
+}));
+```
+
 ### `import.meta.env` during evaluation
 
 WyW-in-JS evaluates a subset of your code at build time to extract styles. When that code relies on Vite's `import.meta.env.*`,

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -52,6 +52,30 @@ wyw({
 });
 ```
 
+## Preserving generated CSS paths
+
+When `build.rollupOptions.output.preserveModules` is enabled, older Rollup versions (used by Vite 3/4) flatten asset names
+and drop directories for WyW-generated `*.wyw-in-js.css` files.
+
+To preserve the original directory layout for WyW CSS assets, enable `preserveCssPaths`:
+
+```js
+import { defineConfig } from 'vite';
+import wyw from '@wyw-in-js/vite';
+
+export default defineConfig({
+  plugins: [wyw({ preserveCssPaths: true })],
+  build: {
+    rollupOptions: {
+      output: {
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+      },
+    },
+  },
+});
+```
+
 ## `import.meta.env` during evaluation
 
 WyW-in-JS evaluates part of your code at build time to extract styles. The Vite plugin injects Vite's `import.meta.env` values

--- a/packages/vite/src/__tests__/preserve-css-paths.test.ts
+++ b/packages/vite/src/__tests__/preserve-css-paths.test.ts
@@ -1,0 +1,159 @@
+const createLogger = () => {
+  const log = (() => undefined) as unknown as ((...args: unknown[]) => void) & {
+    extend: (...args: unknown[]) => unknown;
+  };
+
+  log.extend = () => log;
+  return log;
+};
+
+jest.mock('@wyw-in-js/shared', () => ({
+  __esModule: true,
+  logger: createLogger(),
+  syncResolve: jest.fn(),
+}));
+
+jest.mock('vite', () => ({
+  __esModule: true,
+  createFilter: () => () => true,
+  loadEnv: jest.fn(() => ({})),
+}));
+
+jest.mock('@wyw-in-js/transform', () => ({
+  __esModule: true,
+  createFileReporter: () => ({
+    emitter: { single: jest.fn() },
+    onDone: jest.fn(),
+  }),
+  getFileIdx: () => '1',
+  TransformCacheCollection: class TransformCacheCollection {},
+  transform: jest.fn(),
+}));
+
+describe('vite preserveCssPaths', () => {
+  it('rewrites wyw css assets to preserve directories', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+      assetFileNames: 'assets/[name].[hash].[ext]',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      build: { rollupOptions: { output: outputOptions } },
+    } as any);
+
+    expect(typeof outputOptions.assetFileNames).toBe('function');
+
+    expect(
+      (outputOptions.assetFileNames as any)({
+        name: 'src/components/button.wyw-in-js.css',
+        type: 'asset',
+      })
+    ).toBe('assets/components/[name].[hash].[ext]');
+
+    expect(
+      (outputOptions.assetFileNames as any)({
+        name: '/project/src/components/button.wyw-in-js.css',
+        type: 'asset',
+      })
+    ).toBe('assets/components/[name].[hash].[ext]');
+
+    expect(
+      (outputOptions.assetFileNames as any)({
+        name: 'src/styles/app.css',
+        type: 'asset',
+      })
+    ).toBe('assets/[name].[hash].[ext]');
+  });
+
+  it('preserves hash-only assetFileNames templates', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+      assetFileNames: 'assets/[hash].css',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      build: { rollupOptions: { output: outputOptions } },
+    } as any);
+
+    expect(typeof outputOptions.assetFileNames).toBe('function');
+
+    expect(
+      (outputOptions.assetFileNames as any)({
+        name: 'src/components/button.wyw-in-js.css',
+        type: 'asset',
+      })
+    ).toBe('assets/components/[hash].css');
+
+    expect(
+      (outputOptions.assetFileNames as any)({
+        name: 'src/styles/app.css',
+        type: 'asset',
+      })
+    ).toBe('assets/[hash].css');
+  });
+
+  it('keeps fixed assetFileNames values intact', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+      assetFileNames: 'assets/fixed.css',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      build: { rollupOptions: { output: outputOptions } },
+    } as any);
+
+    expect(typeof outputOptions.assetFileNames).toBe('function');
+
+    expect(
+      (outputOptions.assetFileNames as any)({
+        name: 'src/components/button.wyw-in-js.css',
+        type: 'asset',
+      })
+    ).toBe('assets/fixed.css');
+  });
+
+  it('does not change output naming when preserveCssPaths is disabled', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+      assetFileNames: 'assets/[name].[hash].[ext]',
+    };
+
+    const plugin = wywInJS();
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      build: { rollupOptions: { output: outputOptions } },
+    } as any);
+
+    expect(outputOptions.assetFileNames).toBe('assets/[name].[hash].[ext]');
+  });
+});


### PR DESCRIPTION
## What
- Add `preserveCssPaths` (opt-in) to preserve directory structure for generated `*.wyw-in-js.css` assets when `build.rollupOptions.output.preserveModules` is enabled.
- Includes docs + unit tests + changeset.

## Why
Older Rollup versions (Vite 3/4) flatten asset names and drop directories for WyW CSS assets even when JS output preserves paths.

## Notes
- Default behavior is unchanged unless `preserveCssPaths: true` is set.
- Works with common templates like `assets/[name].[hash].[ext]` and `assets/[hash].css` (keeps hash-only naming, just inserts directories).

## Checks
- `bun run --filter @wyw-in-js/vite lint`
- `bun run --filter @wyw-in-js/vite test`
- `bun run --filter @wyw-in-js/vite build:types`

Fixes #117
