### PR TITLE
fix(transform): handle anonymous default exports in shaker

### DIFF
--- a/.changeset/fix-shaker-anon-default-export.md
+++ b/.changeset/fix-shaker-anon-default-export.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Fix shaker crash when removing anonymous default exports like `export default function() {}`.

--- a/packages/transform/src/__tests__/shaker.test.ts
+++ b/packages/transform/src/__tests__/shaker.test.ts
@@ -136,6 +136,19 @@ describe('shaker', () => {
     expect(code).not.toContain('react/jsx-runtime');
   });
 
+  it('should not crash when dropping an anonymous default export', () => {
+    const code = run(['foo'])`
+      export const foo = 1;
+
+      export default function(nodes) {
+        return nodes;
+      }
+    `;
+
+    expect(code).toContain('foo');
+    expect(code).not.toContain('export default');
+  });
+
   it('should exclude imports metadata when the const export becomes dead (tsx)', () => {
     const [, , imports] = compile(['__wywPreval'])`
       import * as RAC from 'react-aria-components';

--- a/packages/transform/src/plugins/shaker.ts
+++ b/packages/transform/src/plugins/shaker.ts
@@ -83,7 +83,12 @@ function getBindingForExport(exportPath: NodePath): Binding | undefined {
   }
 
   if (exportPath.isFunctionDeclaration() || exportPath.isClassDeclaration()) {
-    return getNonParamBinding(exportPath, exportPath.node.id!.name);
+    const { id } = exportPath.node;
+    if (!id) {
+      // `export default function() {}` / `export default class {}` (anonymous)
+      return undefined;
+    }
+    return getNonParamBinding(exportPath, id.name);
   }
 
   return undefined;


### PR DESCRIPTION
Fixes #222.

The shaker could crash when trying to resolve a binding for an anonymous default export declaration like:

```js
export default function(nodes) {}
```

`ExportDefaultDeclaration` stores the `declaration` path, which can be a `FunctionDeclaration`/`ClassDeclaration` without an `id`. This change makes `getBindingForExport()` handle that case and adds a regression test.

Tests:
- bun run --filter @wyw-in-js/transform lint
- bun run --filter @wyw-in-js/transform test
