### PR TITLE
fix(esbuild): handle empty cssText results

### DIFF
--- a/.changeset/fix-esbuild-empty-csstext.md
+++ b/.changeset/fix-esbuild-empty-csstext.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/esbuild': patch
+---
+
+Fix handling of empty `cssText` results: return the transformed JS even when WyW extracts no CSS from a module.

--- a/packages/esbuild/src/__tests__/empty-csstext.test.ts
+++ b/packages/esbuild/src/__tests__/empty-csstext.test.ts
@@ -1,0 +1,94 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import * as esbuild from 'esbuild';
+
+import wywInJS from '../index';
+
+const getJsText = (result: esbuild.BuildResult): string | null => {
+  const js = result.outputFiles?.find((file) => file.path.endsWith('.js'));
+  return js?.text ?? null;
+};
+
+const hasCssOutput = (result: esbuild.BuildResult): boolean =>
+  Boolean(result.outputFiles?.some((file) => file.path.endsWith('.css')));
+
+it('returns transformed JS even when cssText is empty', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-esbuild-220-'));
+  const outdir = path.join(root, 'dist');
+
+  const entryFile = path.join(root, 'main.ts');
+
+  const nmRoot = path.join(root, 'node_modules');
+  const processorStubDir = path.join(nmRoot, 'test-css-processor');
+
+  fs.mkdirSync(processorStubDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(processorStubDir, 'package.json'),
+    JSON.stringify({
+      name: 'test-css-processor',
+      version: '1.0.0',
+      type: 'module',
+    }),
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(processorStubDir, 'index.js'),
+    `export const css = (strings) => strings.join('');\n`,
+    'utf8'
+  );
+
+  fs.writeFileSync(
+    entryFile,
+    [
+      `import { css } from 'test-css-processor';`,
+      ``,
+      `const className = css\`color: red;\`;`,
+      ``,
+      `// intentionally unused`,
+      ``,
+    ].join('\n'),
+    'utf8'
+  );
+
+  const processorFile = path.resolve(
+    __dirname,
+    '../../../transform/src/__tests__/__fixtures__/test-css-processor.js'
+  );
+
+  const cwd = process.cwd();
+  process.chdir(root);
+
+  try {
+    const result = await esbuild.build({
+      entryPoints: [entryFile],
+      bundle: true,
+      format: 'esm',
+      write: false,
+      outdir,
+      plugins: [
+        wywInJS({
+          configFile: false,
+          tagResolver: (source: string, tag: string) => {
+            if (source === 'test-css-processor' && tag === 'css') {
+              return processorFile;
+            }
+
+            return null;
+          },
+        }),
+      ],
+    });
+
+    expect(hasCssOutput(result)).toBe(false);
+
+    const jsText = getJsText(result);
+    expect(jsText).not.toBeNull();
+    expect(jsText).not.toContain('test-css-processor');
+    expect(jsText).not.toContain('css`');
+  } finally {
+    process.chdir(cwd);
+  }
+});

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -265,9 +265,26 @@ export default function wywInJS({
         const result = await transform(transformServices, code, asyncResolve);
         const resolveDir = dirname(args.path);
 
-        if (!result.cssText) {
+        if (typeof result.cssText === 'undefined') {
           return {
             contents: code,
+            loader,
+            resolveDir,
+          };
+        }
+
+        if (result.cssText === '') {
+          let contents = result.code;
+
+          if (sourceMap && result.sourceMap) {
+            const wywMap = Buffer.from(
+              JSON.stringify(result.sourceMap)
+            ).toString('base64');
+            contents += `/*# sourceMappingURL=data:application/json;base64,${wywMap}*/`;
+          }
+
+          return {
+            contents,
             loader,
             resolveDir,
           };


### PR DESCRIPTION
Fixes #220.

`@wyw-in-js/esbuild` treated `cssText === ''` as “not transformed” due to a truthy check and returned the pre-WyW code. That breaks the common case where the file is transformed but the extracted CSS is empty (e.g. unused `css\`...\``), leaving runtime tag calls in the bundle.

This change:
- distinguishes `cssText === undefined` (not transformed) from `cssText === ''` (transformed, but no CSS),
- returns `result.code` for the empty-css case,
- adds a regression test.

Tests:
- bun run --filter @wyw-in-js/esbuild lint
- bun run --filter @wyw-in-js/esbuild test
