### PR TITLE
fix(transform): handle package-name extraction for pnpm paths (#241)

### DIFF
--- a/.changeset/pnpm-store-package-name.md
+++ b/.changeset/pnpm-store-package-name.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Fix Babel plugin/preset merging when keys are absolute paths from pnpm store (`node_modules/.pnpm/...`) so different packages don't get treated as duplicates.

--- a/packages/transform/src/options/buildOptions.test.ts
+++ b/packages/transform/src/options/buildOptions.test.ts
@@ -31,4 +31,104 @@ describe('buildOptions', () => {
       presets: ['preset-a', 'preset-b'],
     });
   });
+
+  it('does not treat pnpm store paths as a single ".pnpm" package', async () => {
+    const { buildOptions } = await import('./buildOptions');
+
+    const typescriptPath =
+      '/project/node_modules/.pnpm/@babel+plugin-transform-typescript@7.25.9/node_modules/@babel/plugin-transform-typescript/lib/index.js';
+    const reactJsxPath =
+      '/project/node_modules/.pnpm/@babel+plugin-transform-react-jsx@7.25.9/node_modules/@babel/plugin-transform-react-jsx/lib/index.js';
+
+    const merged = buildOptions(
+      {
+        plugins: [[typescriptPath, { foo: true }]],
+      },
+      {
+        plugins: [[reactJsxPath, { bar: true }]],
+      }
+    );
+
+    expect(merged.plugins).toEqual([
+      [typescriptPath, { foo: true }],
+      [reactJsxPath, { bar: true }],
+    ]);
+  });
+
+  it('still recognizes pnpm store paths as Babel plugin keys (Windows path)', async () => {
+    const { buildOptions } = await import('./buildOptions');
+
+    const typescriptWindowsPath =
+      'C:\\project\\node_modules\\.pnpm\\@babel+plugin-transform-typescript@7.25.9\\node_modules\\@babel\\plugin-transform-typescript\\lib\\index.js';
+
+    const merged = buildOptions(
+      {
+        plugins: [['@babel/plugin-transform-typescript', { foo: true }]],
+      },
+      {
+        plugins: [[typescriptWindowsPath, { bar: true }]],
+      }
+    );
+
+    expect(merged.plugins).toEqual([
+      ['@babel/plugin-transform-typescript', { foo: true, bar: true }],
+    ]);
+  });
+
+  it('extracts real package names from pnpm store paths', async () => {
+    const { buildOptions } = await import('./buildOptions');
+
+    const typescriptPath =
+      '/project/node_modules/.pnpm/@babel+plugin-transform-typescript@7.25.9/node_modules/@babel/plugin-transform-typescript/lib/index.js';
+
+    const merged = buildOptions(
+      {
+        plugins: [['@babel/plugin-transform-typescript', { foo: true }]],
+      },
+      {
+        plugins: [[typescriptPath, { bar: true }]],
+      }
+    );
+
+    expect(merged.plugins).toEqual([
+      ['@babel/plugin-transform-typescript', { foo: true, bar: true }],
+    ]);
+  });
+
+  it('extracts package names from node_modules paths', async () => {
+    const { buildOptions } = await import('./buildOptions');
+
+    const pluginPath = '/project/node_modules/my-plugin/lib/index.js';
+
+    const merged = buildOptions(
+      {
+        plugins: [['my-plugin', { foo: true }]],
+      },
+      {
+        plugins: [[pluginPath, { bar: true }]],
+      }
+    );
+
+    expect(merged.plugins).toEqual([['my-plugin', { foo: true, bar: true }]]);
+  });
+
+  it('extracts the innermost package name from nested node_modules paths', async () => {
+    const { buildOptions } = await import('./buildOptions');
+
+    const pluginPath =
+      '/project/node_modules/wrapper/node_modules/inner-plugin/lib/index.js';
+
+    const merged = buildOptions(
+      {
+        plugins: [['inner-plugin', { foo: true }]],
+      },
+      {
+        plugins: [[pluginPath, { bar: true }]],
+      }
+    );
+
+    expect(merged.plugins).toEqual([
+      ['inner-plugin', { foo: true, bar: true }],
+    ]);
+  });
 });


### PR DESCRIPTION
Fixes #241.

Babel plugins/presets can be passed as absolute paths (e.g. via require.resolve). Under pnpm these paths include nested `node_modules` segments (`node_modules/.pnpm/.../node_modules/<pkg>/...`), and we previously extracted the wrong package name (`.pnpm`), causing unrelated plugins to be treated as duplicates.

This change extracts the innermost package name from `.../node_modules/<pkg>/...` paths (incl. scoped packages + nested `node_modules`), and ignores dot-directories.

Tests:
- bun run --filter @wyw-in-js/transform lint
- bun run --filter @wyw-in-js/transform test
- bun run --filter @wyw-in-js/transform build:types