### PR TITLE
fix(transform): handle deleted/renamed dependency files in cache invalidation

### DIFF
--- a/.changeset/fair-pens-clean.md
+++ b/.changeset/fair-pens-clean.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Handle deleted or renamed dependency files during cache invalidation without swallowing unrelated filesystem errors.

--- a/packages/transform/src/__tests__/cache.test.ts
+++ b/packages/transform/src/__tests__/cache.test.ts
@@ -353,6 +353,277 @@ describe('TransformCacheCollection', () => {
       expect(mockedReadFileSync).toHaveBeenCalledWith(leafName, 'utf8');
     });
 
+    it('should not crash when a dependency file has been deleted', () => {
+      const depName = 'deleted-dep.js';
+      const depContent = 'export const x = 1;';
+      const parentName = 'parent.js';
+      const parentContent = 'import { x } from "./deleted-dep.js";';
+
+      const { entrypoint: depEntrypoint } = setupCacheWithEntrypoint(
+        depName,
+        depContent
+      );
+
+      const parentDeps = new Map<
+        string,
+        Pick<IEntrypointDependency, 'resolved'>
+      >([['./deleted-dep.js', { resolved: depName }]]);
+      const { cache } = setupCacheWithEntrypoint(
+        parentName,
+        parentContent,
+        parentDeps
+      );
+
+      cache.add('entrypoints', depName, depEntrypoint as any);
+      cache.invalidateIfChanged(depName, depContent, undefined, 'fs');
+
+      const enoent = new Error(
+        "ENOENT: no such file or directory, open 'deleted-dep.js'"
+      ) as NodeJS.ErrnoException;
+      enoent.code = 'ENOENT';
+
+      mockedReadFileSync.mockImplementation((path) => {
+        if (path === depName) {
+          throw enoent;
+        }
+        throw new Error(`Unexpected readFileSync call: ${path}`);
+      });
+
+      expect(() =>
+        cache.invalidateIfChanged(parentName, parentContent)
+      ).not.toThrow();
+      expect(cache.has('entrypoints', depName)).toBe(false);
+      expect(cache.has('entrypoints', parentName)).toBe(false);
+    });
+
+    it('should invalidate deleted dependency cache entries for all cache types', () => {
+      const depName = 'deleted-dep.js';
+      const depContent = 'export const x = 1;';
+      const parentName = 'parent.js';
+      const parentContent = 'import { x } from "./deleted-dep.js";';
+
+      const { entrypoint: depEntrypoint } = setupCacheWithEntrypoint(
+        depName,
+        depContent
+      );
+
+      const parentDeps = new Map<
+        string,
+        Pick<IEntrypointDependency, 'resolved'>
+      >([['./deleted-dep.js', { resolved: depName }]]);
+      const { cache } = setupCacheWithEntrypoint(
+        parentName,
+        parentContent,
+        parentDeps
+      );
+
+      cache.add('entrypoints', depName, depEntrypoint as any);
+      cache.add('exports', depName, ['x']);
+      cache.invalidateIfChanged(depName, depContent, undefined, 'fs');
+
+      mockedReadFileSync.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+
+      cache.invalidateIfChanged(parentName, parentContent);
+
+      expect(cache.has('entrypoints', depName)).toBe(false);
+      expect(cache.has('exports', depName)).toBe(false);
+    });
+
+    it('should continue processing other dependencies when one is deleted', () => {
+      const deletedDep = 'deleted.js';
+      const deletedContent = 'export const a = 1;';
+      const aliveDep = 'alive.js';
+      const aliveContent = 'export const b = 2;';
+      const newAliveContent = 'export const b = 3;';
+      const parentName = 'parent.js';
+      const parentContent =
+        'import { a } from "./deleted"; import { b } from "./alive";';
+
+      const { entrypoint: deletedEntrypoint } = setupCacheWithEntrypoint(
+        deletedDep,
+        deletedContent
+      );
+      const { entrypoint: aliveEntrypoint } = setupCacheWithEntrypoint(
+        aliveDep,
+        aliveContent
+      );
+
+      const parentDeps = new Map<
+        string,
+        Pick<IEntrypointDependency, 'resolved'>
+      >([
+        ['./deleted', { resolved: deletedDep }],
+        ['./alive', { resolved: aliveDep }],
+      ]);
+      const { cache } = setupCacheWithEntrypoint(
+        parentName,
+        parentContent,
+        parentDeps
+      );
+
+      cache.add('entrypoints', deletedDep, deletedEntrypoint as any);
+      cache.add('entrypoints', aliveDep, aliveEntrypoint as any);
+      cache.invalidateIfChanged(deletedDep, deletedContent, undefined, 'fs');
+      cache.invalidateIfChanged(aliveDep, aliveContent, undefined, 'fs');
+
+      mockedReadFileSync.mockImplementation((path) => {
+        if (path === deletedDep) {
+          throw new Error('ENOENT');
+        }
+        if (path === aliveDep) {
+          return newAliveContent;
+        }
+        throw new Error(`Unexpected readFileSync call: ${path}`);
+      });
+
+      cache.invalidateIfChanged(parentName, parentContent);
+
+      expect(cache.has('entrypoints', deletedDep)).toBe(false);
+      expect(cache.has('entrypoints', aliveDep)).toBe(false);
+      expect(cache.has('entrypoints', parentName)).toBe(false);
+    });
+
+    it('should handle all dependencies being deleted', () => {
+      const dep1 = 'dep1.js';
+      const dep1Content = 'export const a = 1;';
+      const dep2 = 'dep2.js';
+      const dep2Content = 'export const b = 2;';
+      const parentName = 'parent.js';
+      const parentContent =
+        'import { a } from "./dep1"; import { b } from "./dep2";';
+
+      const { entrypoint: dep1Entrypoint } = setupCacheWithEntrypoint(
+        dep1,
+        dep1Content
+      );
+      const { entrypoint: dep2Entrypoint } = setupCacheWithEntrypoint(
+        dep2,
+        dep2Content
+      );
+
+      const parentDeps = new Map<
+        string,
+        Pick<IEntrypointDependency, 'resolved'>
+      >([
+        ['./dep1', { resolved: dep1 }],
+        ['./dep2', { resolved: dep2 }],
+      ]);
+      const { cache } = setupCacheWithEntrypoint(
+        parentName,
+        parentContent,
+        parentDeps
+      );
+
+      cache.add('entrypoints', dep1, dep1Entrypoint as any);
+      cache.add('entrypoints', dep2, dep2Entrypoint as any);
+
+      mockedReadFileSync.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+
+      expect(() =>
+        cache.invalidateIfChanged(parentName, parentContent)
+      ).not.toThrow();
+      expect(cache.has('entrypoints', dep1)).toBe(false);
+      expect(cache.has('entrypoints', dep2)).toBe(false);
+      expect(cache.has('entrypoints', parentName)).toBe(false);
+    });
+
+    it('should handle deleted dependency in recursive chain', () => {
+      const leafName = 'leaf.js';
+      const leafContent = 'export const c = 3;';
+      const intermediateName = 'intermediate.js';
+      const intermediateContent =
+        'import { c } from "./leaf.js"; export const b = c;';
+      const rootName = 'root.js';
+      const rootContent = 'import { b } from "./intermediate.js";';
+
+      const { entrypoint: leafEntrypoint } = setupCacheWithEntrypoint(
+        leafName,
+        leafContent
+      );
+
+      const intermediateDeps = new Map<
+        string,
+        Pick<IEntrypointDependency, 'resolved'>
+      >([['./leaf.js', { resolved: leafName }]]);
+      const { entrypoint: intermediateEntrypoint } = setupCacheWithEntrypoint(
+        intermediateName,
+        intermediateContent,
+        intermediateDeps
+      );
+
+      const rootDeps = new Map<string, Pick<IEntrypointDependency, 'resolved'>>(
+        [['./intermediate.js', { resolved: intermediateName }]]
+      );
+      const { cache } = setupCacheWithEntrypoint(
+        rootName,
+        rootContent,
+        rootDeps
+      );
+
+      cache.add('entrypoints', leafName, leafEntrypoint as any);
+      cache.add('entrypoints', intermediateName, intermediateEntrypoint as any);
+      cache.invalidateIfChanged(leafName, leafContent, undefined, 'fs');
+
+      mockedReadFileSync.mockImplementation((path) => {
+        if (path === intermediateName) {
+          return intermediateContent;
+        }
+        if (path === leafName) {
+          throw new Error('ENOENT');
+        }
+        throw new Error(`Unexpected readFileSync call: ${path}`);
+      });
+
+      expect(() =>
+        cache.invalidateIfChanged(rootName, rootContent)
+      ).not.toThrow();
+      expect(cache.has('entrypoints', leafName)).toBe(false);
+      expect(cache.has('entrypoints', intermediateName)).toBe(false);
+      expect(cache.has('entrypoints', rootName)).toBe(false);
+    });
+
+    it('should handle deleted dependency with query/hash in resolved path', () => {
+      const depName = 'dep.js';
+      const depContent = 'export const x = 1;';
+      const parentName = 'parent.js';
+      const parentContent = 'import { x } from "./dep.js?raw";';
+
+      const { entrypoint: depEntrypoint } = setupCacheWithEntrypoint(
+        depName,
+        depContent
+      );
+
+      const resolvedWithQuery = `${depName}?raw`;
+      const parentDeps = new Map<
+        string,
+        Pick<IEntrypointDependency, 'resolved'>
+      >([['./dep.js?raw', { resolved: resolvedWithQuery }]]);
+      const { cache } = setupCacheWithEntrypoint(
+        parentName,
+        parentContent,
+        parentDeps
+      );
+
+      cache.add('entrypoints', resolvedWithQuery, depEntrypoint as any);
+
+      mockedReadFileSync.mockImplementation((path) => {
+        if (path === depName) {
+          throw new Error('ENOENT');
+        }
+        throw new Error(`Unexpected readFileSync call: ${path}`);
+      });
+
+      expect(() =>
+        cache.invalidateIfChanged(parentName, parentContent)
+      ).not.toThrow();
+      expect(cache.has('entrypoints', resolvedWithQuery)).toBe(false);
+      expect(mockedReadFileSync).toHaveBeenCalledWith(depName, 'utf8');
+    });
+
     it('should handle cyclic dependencies without infinite recursion', () => {
       const fileA = 'a.js';
       const contentA = 'import { b } from "./b.js"; export const a = () => b;';

--- a/packages/transform/src/__tests__/cache.test.ts
+++ b/packages/transform/src/__tests__/cache.test.ts
@@ -18,6 +18,15 @@ type MockEntrypoint = {
 
 const mockedReadFileSync = jest.spyOn(fs, 'readFileSync');
 
+const createErrnoError = (
+  code: string,
+  message = code
+): NodeJS.ErrnoException => {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+};
+
 const setupCacheWithEntrypoint = (
   filename: string,
   content: string,
@@ -377,10 +386,10 @@ describe('TransformCacheCollection', () => {
       cache.add('entrypoints', depName, depEntrypoint as any);
       cache.invalidateIfChanged(depName, depContent, undefined, 'fs');
 
-      const enoent = new Error(
+      const enoent = createErrnoError(
+        'ENOENT',
         "ENOENT: no such file or directory, open 'deleted-dep.js'"
-      ) as NodeJS.ErrnoException;
-      enoent.code = 'ENOENT';
+      );
 
       mockedReadFileSync.mockImplementation((path) => {
         if (path === depName) {
@@ -394,6 +403,49 @@ describe('TransformCacheCollection', () => {
       ).not.toThrow();
       expect(cache.has('entrypoints', depName)).toBe(false);
       expect(cache.has('entrypoints', parentName)).toBe(false);
+    });
+
+    it('should rethrow non-missing dependency read errors', () => {
+      const depName = 'protected-dep.js';
+      const depContent = 'export const x = 1;';
+      const parentName = 'parent.js';
+      const parentContent = 'import { x } from "./protected-dep.js";';
+
+      const { entrypoint: depEntrypoint } = setupCacheWithEntrypoint(
+        depName,
+        depContent
+      );
+
+      const parentDeps = new Map<
+        string,
+        Pick<IEntrypointDependency, 'resolved'>
+      >([['./protected-dep.js', { resolved: depName }]]);
+      const { cache } = setupCacheWithEntrypoint(
+        parentName,
+        parentContent,
+        parentDeps
+      );
+
+      cache.add('entrypoints', depName, depEntrypoint as any);
+      cache.invalidateIfChanged(depName, depContent, undefined, 'fs');
+
+      const eacces = createErrnoError(
+        'EACCES',
+        "EACCES: permission denied, open 'protected-dep.js'"
+      );
+
+      mockedReadFileSync.mockImplementation((path) => {
+        if (path === depName) {
+          throw eacces;
+        }
+        throw new Error(`Unexpected readFileSync call: ${path}`);
+      });
+
+      expect(() =>
+        cache.invalidateIfChanged(parentName, parentContent)
+      ).toThrow(eacces);
+      expect(cache.has('entrypoints', depName)).toBe(true);
+      expect(cache.has('entrypoints', parentName)).toBe(true);
     });
 
     it('should invalidate deleted dependency cache entries for all cache types', () => {
@@ -422,7 +474,7 @@ describe('TransformCacheCollection', () => {
       cache.invalidateIfChanged(depName, depContent, undefined, 'fs');
 
       mockedReadFileSync.mockImplementation(() => {
-        throw new Error('ENOENT');
+        throw createErrnoError('ENOENT');
       });
 
       cache.invalidateIfChanged(parentName, parentContent);
@@ -470,7 +522,7 @@ describe('TransformCacheCollection', () => {
 
       mockedReadFileSync.mockImplementation((path) => {
         if (path === deletedDep) {
-          throw new Error('ENOENT');
+          throw createErrnoError('ENOENT');
         }
         if (path === aliveDep) {
           return newAliveContent;
@@ -520,7 +572,7 @@ describe('TransformCacheCollection', () => {
       cache.add('entrypoints', dep2, dep2Entrypoint as any);
 
       mockedReadFileSync.mockImplementation(() => {
-        throw new Error('ENOENT');
+        throw createErrnoError('ENOENT');
       });
 
       expect(() =>
@@ -573,7 +625,7 @@ describe('TransformCacheCollection', () => {
           return intermediateContent;
         }
         if (path === leafName) {
-          throw new Error('ENOENT');
+          throw createErrnoError('ENOENT');
         }
         throw new Error(`Unexpected readFileSync call: ${path}`);
       });
@@ -612,7 +664,7 @@ describe('TransformCacheCollection', () => {
 
       mockedReadFileSync.mockImplementation((path) => {
         if (path === depName) {
-          throw new Error('ENOENT');
+          throw createErrnoError('ENOENT');
         }
         throw new Error(`Unexpected readFileSync call: ${path}`);
       });

--- a/packages/transform/src/cache.ts
+++ b/packages/transform/src/cache.ts
@@ -242,10 +242,19 @@ export class TransformCacheCollection<
         const dependencyFilename = dependency.resolved;
 
         if (dependencyFilename) {
-          const dependencyContent = fs.readFileSync(
-            stripQueryAndHash(dependencyFilename),
-            'utf8'
-          );
+          let dependencyContent: string;
+          try {
+            dependencyContent = fs.readFileSync(
+              stripQueryAndHash(dependencyFilename),
+              'utf8'
+            );
+          } catch {
+            this.invalidateForFile(dependencyFilename);
+            anyDepChanged = true;
+            // eslint-disable-next-line no-continue
+            continue;
+          }
+
           const dependencyChanged = this.invalidateIfChanged(
             dependencyFilename,
             dependencyContent,

--- a/packages/transform/src/cache.ts
+++ b/packages/transform/src/cache.ts
@@ -12,6 +12,15 @@ function hashContent(content: string) {
   return createHash('sha256').update(content).digest('hex');
 }
 
+function isMissingFileError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const { code } = error as NodeJS.ErrnoException;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
 interface IBaseCachedEntrypoint {
   dependencies: Map<string, { resolved: string | null }>;
   initialCode?: string;
@@ -248,7 +257,11 @@ export class TransformCacheCollection<
               stripQueryAndHash(dependencyFilename),
               'utf8'
             );
-          } catch {
+          } catch (error) {
+            if (!isMissingFileError(error)) {
+              throw error;
+            }
+
             this.invalidateForFile(dependencyFilename);
             anyDepChanged = true;
             // eslint-disable-next-line no-continue


### PR DESCRIPTION
## Problem

When a file tracked in the in-memory `TransformCacheCollection` dependency graph is deleted or renamed, `invalidateIfChanged` crashes with an unhandled `ENOENT` from `fs.readFileSync`. This kills the running build process.

This happens during watch/dev mode when the `TransformCacheCollection` persists in memory across recompilations. A file rename, branch switch, or git rebase can leave stale dependency references pointing to paths that no longer exist on disk. The next recompilation walks the stale dependency graph and crashes. A full process restart recovers (fresh `TransformCacheCollection`), but the dev experience is disrupted.

### Reproduction

1. Start a bundler dev server with wyw-in-js loader (webpack, esbuild, etc.)
2. Build successfully (populates the in-memory transform cache with dependency graph)
3. Delete or rename a file that was imported by a styled component
4. Trigger recompilation (HMR / manual) → **crash**: `ENOENT: no such file or directory`
5. Process must be restarted to recover

### Stack trace

```
Error: ENOENT: no such file or directory, open '...'
    at Object.readFileSync (node:fs)
    at TransformCacheCollection.invalidateIfChanged (cache.js)
    at TransformCacheCollection.invalidateIfChanged (cache.js) // recursive
    ...
    at Entrypoint.createRoot
    at transform
    at Object.webpack5LoaderPlugin
```

## Fix

Wrap the `fs.readFileSync` call inside `invalidateIfChanged`'s dependency traversal loop in a try-catch. When a dependency file cannot be read:

- Invalidate the stale cache entry for that file via `invalidateForFile()`
- Mark `anyDepChanged = true` so the change propagates upward — parent output (e.g. extracted CSS) was generated using the deleted dependency's exports and is now stale
- `continue` to the next dependency

This is consistent with the error handling already present in the `add()` method which gracefully handles missing files during entrypoint registration.

## Tests

Added 6 test cases covering:
- Basic ENOENT — no crash, dependency entry invalidated
- All cache types (entrypoints + exports) cleaned up for deleted dep
- Multiple dependencies where one is deleted — remaining deps still processed
- All dependencies deleted — no crash
- Recursive dependency chain with deleted leaf node
- Deleted dependency with `?query`/`#hash` in resolved path (stripped before read)
