### PR TITLE
fix(vite): avoid Node fallback for external file ids

### DIFF
--- a/.changeset/fix-vite-external-resolve.md
+++ b/.changeset/fix-vite-external-resolve.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/vite': patch
+---
+
+Avoid falling back to Node resolution for Vite `external` resolved file ids (incl. `external: "absolute"`), which could break aliased imports during build-time evaluation (SSR/dev).


### PR DESCRIPTION
Fixes #217.

Vite can mark resolved file ids as `external` (including `external: "absolute"`) in SSR/dev flows. Previously, WyW would always fall back to the Node resolver for any `external` result, which breaks aliased file imports (Node can't resolve `@/...`).

This change prefers Vite's resolved file path when it points to a real file and only falls back to Node resolution for bare specifiers.

Tests:
- bun run --filter @wyw-in-js/vite lint
- bun run --filter @wyw-in-js/vite test
- bun run --filter @wyw-in-js/e2e-vite test
