### PR TITLE
fix(transform): add hint for browser-only eval crashes

### DIFF
--- a/.changeset/fix-eval-browseronly-hint.md
+++ b/.changeset/fix-eval-browseronly-hint.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Improve eval error diagnostics: when build-time evaluation fails due to browser-only globals (e.g. `window`), include a hint about using `importOverrides` / moving runtime-only code out of evaluated modules.

--- a/apps/website/pages/configuration.mdx
+++ b/apps/website/pages/configuration.mdx
@@ -231,6 +231,7 @@ module.exports = {
   Notes:
 
   - When WyW evaluates `__wywPreval`, it tree-shakes the module and removes `import '...';` side-effect imports by default, to avoid executing unrelated runtime code in Node.js (some libraries touch `document`, `window`, etc).
+  - If your evaluated modules import browser-only packages (e.g. `msw/browser`), evaluation can still fail in Node.js. In that case, move the browser-only initialization out of evaluated modules, or mock the import via `importOverrides`.
   - If you need a side-effect import to run during evaluation, or you need to stub a problematic side-effect import, add an override for that import:
     - `{ noShake: true }` keeps the import and disables tree-shaking for that dependency.
     - `{ mock: './path/to/mock' }` keeps the import but redirects it to a mock module.


### PR DESCRIPTION
Fixes #221.

When build-time evaluation crashes due to browser-only globals (e.g. `window`, `document`, `navigator`), the error message is confusing and the mitigation (mocking via `importOverrides` / moving runtime-only init out of evaluated modules) is easy to miss.

This change appends a multi-line hint to the wrapped EvalError in that class of failures and adds a regression test. It also expands the `importOverrides` docs note to explicitly mention browser-only packages like `msw/browser`.

Tests:
- bun run --filter @wyw-in-js/transform lint
- bun run --filter @wyw-in-js/transform test
