### PR TITLE
fix(transform): re-validate evaluated deps against disk in getEntrypoint

### DIFF
--- a/.changeset/cool-dingos-watch.md
+++ b/.changeset/cool-dingos-watch.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Revalidate evaluated dependencies against disk during entrypoint freshness checks, and rethrow non-missing filesystem errors instead of treating them as cache invalidations.

--- a/packages/transform/src/__tests__/stale-dep-watch-cache.test.ts
+++ b/packages/transform/src/__tests__/stale-dep-watch-cache.test.ts
@@ -72,6 +72,15 @@ const createServices = (
   };
 };
 
+const createErrnoError = (
+  code: string,
+  message = code
+): NodeJS.ErrnoException => {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+};
+
 describe('stale dependency detection in watch mode', () => {
   it('getEntrypoint detects stale evaluated entrypoint when file changed on disk', () => {
     // Directly tests the getEntrypoint short-circuit at module.ts:477.
@@ -190,5 +199,47 @@ describe('stale dependency detection in watch mode', () => {
 
     const result = parentModule.getEntrypoint(depFile, ['val'], logger);
     expect(result?.evaluated).toBe(true);
+  });
+
+  it('checkFreshness rethrows non-missing filesystem errors', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-getep-eacces-'));
+    const depFile = path.join(root, 'dep.ts');
+
+    fs.writeFileSync(depFile, dedent`export const val = 'same';`);
+
+    const cache = new TransformCacheCollection();
+    cache.add('entrypoints', depFile, {
+      name: depFile,
+      initialCode: 'export const val = "same";',
+      dependencies: new Map(),
+      invalidationDependencies: new Map(),
+      invalidateOnDependencyChange: new Set(),
+      generation: 1,
+      evaluated: true,
+      evaluatedOnly: ['val'],
+      only: ['val'],
+      ignored: false,
+      exports: {},
+      log: logger,
+    } as any);
+
+    const eacces = createErrnoError(
+      'EACCES',
+      `EACCES: permission denied, stat '${depFile}'`
+    );
+    const statSpy = jest.spyOn(fs, 'statSync').mockImplementation((pathArg) => {
+      if (pathArg === depFile) {
+        throw eacces;
+      }
+
+      throw new Error(`Unexpected statSync call: ${String(pathArg)}`);
+    });
+
+    try {
+      expect(() => cache.checkFreshness(depFile, depFile)).toThrow(eacces);
+      expect(cache.has('entrypoints', depFile)).toBe(true);
+    } finally {
+      statSpy.mockRestore();
+    }
   });
 });

--- a/packages/transform/src/__tests__/stale-dep-watch-cache.test.ts
+++ b/packages/transform/src/__tests__/stale-dep-watch-cache.test.ts
@@ -1,0 +1,194 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import * as babel from '@babel/core';
+import dedent from 'dedent';
+
+import { logger } from '@wyw-in-js/shared';
+import type { StrictOptions } from '@wyw-in-js/shared';
+
+import { TransformCacheCollection } from '../cache';
+import { Module } from '../module';
+import { Entrypoint } from '../transform/Entrypoint';
+import type { LoadAndParseFn } from '../transform/Entrypoint.types';
+import type { Services } from '../transform/types';
+import { EventEmitter } from '../utils/EventEmitter';
+
+const pluginOptions: StrictOptions = {
+  babelOptions: {
+    babelrc: false,
+    configFile: false,
+    presets: [
+      ['@babel/preset-env', { loose: true }],
+      '@babel/preset-typescript',
+    ],
+  },
+  displayName: false,
+  evaluate: true,
+  extensions: ['.cjs', '.js', '.jsx', '.ts', '.tsx'],
+  features: {
+    dangerousCodeRemover: true,
+    globalCache: true,
+    happyDOM: true,
+    softErrors: false,
+    useBabelConfigs: true,
+    useWeakRefInEval: true,
+  },
+  highPriorityPlugins: [],
+  rules: [],
+};
+
+const createServices = (
+  cache: TransformCacheCollection,
+  filename: string
+): Services => {
+  const loadAndParseFn: LoadAndParseFn = (services, name, loadedCode) => ({
+    get ast() {
+      return services.babel.parseSync(loadedCode ?? '', {
+        filename: name,
+        presets: [
+          ['@babel/preset-env', { loose: true }],
+          '@babel/preset-typescript',
+        ],
+      })!;
+    },
+    code: loadedCode!,
+    evaluator: jest.fn(),
+    evalConfig: {},
+  });
+
+  return {
+    babel,
+    cache,
+    emitWarning: jest.fn(),
+    loadAndParseFn,
+    log: logger,
+    eventEmitter: EventEmitter.dummy,
+    options: {
+      filename,
+      pluginOptions,
+    },
+  };
+};
+
+describe('stale dependency detection in watch mode', () => {
+  it('getEntrypoint detects stale evaluated entrypoint when file changed on disk', () => {
+    // Directly tests the getEntrypoint short-circuit at module.ts:477.
+    // When an entrypoint is cached as evaluated with sufficient evaluatedOnly,
+    // getEntrypoint should re-read the file from disk to verify freshness
+    // before returning the cached result.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-getep-'));
+    const parentFile = path.join(root, 'parent.ts');
+    const depFile = path.join(root, 'dep.ts');
+
+    fs.writeFileSync(depFile, dedent`export const val = 'old';`);
+    fs.writeFileSync(
+      parentFile,
+      dedent`
+        import { val } from './dep';
+        export const result = val;
+      `
+    );
+
+    const cache = new TransformCacheCollection();
+
+    // Create and evaluate dep (simulates a previous compilation)
+    const depServices = createServices(cache, depFile);
+    const depCode = fs.readFileSync(depFile, 'utf-8');
+    const depEntrypoint = Entrypoint.createRoot(
+      depServices,
+      depFile,
+      ['val'],
+      depCode
+    );
+    depEntrypoint.setTransformResult({
+      code: '"use strict";\nexports.val = "old";',
+      metadata: null,
+    });
+
+    const depModule = new Module(depServices, depEntrypoint);
+    depModule.evaluate();
+    depEntrypoint.createEvaluated();
+
+    // Verify dep is cached as evaluated
+    const cachedDep = cache.get('entrypoints', depFile);
+    expect(cachedDep?.evaluated).toBe(true);
+
+    // Change dep on disk
+    fs.writeFileSync(depFile, dedent`export const val = 'new';`);
+
+    // Create a parent module that will call getEntrypoint for dep
+    const parentServices = createServices(cache, parentFile);
+    const parentCode = fs.readFileSync(parentFile, 'utf-8');
+    const parentEntrypoint = Entrypoint.createRoot(
+      parentServices,
+      parentFile,
+      ['result'],
+      parentCode
+    );
+    parentEntrypoint.setTransformResult({
+      code: '"use strict";\nvar _dep = require("./dep");\nexports.result = _dep.val;',
+      metadata: null,
+    });
+    const parentModule = new Module(parentServices, parentEntrypoint);
+
+    // getEntrypoint should detect the dep changed on disk
+    // Without fix: returns stale evaluated entrypoint (evaluated=true)
+    // With fix: invalidates stale entry, falls through to re-read from disk
+    const result = parentModule.getEntrypoint(depFile, ['val'], logger);
+    expect(result?.evaluated).toBe(false);
+  });
+
+  it('getEntrypoint returns cached entrypoint when file unchanged', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-getep-fresh-'));
+    const parentFile = path.join(root, 'parent.ts');
+    const depFile = path.join(root, 'dep.ts');
+
+    fs.writeFileSync(depFile, dedent`export const val = 'same';`);
+    fs.writeFileSync(
+      parentFile,
+      dedent`
+        import { val } from './dep';
+        export const result = val;
+      `
+    );
+
+    const cache = new TransformCacheCollection();
+
+    const depServices = createServices(cache, depFile);
+    const depCode = fs.readFileSync(depFile, 'utf-8');
+    const depEntrypoint = Entrypoint.createRoot(
+      depServices,
+      depFile,
+      ['val'],
+      depCode
+    );
+    depEntrypoint.setTransformResult({
+      code: '"use strict";\nexports.val = "same";',
+      metadata: null,
+    });
+
+    const depModule = new Module(depServices, depEntrypoint);
+    depModule.evaluate();
+    depEntrypoint.createEvaluated();
+
+    // File unchanged on disk — should return the cached evaluated entrypoint
+    const parentServices = createServices(cache, parentFile);
+    const parentCode = fs.readFileSync(parentFile, 'utf-8');
+    const parentEntrypoint = Entrypoint.createRoot(
+      parentServices,
+      parentFile,
+      ['result'],
+      parentCode
+    );
+    parentEntrypoint.setTransformResult({
+      code: '"use strict";\nvar _dep = require("./dep");\nexports.result = _dep.val;',
+      metadata: null,
+    });
+    const parentModule = new Module(parentServices, parentEntrypoint);
+
+    const result = parentModule.getEntrypoint(depFile, ['val'], logger);
+    expect(result?.evaluated).toBe(true);
+  });
+});

--- a/packages/transform/src/cache.ts
+++ b/packages/transform/src/cache.ts
@@ -12,6 +12,15 @@ function hashContent(content: string) {
   return createHash('sha256').update(content).digest('hex');
 }
 
+function isMissingFileError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const { code } = error as NodeJS.ErrnoException;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
 interface IBaseCachedEntrypoint {
   dependencies: Map<string, { resolved: string | null }>;
   initialCode?: string;
@@ -397,7 +406,11 @@ export class TransformCacheCollection<
       }
 
       return false;
-    } catch {
+    } catch (error) {
+      if (!isMissingFileError(error)) {
+        throw error;
+      }
+
       this.invalidateForFile(filename);
       return true;
     }

--- a/packages/transform/src/cache.ts
+++ b/packages/transform/src/cache.ts
@@ -53,6 +53,8 @@ export class TransformCacheCollection<
 
   private contentHashes = new Map<string, { fs?: string; loaded?: string }>();
 
+  private fileMtimes = new Map<string, number>();
+
   private readonly exportDependencies = new Map<string, Set<string>>();
 
   constructor(caches: Partial<ICaches<TEntrypoint>> = {}) {
@@ -373,6 +375,34 @@ export class TransformCacheCollection<
     return this.getCachedDependencies(filename).size > 0;
   }
 
+  /**
+   * Fast check if a file changed on disk since last seen.
+   * Uses mtime as a fast path — only reads the file if mtime differs.
+   * Returns true if the file changed (cache was invalidated).
+   */
+  public checkFreshness(filename: string, strippedFilename: string): boolean {
+    try {
+      const currentMtime = fs.statSync(strippedFilename).mtimeMs;
+      const cachedMtime = this.fileMtimes.get(filename);
+
+      if (cachedMtime !== undefined && currentMtime === cachedMtime) {
+        return false;
+      }
+
+      const content = fs.readFileSync(strippedFilename, 'utf-8');
+      this.fileMtimes.set(filename, currentMtime);
+
+      if (this.invalidateIfChanged(filename, content, undefined, 'fs')) {
+        return true;
+      }
+
+      return false;
+    } catch {
+      this.invalidateForFile(filename);
+      return true;
+    }
+  }
+
   private setContentHash(
     filename: string,
     source: 'fs' | 'loaded',
@@ -381,9 +411,19 @@ export class TransformCacheCollection<
     const current = this.contentHashes.get(filename);
     if (current) {
       current[source] = hash;
-      return;
+    } else {
+      this.contentHashes.set(filename, { [source]: hash });
     }
 
-    this.contentHashes.set(filename, { [source]: hash });
+    if (source === 'fs') {
+      try {
+        this.fileMtimes.set(
+          filename,
+          fs.statSync(stripQueryAndHash(filename)).mtimeMs
+        );
+      } catch {
+        // ignore
+      }
+    }
   }
 }

--- a/packages/transform/src/module.ts
+++ b/packages/transform/src/module.ts
@@ -473,10 +473,16 @@ export class Module {
       return null;
     }
 
-    const entrypoint = this.cache.get('entrypoints', filename);
+    let entrypoint = this.cache.get('entrypoints', filename);
     if (entrypoint && isSuperSet(entrypoint.evaluatedOnly ?? [], only)) {
-      log('✅ file has been already evaluated');
-      return entrypoint;
+      if (this.cache.checkFreshness(filename, strippedFilename)) {
+        entrypoint = undefined;
+      }
+
+      if (entrypoint) {
+        log('✅ file has been already evaluated');
+        return entrypoint;
+      }
     }
 
     if (entrypoint?.ignored) {


### PR DESCRIPTION
## Problem

`Module.getEntrypoint()` returns cached evaluated entrypoints without checking if the file changed on disk since it was last evaluated. This causes **permanently stale content** during watch mode — once a file is evaluated with wrong content, the bad result persists for the entire process lifetime. Recompilation commands don't help; only a full process restart recovers.

### Root cause

`module.ts:476-479` — the "already evaluated" short-circuit:

```ts
const entrypoint = this.cache.get('entrypoints', filename);
if (entrypoint && isSuperSet(entrypoint.evaluatedOnly ?? [], only)) {
  log('✅ file has been already evaluated');
  return entrypoint;  // ← never checks disk
}
```

The `TransformCacheCollection` is a module-level singleton in bundler loaders, persisting across all recompilations within a process. When a file is evaluated during one compilation, its entrypoint is cached with `evaluated: true`. On subsequent compilations, `getEntrypoint` returns this cached result without verifying the file still has the same content on disk.

### When this happens

Not all dependencies go through `Entrypoint.innerCreate` (which does have a disk freshness check). Dependencies discovered only during eval — via `Module.require` → `getEntrypoint` — bypass prepare-stage dependency tracking entirely. These eval-only deps hit the `getEntrypoint` short-circuit directly.

This commonly occurs with:
- Deep transitive dependencies through theme/palette/config barrel exports
- Dependencies resolved via Node.js fallback (`resolveDependency` line 631) rather than the bundler's async resolver
- Files that change during git rebase/merge (briefly have conflict markers, get evaluated with broken content, then are fixed — but the bad evaluation persists)

### Reproduction

In a real webpack project: start dev server → build successfully → a transitive dependency gets broken content (e.g. merge conflict markers during a git rebase) → wyw evaluates it with the broken content → fix the file → save → webpack recompiles (HMR or manual `compiler.watching.invalidate()`) → wyw **still uses the stale cached evaluation**, producing errors like:

```
SyntaxError: /path/to/packages/ui-kit/src/palettes/warm.ts: Unexpected token (4:0)

  2 |
  3 | export const warmBase: Omit<ThemePalette, "accent" | "accentDark" | "key"> = {
> 4 | <<<<<<< HEAD
    | ^
  5 |   deneutralize: {sepia: 0.1, oklchL: 0.98},
  6 | =======
  7 |   deneutralize: {sepia: 0.3, oklchL: 0.97},
```

The file no longer has conflict markers on disk. Further edits to the file don't help — wyw keeps returning the stale cached evaluation from the first bad read. Only a full process restart recovers.

### Test failure without fix

```
packages/transform/src/__tests__/stale-dep-watch-cache.test.ts:
135 |
136 |     // getEntrypoint should detect the dep changed on disk
137 |     // Without fix: returns stale evaluated entrypoint (evaluated=true)
138 |     // With fix: invalidates stale entry, falls through to re-read from disk
139 |     const result = parentModule.getEntrypoint(depFile, ['val'], logger);
140 |     expect(result?.evaluated).toBe(false);
                                    ^
error: expect(received).toBe(expected)

Expected: false
Received: true

(fail) stale dependency detection in watch mode > getEntrypoint detects stale evaluated entrypoint when file changed on disk
```

The test creates an evaluated entrypoint for a dep file, changes the file on disk, then calls `getEntrypoint`. Without the fix, the stale evaluated entrypoint is returned (`evaluated: true`). With the fix, the stale entry is invalidated and a fresh entrypoint is created (`evaluated: false`).

## Fix

Before returning a cached evaluated entrypoint, re-read the file from disk and call `invalidateIfChanged`. If the content changed, clear `entrypoint` so the method falls through to the existing re-processing path at line 539 (`Entrypoint.createRoot` with fresh `readFileSync`).

```ts
let entrypoint = this.cache.get('entrypoints', filename);
if (entrypoint && isSuperSet(entrypoint.evaluatedOnly ?? [], only)) {
  try {
    if (this.cache.invalidateIfChanged(
      filename,
      fs.readFileSync(strippedFilename, 'utf-8'),
      undefined,
      'fs'
    )) {
      entrypoint = undefined;
    }
  } catch {
    entrypoint = undefined;
  }

  if (entrypoint) {
    log('✅ file has been already evaluated');
    return entrypoint;
  }
}
```

This is consistent with the freshness check already used in `Entrypoint.innerCreate` (lines 219-226) for non-evaluated cached entrypoints.

### Performance

Adds one `readFileSync` per cached evaluated dependency per `getEntrypoint` call. In the common case (file unchanged), the file is in OS page cache — just a syscall + SHA-256 hash comparison. No disk I/O, no parsing, no new allocations. The existing evaluated entrypoint is returned as before.

## Tests

- **`getEntrypoint detects stale evaluated entrypoint when file changed on disk`** — creates an evaluated dep, changes file on disk, verifies `getEntrypoint` returns a fresh (non-evaluated) entrypoint. **Fails without fix.**
- **`getEntrypoint returns cached entrypoint when file unchanged`** — verifies no regression: unchanged file returns the cached evaluated entrypoint.
