### PR TITLE
feat(transform): add tagResolver meta (#139)

### DIFF
--- a/.changeset/tagresolver-meta.md
+++ b/.changeset/tagresolver-meta.md
@@ -1,0 +1,6 @@
+---
+"@wyw-in-js/shared": patch
+"@wyw-in-js/transform": patch
+---
+
+Extend `tagResolver` with a third `meta` argument (`sourceFile`, `resolvedSource`) so custom tag processors can be resolved reliably.

--- a/apps/website/pages/configuration.mdx
+++ b/apps/website/pages/configuration.mdx
@@ -317,21 +317,32 @@ module.exports = {
   ];
   ```
 
-- `tagResolver: (source, tag) => string`
+- `tagResolver: (source, tag, meta) => string`
 
   A custom function to use when resolving template tags.
 
   By default, linaria APIs like `css` and `styled` **must** be imported directly from the package – this is because babel needs to be able to recognize the API's to do static style extraction. `tagResolver` allows `css` and `styled` APIs to be imported from other files too.
 
-  `tagResolver` takes the path for the source module (eg. `@linaria/core`) and the name of imported tag (eg. `css`), and returns the full path to the related processor. If `tagResolver` returns `null`, the default tag processor will be used.
+  `tagResolver` takes the source specifier from the import (eg. `@linaria/core` or `./my-local-folder/linaria`), the imported tag name (eg. `css`), and `meta`:
+
+  - `meta.sourceFile` — the importer file path
+  - `meta.resolvedSource` — best-effort resolved path for `source` (when available)
+
+  It returns the full path to the related processor. If `tagResolver` returns `null`, the default tag processor will be used.
 
   For example, we can use this to map `@linaria/core` , `@linaria/react` or `@linaria/atomic` where we re-export the module.
 
   ```js
   {
-    tagResolver: (source, tag) => {
+    tagResolver: (source, tag, { sourceFile, resolvedSource }) => {
+      const { createRequire } = require('module');
+      const { join } = require('path');
       const pathToLocalFile = join(__dirname, './my-local-folder/linaria.js');
-      if (source === pathToLocalFile) {
+      const resolved =
+        resolvedSource ??
+        (sourceFile ? createRequire(sourceFile).resolve(source) : null);
+
+      if (resolved === pathToLocalFile) {
         if (tag === 'css') {
           return require.resolve('@linaria/core/processors/css');
         }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,6 +19,7 @@ export type {
   ImportLoaders,
   ImportOverride,
   ImportOverrides,
+  TagResolverMeta,
   StrictOptions,
   EvalRule,
   Evaluator,

--- a/packages/shared/src/options/types.ts
+++ b/packages/shared/src/options/types.ts
@@ -111,6 +111,11 @@ export type ImportLoader =
 
 export type ImportLoaders = Record<string, ImportLoader | false>;
 
+export type TagResolverMeta = {
+  resolvedSource?: string;
+  sourceFile: string | null | undefined;
+};
+
 type AllFeatureFlags = {
   dangerousCodeRemover: FeatureFlag;
   globalCache: FeatureFlag;
@@ -146,7 +151,11 @@ export type StrictOptions = {
     filename: string
   ) => Partial<VmContext>;
   rules: EvalRule[];
-  tagResolver?: (source: string, tag: string) => string | null;
+  tagResolver?: (
+    source: string,
+    tag: string,
+    meta: TagResolverMeta
+  ) => string | null;
   variableNameConfig?: 'var' | 'dashes' | 'raw';
   variableNameSlug?: string | VariableNameFn;
 };

--- a/packages/transform/src/__tests__/__fixtures__/tag-resolver/linaria.js
+++ b/packages/transform/src/__tests__/__fixtures__/tag-resolver/linaria.js
@@ -1,0 +1,1 @@
+export * from '@linaria/core';

--- a/packages/transform/src/__tests__/tagResolver.meta.test.ts
+++ b/packages/transform/src/__tests__/tagResolver.meta.test.ts
@@ -1,0 +1,99 @@
+import path from 'path';
+
+import * as babel from '@babel/core';
+
+import type { StrictOptions } from '@wyw-in-js/shared';
+
+import { applyProcessors } from '../utils/getTagProcessor';
+
+const processorPath = path.resolve(
+  __dirname,
+  '__fixtures__',
+  'test-css-processor.js'
+);
+const linariaWrapperPath = path.resolve(
+  __dirname,
+  '__fixtures__',
+  'tag-resolver',
+  'linaria.js'
+);
+
+describe('tagResolver meta', () => {
+  it('passes sourceFile and resolvedSource for local wrapper imports', () => {
+    const code = `
+      import { css } from './__fixtures__/tag-resolver/linaria';
+
+      export const a = css\`
+        color: red;
+      \`;
+    `;
+
+    const fileContext = {
+      filename: path.join(__dirname, 'tag-resolver-source.js'),
+      root: __dirname,
+    };
+
+    let received: {
+      meta: { resolvedSource?: string; sourceFile: string | null | undefined };
+      source: string;
+      tag: string;
+    } | null = null;
+
+    const options: Pick<
+      StrictOptions,
+      | 'classNameSlug'
+      | 'displayName'
+      | 'extensions'
+      | 'evaluate'
+      | 'tagResolver'
+    > = {
+      displayName: false,
+      evaluate: true,
+      extensions: ['.js'],
+      tagResolver: (source, tag, meta) => {
+        received = { source, tag, meta };
+        return processorPath;
+      },
+    };
+
+    const cssText: string[] = [];
+
+    babel.transformSync(code, {
+      filename: fileContext.filename,
+      babelrc: false,
+      configFile: false,
+      sourceType: 'module',
+      plugins: [
+        () => ({
+          visitor: {
+            Program(programPath) {
+              applyProcessors(
+                programPath,
+                fileContext,
+                options,
+                (processor) => {
+                  processor.build(new Map());
+                  processor.artifacts.forEach((artifact) => {
+                    if (artifact[0] !== 'css') return;
+                    const [rules] = artifact[1];
+                    Object.values(rules).forEach((rule) => {
+                      cssText.push(rule.cssText);
+                    });
+                  });
+                }
+              );
+            },
+          },
+        }),
+      ],
+    });
+
+    expect(cssText.join('\n')).toContain('color: red');
+
+    expect(received).not.toBeNull();
+    expect(received?.source).toBe('./__fixtures__/tag-resolver/linaria');
+    expect(received?.tag).toBe('css');
+    expect(received?.meta.sourceFile).toBe(fileContext.filename);
+    expect(received?.meta.resolvedSource).toBe(linariaWrapperPath);
+  });
+});


### PR DESCRIPTION
## Summary
- Extend `tagResolver` to accept a third `meta` argument: `{ sourceFile, resolvedSource }`.
- Export `TagResolverMeta` from `@wyw-in-js/shared`.
- Update docs + add a regression test for local wrapper imports.

Closes #139

## Notes
- `meta.resolvedSource` is best-effort and may be `undefined` if resolution fails.
- Backward compatible: existing 2-arg resolvers still work.

## Checks
- `bun run --filter @wyw-in-js/shared lint`
- `bun run --filter @wyw-in-js/shared test`
- `bun run --filter @wyw-in-js/shared build:types`
- `bun run --filter @wyw-in-js/transform lint`
- `bun run --filter @wyw-in-js/transform test`
- `bun run --filter @wyw-in-js/transform build:types`
