### PR TITLE
fix(transform): strip react-refresh helpers in eval (#247)

### DIFF
--- a/.changeset/calm-shirts-argue.md
+++ b/.changeset/calm-shirts-argue.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/transform": patch
+---
+
+Strip Vite React Refresh helpers (`$RefreshReg$`/`$RefreshSig$`) when they are injected as local functions by `@vitejs/plugin-react@5.1.x`, preventing unintended code execution during eval.

--- a/packages/transform/src/__tests__/preeval.test.ts
+++ b/packages/transform/src/__tests__/preeval.test.ts
@@ -91,6 +91,37 @@ describe('preeval', () => {
     expect(code).toMatchSnapshot();
   });
 
+  it('should remove local vite react-refresh helpers ($RefreshReg$/$RefreshSig$)', () => {
+    const { code } = run`
+      var _s = $RefreshSig$();
+
+      function Component() {
+        _s();
+        return null;
+      }
+
+      _s(Component, "Y89bt/pi8lrdHE1hdS9fijgV/R0=");
+      _c = Component;
+      var _c;
+      $RefreshReg$(_c, "Component");
+
+      function $RefreshReg$(type, id) {
+        return type;
+      }
+
+      function $RefreshSig$() {
+        return () => () => {};
+      }
+    `;
+
+    expect(code).not.toContain('$RefreshReg$');
+    expect(code).not.toContain('$RefreshSig$');
+    expect(code).not.toContain('_s(');
+    expect(() => {
+      runInNewContext(code);
+    }).not.toThrow();
+  });
+
   it('should not remove "location" in types only because it looks like a global variable', () => {
     const { code } = run`
       interface IProps {

--- a/packages/transform/src/utils/removeDangerousCode.ts
+++ b/packages/transform/src/utils/removeDangerousCode.ts
@@ -39,6 +39,7 @@ const ssrCheckFields = new Set([
 const forbiddenGlobals = new Set([
   ...ssrCheckFields,
   '$RefreshReg$',
+  '$RefreshSig$',
   'XMLHttpRequest',
   'clearImmediate',
   'clearInterval',
@@ -50,8 +51,15 @@ const forbiddenGlobals = new Set([
   'setTimeout',
 ]);
 
+const alwaysForbiddenIdentifiers = new Set(['$RefreshReg$', '$RefreshSig$']);
+
 const isBrowserGlobal = (id: NodePath<Identifier>) => {
-  return forbiddenGlobals.has(id.node.name) && isGlobal(id);
+  const { name } = id.node;
+  if (alwaysForbiddenIdentifiers.has(name)) {
+    return nonType(id);
+  }
+
+  return forbiddenGlobals.has(name) && isGlobal(id);
 };
 
 const isSSRCheckField = (id: NodePath<Identifier>) => {


### PR DESCRIPTION
Fixes #247.

Vite @vitejs/plugin-react 5.1.x may inject local `$RefreshReg$`/`$RefreshSig$` helpers. During WyW eval we should not execute/react to these refresh-only hooks, otherwise runtime-only code can leak into eval and trigger dev-time crashes.

Changes:
- Treat `$RefreshReg$` and `$RefreshSig$` as always-forbidden identifiers in removeDangerousCode, even when locally declared.
- Add a unit test covering local React Refresh helpers being stripped.
- Add a patch changeset for @wyw-in-js/transform.

Commands:
- bun run --filter @wyw-in-js/transform lint
- bun run --filter @wyw-in-js/transform test
- bun run --filter @wyw-in-js/transform build:types