### PR TITLE
fix(vite): isolate transform cache per context (#234)

### DIFF
--- a/.changeset/vite-split-cache-per-context.md
+++ b/.changeset/vite-split-cache-per-context.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/vite': patch
+---
+
+Fix a Vite dev error ("action handler is already set") by isolating WyW transform cache per plugin context.


### PR DESCRIPTION
Fixes a Vite dev crash: `Internal server error: action handler is already set`.

Root cause:
- A single WyW `TransformCacheCollection` was shared across different Vite plugin contexts (client/SSR environments), so cached actions could be resumed with a different handler instance.

Changes:
- Keep a separate `TransformCacheCollection` per Vite plugin context (`this`).
- Invalidate dependencies across all created caches during HMR.
- Add a regression test for per-context cache isolation.
- Add a changeset (patch) for `@wyw-in-js/vite`.

Validation:
- bun run --filter @wyw-in-js/vite lint
- bun run --filter @wyw-in-js/vite test
- bun run --filter @wyw-in-js/vite build:types
