### PR TITLE
chore(changesets): reduce dependency noise in release notes

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,0 +1,31 @@
+async function getReleaseLine(changeset) {
+  const [firstLine, ...futureLines] = changeset.summary
+    .split('\n')
+    .map((line) => line.trimRight());
+
+  let releaseLine = `- ${changeset.commit ? `${changeset.commit.slice(0, 7)}: ` : ''}${firstLine}`;
+
+  if (futureLines.length > 0) {
+    releaseLine += `\n${futureLines.map((line) => `  ${line}`).join('\n')}`;
+  }
+
+  return releaseLine;
+}
+
+async function getDependencyReleaseLine(_changesets, dependenciesUpdated) {
+  if (dependenciesUpdated.length === 0) {
+    return '';
+  }
+
+  const updatedDependenciesList = dependenciesUpdated
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((dependency) => `  - ${dependency.name}@${dependency.newVersion}`);
+
+  return ['- Updated dependencies', ...updatedDependenciesList].join('\n');
+}
+
+module.exports = {
+  getReleaseLine,
+  getDependencyReleaseLine,
+};

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "./changelog.cjs",
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
This switches Changesets to a small custom changelog generator to avoid repeating dozens of `Updated dependencies [hash]` lines.

Effect:
- Keeps the per-changeset bullet formatting (commit hash + first line).
- Collapses dependency updates into a single `Updated dependencies` entry with a stable, sorted list.

This should make the changesets release PR (e.g. #166) and package CHANGELOGs significantly shorter without changing the release plan.