### PR TITLE
docs: stability page + 1.0.0 baseline changeset (#118)

### DIFF
--- a/.changeset/release-1-0-0-baseline.md
+++ b/.changeset/release-1-0-0-baseline.md
@@ -1,0 +1,33 @@
+---
+"@wyw-in-js/babel-config": major
+"@wyw-in-js/babel-preset": major
+"@wyw-in-js/bun": major
+"@wyw-in-js/cli": major
+"@wyw-in-js/e2e-bun": major
+"@wyw-in-js/e2e-parcel": major
+"@wyw-in-js/e2e-vite": major
+"@wyw-in-js/esbuild": major
+"@wyw-in-js/eslint-config": major
+"@wyw-in-js/nextjs": major
+"@wyw-in-js/object-syntax": major
+"@wyw-in-js/parcel-transformer": major
+"@wyw-in-js/processor-utils": major
+"@wyw-in-js/rollup": major
+"@wyw-in-js/sample-processor": major
+"@wyw-in-js/shared": major
+"@wyw-in-js/template-tag-syntax": major
+"@wyw-in-js/transform": major
+"@wyw-in-js/ts-config": major
+"@wyw-in-js/turbopack-loader": major
+"@wyw-in-js/vite": major
+"@wyw-in-js/webpack-loader": major
+"@wyw-in-js/website": major
+"nextjs-wyw-demo": major
+"vite-react-refresh-repro": major
+"wyw-in-js": major
+---
+
+Release **1.0.0** introduces no breaking changes compared to previous releases.
+
+This release establishes a stable baseline for future development, including upcoming releases focused on performance
+and build-time optimizations.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This library evolved from the CSS-in-JS library [Linaria][1], with the aim of de
 ## Documentation
 
 - Website: https://wyw-in-js.dev/
+- Stability: https://wyw-in-js.dev/stability
 - Configuration: https://wyw-in-js.dev/configuration
 - How it works: https://wyw-in-js.dev/how-it-works
 - Bundlers: https://wyw-in-js.dev/bundlers

--- a/apps/website/pages/_meta.json
+++ b/apps/website/pages/_meta.json
@@ -1,5 +1,6 @@
 {
   "index": "Introduction",
+  "stability": "Stability",
   "how-it-works": "How it works?",
   "how-to": "How to use",
   "bundlers": "Supported bundlers",

--- a/apps/website/pages/stability.mdx
+++ b/apps/website/pages/stability.mdx
@@ -1,0 +1,50 @@
+# Stability & Production Readiness
+
+WyW-in-JS is used in production build pipelines and aims to provide a predictable upgrade path.
+
+## Versioning (SemVer)
+
+WyW-in-JS follows SemVer for the published `@wyw-in-js/*` packages.
+
+- `1.0.0` is a “stable baseline” release and introduces no breaking changes compared to the pre-`1.0.0` line.
+- `1.x` is the first “stable baseline” line. Breaking changes are introduced only in `2.0.0` and higher.
+- `minor` releases add features in a backwards-compatible way.
+- `patch` releases are for bugfixes and small improvements.
+
+The pre-`1.0.0` (`0.x`) line existed mostly because the project evolved rapidly, despite being used in real production
+setups.
+
+## Why “stable” is non-trivial here
+
+WyW-in-JS does a lot of work at **build time**, including static analysis and evaluating parts of JavaScript to compute
+styles and artifacts.
+
+This means it interacts with:
+
+- unbounded user code patterns,
+- dependencies with various build-time assumptions,
+- bundler-specific resolution behavior.
+
+Because of that, some edge cases are inevitably discovered only on specific codebases. We treat such cases as bugs and
+aim to keep regressions rare, but “perfect stability across all possible JS” is not realistic for a build-time evaluator.
+
+## Upgrading safely
+
+- Read the changelog before upgrading (especially when jumping across minor versions).
+- Validate the new version on a representative project (or a small repro extracted from it).
+- If you hit a regression, please file an issue with:
+  - the exact `@wyw-in-js/*` versions,
+  - bundler/framework + version,
+  - a minimal reproduction (or a small repository/zip), and
+  - error logs and stack traces (ideally with `DEBUG=wyw-in-js:*`).
+
+## Support
+
+- Community support happens via GitHub issues and discussions.
+- If wyw-in-js is critical to your production workflow, consider supporting the project via GitHub Sponsors:
+  https://github.com/sponsors/anber
+
+## Roadmap (high level)
+
+- `2.0.0` will include breaking changes (for example: moving to an ESM-only architecture and requiring newer Node.js).
+- `3.0.0` is focused on performance/scalability work (moving parts of the pipeline to Rust/oxc).


### PR DESCRIPTION
Refs #118

- Add `/stability` page describing SemVer expectations, build-time evaluation caveats, and upgrade guidance.
- Link the stability page from the website nav and README.
- Add a major changeset to bump the workspace to `1.0.0` as a stable baseline (no breaking changes intended).

Checks:
- `bun run build`
- `bun run lint`
- `bun run test`