### PR TITLE
fix(vite): handle /@fs alias resolution (#217)

### DIFF
--- a/.changeset/fix-vite-fs-alias.md
+++ b/.changeset/fix-vite-fs-alias.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/vite": patch
+---
+
+Handle Vite `/@fs/` resolved ids so alias imports resolve during eval instead of falling back to Node.

--- a/e2e/vite/fixture.css
+++ b/e2e/vite/fixture.css
@@ -1,3 +1,6 @@
+.cqwr8qb {
+  color: blue;
+}
 .c2tf5um {
   color: red;
   background: green;

--- a/e2e/vite/fixture.keep-comments.css
+++ b/e2e/vite/fixture.keep-comments.css
@@ -1,3 +1,6 @@
+.cqwr8qb {
+  color: blue;
+}
 .c2tf5um {
   /*rtl:ignore*/
   color: red;

--- a/e2e/vite/scripts/test.cjs
+++ b/e2e/vite/scripts/test.cjs
@@ -25,6 +25,11 @@ async function buildArtefact(outDir, pluginOptions) {
       cssMinify: false,
     },
     configFile: false,
+    resolve: {
+      alias: {
+        '@': path.resolve(PKG_DIR, 'src'),
+      },
+    },
     plugins: [pluginOptions ? wyw.default(pluginOptions) : wyw.default()],
   });
 }

--- a/e2e/vite/src/alias.ts
+++ b/e2e/vite/src/alias.ts
@@ -1,0 +1,7 @@
+import { css } from '@wyw-in-js/template-tag-syntax';
+
+const classB = css`
+  color: blue;
+`;
+
+export { classB };

--- a/e2e/vite/src/index.ts
+++ b/e2e/vite/src/index.ts
@@ -1,4 +1,5 @@
 import { css } from '@wyw-in-js/template-tag-syntax';
+import { classB } from '@/alias';
 
 const classA = css`
   /*rtl:ignore*/
@@ -6,4 +7,4 @@ const classA = css`
   background: green;
 `;
 
-export { classA };
+export { classA, classB };

--- a/e2e/vite/tsconfig.json
+++ b/e2e/vite/tsconfig.json
@@ -4,7 +4,10 @@
   "compilerOptions": {
     "allowJs": true,
     "rootDir": "../..",
-    "baseUrl": "../.."
+    "baseUrl": "../..",
+    "paths": {
+      "@/*": ["./e2e/vite/src/*"]
+    }
   },
   "include": ["./src/*", "./scripts/*"],
   "ts-node": {


### PR DESCRIPTION
## Summary
- normalize Vite /@fs resolved ids before virtual-id filtering
- add unit coverage for /@fs
- add Vite e2e alias fixture
- add changeset

## Regression
Regression from #163 (commit 691f946): the `/@` virtual-id guard also filtered `/@fs/...` ids, so alias imports fell back to the Node resolver and failed on `@/...`.

## Tests
- bun test src (packages/vite)
- bun run build:types (packages/vite)
- node -r ts-node/register ./scripts/test.cjs (e2e/vite)
