### PR TITLE
fix(turbopack-loader): avoid :global in keyframes

### DIFF
--- a/.changeset/turbopack-keyframes-global.md
+++ b/.changeset/turbopack-keyframes-global.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/turbopack-loader': patch
+---
+
+Avoid injecting `:global()` into `@keyframes` preludes when globalizing CSS Modules output so LightningCSS can parse the result.

--- a/packages/turbopack-loader/src/__tests__/css-modules.test.ts
+++ b/packages/turbopack-loader/src/__tests__/css-modules.test.ts
@@ -19,9 +19,17 @@ describe('makeCssModuleGlobal', () => {
     );
   });
 
-  it('marks keyframes names as global', () => {
+  it('keeps keyframes names untouched', () => {
     expect(makeCssModuleGlobal('@keyframes spin{from{a:0}to{a:1}}')).toBe(
-      '@keyframes :global(spin){from{a:0}to{a:1}}'
+      '@keyframes spin{from{a:0}to{a:1}}'
     );
+  });
+
+  it('keeps keyframes names untouched when used in animation', () => {
+    expect(
+      makeCssModuleGlobal(
+        '.a{animation: spin 1s;}@keyframes spin{from{a:0}to{a:1}}'
+      )
+    ).toBe(':global(.a){animation: spin 1s;}@keyframes spin{from{a:0}to{a:1}}');
   });
 });

--- a/packages/turbopack-loader/src/css-modules.ts
+++ b/packages/turbopack-loader/src/css-modules.ts
@@ -146,23 +146,6 @@ function wrapSelector(selectorText: string) {
   return selectors.map((selector) => `:global(${selector})`).join(', ');
 }
 
-function wrapKeyframesHeader(prelude: string) {
-  let idx = 0;
-  while (idx < prelude.length && isWhitespace(prelude[idx])) idx += 1;
-
-  if (prelude.slice(idx).startsWith(':global(')) {
-    return prelude;
-  }
-
-  const match = /^[A-Za-z_-][A-Za-z0-9_-]*/.exec(prelude.slice(idx));
-  if (!match) return prelude;
-
-  const name = match[0];
-  const before = prelude.slice(0, idx);
-  const after = prelude.slice(idx + name.length);
-  return `${before}:global(${name})${after}`;
-}
-
 function makeCssModuleGlobalInner(css: string) {
   let idx = 0;
   let out = '';
@@ -208,7 +191,7 @@ function makeCssModuleGlobalInner(css: string) {
         const blockBody = css.slice(terminatorIdx + 1, blockEndIdx);
 
         if (isKeyframesAtRule(atRuleName)) {
-          out += `@${atRuleName}${wrapKeyframesHeader(prelude)}{${blockBody}}`;
+          out += `@${atRuleName}${prelude}{${blockBody}}`;
         } else if (nestingAtRules.has(atRuleName.toLowerCase())) {
           out += `@${atRuleName}${prelude}{${makeCssModuleGlobalInner(
             blockBody


### PR DESCRIPTION
## Summary
- stop injecting :global(...) into @keyframes preludes for CSS Modules output
- update turbopack-loader keyframes unit coverage
- add changeset for @wyw-in-js/turbopack-loader patch

Fixes #236

## Testing
- bun run check (fails: e2e/parcel CSS output mismatch: class hash differs in worktree path)
- SSL_CERT_FILE=/etc/ssl/cert.pem bun run build
