### PR TITLE
fix(vite): keep preserved-module CSS links valid in library output

### DIFF
--- a/.changeset/vite-preserve-js-css-links.md
+++ b/.changeset/vite-preserve-js-css-links.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/vite': patch
+---
+
+Restore preserved-module JS-to-CSS links for WyW-generated CSS assets in Vite library builds.

--- a/e2e/vite/scripts/test.cjs
+++ b/e2e/vite/scripts/test.cjs
@@ -2,12 +2,15 @@
 
 const fs = require('node:fs/promises');
 const path = require('node:path');
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
 const colors = require('picocolors');
 const prettier = require('prettier');
 const { build } = require('vite');
 const wyw = require('@wyw-in-js/vite');
 
 const PKG_DIR = path.resolve(__dirname, '..');
+const execFileAsync = promisify(execFile);
 
 /**
  * @param {string} value
@@ -34,6 +37,29 @@ async function buildArtefact(outDir, pluginOptions) {
   });
 }
 
+async function buildPreserveModulesArtefact(outDir, format) {
+  await build({
+    build: {
+      outDir,
+      cssCodeSplit: true,
+      cssMinify: false,
+      lib: {
+        entry: path.resolve(PKG_DIR, 'src/preserve-modules/index.ts'),
+        formats: [format],
+      },
+      rollupOptions: {
+        output: {
+          assetFileNames: '[name][extname]',
+          preserveModules: true,
+          preserveModulesRoot: path.resolve(PKG_DIR, 'src/preserve-modules'),
+        },
+      },
+    },
+    configFile: false,
+    plugins: [wyw.default({ preserveCssPaths: true })],
+  });
+}
+
 async function getCSSFromManifest(outDir) {
   const manifestPath = path.resolve(outDir, '.vite', 'manifest.json');
   const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf-8'));
@@ -55,6 +81,72 @@ async function getCSSFromManifest(outDir) {
 
   return prettier.format(cssSnapshot, {
     parser: 'css',
+  });
+}
+
+async function assertFileMatches(filePath, pattern) {
+  const contents = normalizeLineEndings(await fs.readFile(filePath, 'utf-8'));
+
+  if (!pattern.test(contents)) {
+    throw new Error(`${path.relative(PKG_DIR, filePath)} does not match ${pattern}`);
+  }
+}
+
+async function assertFileDoesNotContain(filePath, text) {
+  const contents = normalizeLineEndings(await fs.readFile(filePath, 'utf-8'));
+
+  if (contents.includes(text)) {
+    throw new Error(`${path.relative(PKG_DIR, filePath)} unexpectedly contains ${text}`);
+  }
+}
+
+async function listFilesRecursively(dirPath) {
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.resolve(dirPath, entry.name);
+
+      if (entry.isDirectory()) {
+        return listFilesRecursively(entryPath);
+      }
+
+      return [entryPath];
+    })
+  );
+
+  return files.flat();
+}
+
+async function findFileMatching(dirPath, predicate) {
+  const files = await listFilesRecursively(dirPath);
+
+  for (const filePath of files) {
+    const contents = normalizeLineEndings(await fs.readFile(filePath, 'utf-8'));
+    if (predicate(filePath, contents)) {
+      return filePath;
+    }
+  }
+
+  throw new Error(`No matching file found under ${path.relative(PKG_DIR, dirPath)}`);
+}
+
+async function assertCjsModuleLoads(filePath) {
+  const script = `
+    require.extensions['.css'] = () => {};
+    const mod = require(process.argv[1]);
+    if (!mod || typeof mod.rootClass !== 'string') {
+      throw new Error('Missing rootClass export');
+    }
+    if (!mod || typeof mod.buttonClass !== 'string') {
+      throw new Error('Missing buttonClass export');
+    }
+    if (!mod || mod.plainValue !== 'plain') {
+      throw new Error('Unexpected plainValue export');
+    }
+  `;
+
+  await execFileAsync(process.execPath, ['-e', script, filePath], {
+    cwd: PKG_DIR,
   });
 }
 
@@ -94,6 +186,78 @@ async function main() {
       console.log(cssFixture);
 
       throw new Error(`[${testCase.name}] CSS output does not match fixture`);
+    }
+  }
+
+  const preserveModulesCases = [
+    {
+      format: 'es',
+      name: 'preserveModules-es',
+      outDir: path.resolve(PKG_DIR, 'dist-preserve-modules'),
+      cssEdgePattern: /import ["']\.\/index\.wyw-in-js\.css["'];/,
+      nestedCssEdgePattern: /import ["']\.\/(?:nested\/)+button\.wyw-in-js\.css["'];/,
+    },
+    {
+      format: 'cjs',
+      name: 'preserveModules-cjs',
+      outDir: path.resolve(PKG_DIR, 'dist-preserve-modules-cjs'),
+      cssEdgePattern: /require\(["']\.\/index\.wyw-in-js\.css["']\);/,
+      nestedCssEdgePattern: /require\(["']\.\/(?:nested\/)+button\.wyw-in-js\.css["']\);/,
+    },
+  ];
+
+  for (const preserveModulesCase of preserveModulesCases) {
+    console.log(colors.blue('Running case:'), preserveModulesCase.name);
+    await fs.rm(preserveModulesCase.outDir, { recursive: true, force: true });
+
+    await buildPreserveModulesArtefact(
+      preserveModulesCase.outDir,
+      preserveModulesCase.format
+    );
+
+    const rootModulePath = await findFileMatching(
+      preserveModulesCase.outDir,
+      (filePath, contents) =>
+        /\.(?:mjs|js)$/.test(filePath) &&
+        contents.includes('rootClass') &&
+        contents.includes('./index.wyw-in-js.css')
+    );
+    const nestedModulePath = await findFileMatching(
+      preserveModulesCase.outDir,
+      (filePath, contents) =>
+        /\.(?:mjs|js)$/.test(filePath) &&
+        contents.includes('button.wyw-in-js.css')
+    );
+    const plainModulePath = await findFileMatching(
+      preserveModulesCase.outDir,
+      (filePath, contents) =>
+        /\.(?:mjs|js)$/.test(filePath) &&
+        contents.includes('"plain"') &&
+        !contents.includes('.css')
+    );
+
+    await assertFileMatches(
+      rootModulePath,
+      preserveModulesCase.cssEdgePattern
+    );
+    await assertFileMatches(
+      nestedModulePath,
+      preserveModulesCase.nestedCssEdgePattern
+    );
+    await assertFileDoesNotContain(
+      plainModulePath,
+      '.css'
+    );
+    await fs.access(
+      path.resolve(preserveModulesCase.outDir, 'index.wyw-in-js.css')
+    );
+    await findFileMatching(
+      preserveModulesCase.outDir,
+      (filePath) => filePath.endsWith('button.wyw-in-js.css')
+    );
+
+    if (preserveModulesCase.format === 'cjs') {
+      await assertCjsModuleLoads(rootModulePath);
     }
   }
 }

--- a/e2e/vite/src/preserve-modules/index.ts
+++ b/e2e/vite/src/preserve-modules/index.ts
@@ -1,0 +1,8 @@
+import { css } from '@wyw-in-js/template-tag-syntax';
+
+export { buttonClass } from './nested/button';
+export { plainValue } from './plain';
+
+export const rootClass = css`
+  color: red;
+`;

--- a/e2e/vite/src/preserve-modules/nested/button.ts
+++ b/e2e/vite/src/preserve-modules/nested/button.ts
@@ -1,0 +1,5 @@
+import { css } from '@wyw-in-js/template-tag-syntax';
+
+export const buttonClass = css`
+  color: blue;
+`;

--- a/e2e/vite/src/preserve-modules/plain.ts
+++ b/e2e/vite/src/preserve-modules/plain.ts
@@ -1,0 +1,1 @@
+export const plainValue = 'plain';

--- a/packages/vite/src/__tests__/preserve-css-paths.test.ts
+++ b/packages/vite/src/__tests__/preserve-css-paths.test.ts
@@ -347,7 +347,9 @@ describe('vite preserveCssPaths', () => {
       false as never
     );
 
-    expect((bundle['index.js'] as any).code).not.toContain('import "./index.css";');
+    expect((bundle['index.js'] as any).code).not.toContain(
+      'import "./index.css";'
+    );
   });
 
   it('restores nested css imports for preserveModules library chunks', async () => {

--- a/packages/vite/src/__tests__/preserve-css-paths.test.ts
+++ b/packages/vite/src/__tests__/preserve-css-paths.test.ts
@@ -232,6 +232,124 @@ describe('vite preserveCssPaths', () => {
     );
   });
 
+  it('restores renamed root-level css imports for preserveModules chunks without build.lib', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      format: 'es',
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      createResolver: () => jest.fn().mockResolvedValue(undefined),
+      build: {
+        cssCodeSplit: true,
+        rollupOptions: { output: outputOptions },
+      },
+    } as any);
+
+    transformMock.mockResolvedValueOnce({
+      code: 'export const root = "root";',
+      sourceMap: null,
+      cssText: '.root { color: red; }',
+      dependencies: [],
+    });
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'export const root = "root";',
+      '/project/src/index.ts'
+    );
+
+    const bundle = {
+      'index.js': {
+        type: 'chunk',
+        fileName: 'index.js',
+        code: '/* empty css */\nexport const root = "root";\n',
+        facadeModuleId: '/project/src/index.ts',
+      },
+      'index.css': {
+        type: 'asset',
+        fileName: 'index.css',
+        name: '/project/src/index.wyw-in-js.css',
+        source: '.root { color: red; }',
+      },
+    };
+
+    plugin.generateBundle?.(
+      outputOptions as any,
+      bundle as any,
+      false as never
+    );
+
+    expect((bundle['index.js'] as any).code).toContain('import "./index.css";');
+  });
+
+  it('does not inject css imports when preserveModules is disabled', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      format: 'es',
+      preserveModules: false,
+      preserveModulesRoot: '/project/src',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      createResolver: () => jest.fn().mockResolvedValue(undefined),
+      build: {
+        cssCodeSplit: true,
+        rollupOptions: { output: outputOptions },
+      },
+    } as any);
+
+    transformMock.mockResolvedValueOnce({
+      code: 'export const root = "root";',
+      sourceMap: null,
+      cssText: '.root { color: red; }',
+      dependencies: [],
+    });
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'export const root = "root";',
+      '/project/src/index.ts'
+    );
+
+    const bundle = {
+      'index.js': {
+        type: 'chunk',
+        fileName: 'index.js',
+        code: '/* empty css */\nexport const root = "root";\n',
+        facadeModuleId: '/project/src/index.ts',
+      },
+      'index.css': {
+        type: 'asset',
+        fileName: 'index.css',
+        name: '/project/src/index.wyw-in-js.css',
+        source: '.root { color: red; }',
+      },
+    };
+
+    plugin.generateBundle?.(
+      outputOptions as any,
+      bundle as any,
+      false as never
+    );
+
+    expect((bundle['index.js'] as any).code).not.toContain('import "./index.css";');
+  });
+
   it('restores nested css imports for preserveModules library chunks', async () => {
     const { default: wywInJS } = await import('../index');
 
@@ -409,6 +527,67 @@ describe('vite preserveCssPaths', () => {
 
     expect((bundle['index.js'] as any).code).toContain(
       '"use strict";require("./index.wyw-in-js.css");'
+    );
+  });
+
+  it('restores renamed root-level css requires for preserveModules CommonJS chunks without build.lib', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      format: 'cjs',
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      createResolver: () => jest.fn().mockResolvedValue(undefined),
+      build: {
+        cssCodeSplit: true,
+        rollupOptions: { output: outputOptions },
+      },
+    } as any);
+
+    transformMock.mockResolvedValueOnce({
+      code: 'exports.root = "root";',
+      sourceMap: null,
+      cssText: '.root { color: red; }',
+      dependencies: [],
+    });
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'exports.root = "root";',
+      '/project/src/index.ts'
+    );
+
+    const bundle = {
+      'index.js': {
+        type: 'chunk',
+        fileName: 'index.js',
+        code: '"use strict";Object.defineProperty(exports,Symbol.toStringTag,{value:"Module"});exports.root = "root";\n',
+        facadeModuleId: '/project/src/index.ts',
+      },
+      'index.css': {
+        type: 'asset',
+        fileName: 'index.css',
+        name: '/project/src/index.wyw-in-js.css',
+        source: '.root { color: red; }',
+      },
+    };
+
+    plugin.generateBundle?.(
+      outputOptions as any,
+      bundle as any,
+      false as never
+    );
+
+    expect((bundle['index.js'] as any).code).toContain(
+      '"use strict";require("./index.css");'
     );
   });
 

--- a/packages/vite/src/__tests__/preserve-css-paths.test.ts
+++ b/packages/vite/src/__tests__/preserve-css-paths.test.ts
@@ -1,3 +1,5 @@
+const transformMock = jest.fn();
+
 const createLogger = () => {
   const log = (() => undefined) as unknown as ((...args: unknown[]) => void) & {
     extend: (...args: unknown[]) => unknown;
@@ -24,10 +26,20 @@ jest.mock('@wyw-in-js/transform', () => ({
   }),
   getFileIdx: () => '1',
   TransformCacheCollection: class TransformCacheCollection {},
-  transform: jest.fn(),
+  transform: (...args: unknown[]) => transformMock(...args),
 }));
 
 describe('vite preserveCssPaths', () => {
+  beforeEach(() => {
+    transformMock.mockReset();
+    transformMock.mockResolvedValue({
+      code: 'export {}',
+      sourceMap: null,
+      cssText: undefined,
+      dependencies: [],
+    });
+  });
+
   it('rewrites wyw css assets to preserve directories', async () => {
     const { default: wywInJS } = await import('../index');
 
@@ -156,5 +168,365 @@ describe('vite preserveCssPaths', () => {
     } as any);
 
     expect(outputOptions.assetFileNames).toBe('assets/[name].[hash].[ext]');
+  });
+
+  it('restores root-level css imports for preserveModules library chunks', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      format: 'es',
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      createResolver: () => jest.fn().mockResolvedValue(undefined),
+      build: {
+        lib: { entry: '/project/src/index.ts', formats: ['es'] },
+        cssCodeSplit: true,
+        rollupOptions: { output: outputOptions },
+      },
+    } as any);
+
+    transformMock.mockResolvedValueOnce({
+      code: 'export const root = "root";',
+      sourceMap: null,
+      cssText: '.root { color: red; }',
+      dependencies: [],
+    });
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'export const root = "root";',
+      '/project/src/index.ts'
+    );
+
+    const bundle = {
+      'index.js': {
+        type: 'chunk',
+        fileName: 'index.js',
+        code: '/* empty css */\nexport const root = "root";\n',
+        facadeModuleId: '/project/src/index.ts',
+      },
+      'index.wyw-in-js.css': {
+        type: 'asset',
+        fileName: 'index.wyw-in-js.css',
+        name: '/project/src/index.wyw-in-js.css',
+        source: '.root { color: red; }',
+      },
+    };
+
+    plugin.generateBundle?.(
+      outputOptions as any,
+      bundle as any,
+      false as never
+    );
+
+    expect((bundle['index.js'] as any).code).toContain(
+      'import "./index.wyw-in-js.css";'
+    );
+  });
+
+  it('restores nested css imports for preserveModules library chunks', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      format: 'es',
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      createResolver: () => jest.fn().mockResolvedValue(undefined),
+      build: {
+        lib: { entry: '/project/src/index.ts', formats: ['es'] },
+        cssCodeSplit: true,
+        rollupOptions: { output: outputOptions },
+      },
+    } as any);
+
+    transformMock.mockResolvedValueOnce({
+      code: 'export const button = "button";',
+      sourceMap: null,
+      cssText: '.button { color: blue; }',
+      dependencies: [],
+    });
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'export const button = "button";',
+      '/project/src/nested/button.ts'
+    );
+
+    const bundle = {
+      'nested/button.js': {
+        type: 'chunk',
+        fileName: 'nested/button.js',
+        code: 'export const button = "button";\n',
+        facadeModuleId: '/project/src/nested/button.ts',
+      },
+      'nested/button.wyw-in-js.css': {
+        type: 'asset',
+        fileName: 'nested/button.wyw-in-js.css',
+        name: 'src/nested/button.wyw-in-js.css',
+        source: '.button { color: blue; }',
+      },
+    };
+
+    plugin.generateBundle?.(
+      outputOptions as any,
+      bundle as any,
+      false as never
+    );
+
+    expect((bundle['nested/button.js'] as any).code).toContain(
+      'import "./button.wyw-in-js.css";'
+    );
+  });
+
+  it('does not inject css imports when no wyw css asset is emitted', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      format: 'es',
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      createResolver: () => jest.fn().mockResolvedValue(undefined),
+      build: {
+        lib: { entry: '/project/src/index.ts', formats: ['es'] },
+        cssCodeSplit: true,
+        rollupOptions: { output: outputOptions },
+      },
+    } as any);
+
+    transformMock.mockResolvedValueOnce({
+      code: 'export const plain = "plain";',
+      sourceMap: null,
+      cssText: '.plain { color: inherit; }',
+      dependencies: [],
+    });
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'export const plain = "plain";',
+      '/project/src/plain.ts'
+    );
+
+    const bundle = {
+      'plain.js': {
+        type: 'chunk',
+        fileName: 'plain.js',
+        code: 'export const plain = "plain";\n',
+        facadeModuleId: '/project/src/plain.ts',
+      },
+    };
+
+    plugin.generateBundle?.(
+      outputOptions as any,
+      bundle as any,
+      false as never
+    );
+
+    expect((bundle['plain.js'] as any).code).toBe(
+      'export const plain = "plain";\n'
+    );
+  });
+
+  it('restores root-level css requires for preserveModules CommonJS chunks', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      format: 'cjs',
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      createResolver: () => jest.fn().mockResolvedValue(undefined),
+      build: {
+        lib: { entry: '/project/src/index.ts', formats: ['cjs'] },
+        cssCodeSplit: true,
+        rollupOptions: { output: outputOptions },
+      },
+    } as any);
+
+    transformMock.mockResolvedValueOnce({
+      code: 'exports.root = "root";',
+      sourceMap: null,
+      cssText: '.root { color: red; }',
+      dependencies: [],
+    });
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'exports.root = "root";',
+      '/project/src/index.ts'
+    );
+
+    const bundle = {
+      'index.js': {
+        type: 'chunk',
+        fileName: 'index.js',
+        code: '"use strict";Object.defineProperty(exports,Symbol.toStringTag,{value:"Module"});exports.root = "root";\n',
+        facadeModuleId: '/project/src/index.ts',
+      },
+      'index.wyw-in-js.css': {
+        type: 'asset',
+        fileName: 'index.wyw-in-js.css',
+        name: '/project/src/index.wyw-in-js.css',
+        source: '.root { color: red; }',
+      },
+    };
+
+    plugin.generateBundle?.(
+      outputOptions as any,
+      bundle as any,
+      false as never
+    );
+
+    expect((bundle['index.js'] as any).code).toContain(
+      '"use strict";require("./index.wyw-in-js.css");'
+    );
+  });
+
+  it('restores nested css requires for preserveModules CommonJS chunks', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      format: 'cjs',
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      createResolver: () => jest.fn().mockResolvedValue(undefined),
+      build: {
+        lib: { entry: '/project/src/index.ts', formats: ['cjs'] },
+        cssCodeSplit: true,
+        rollupOptions: { output: outputOptions },
+      },
+    } as any);
+
+    transformMock.mockResolvedValueOnce({
+      code: 'exports.button = "button";',
+      sourceMap: null,
+      cssText: '.button { color: blue; }',
+      dependencies: [],
+    });
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'exports.button = "button";',
+      '/project/src/nested/button.ts'
+    );
+
+    const bundle = {
+      'nested/button.js': {
+        type: 'chunk',
+        fileName: 'nested/button.js',
+        code: '"use strict";exports.button = "button";\n',
+        facadeModuleId: '/project/src/nested/button.ts',
+      },
+      'nested/button.wyw-in-js.css': {
+        type: 'asset',
+        fileName: 'nested/button.wyw-in-js.css',
+        name: 'src/nested/button.wyw-in-js.css',
+        source: '.button { color: blue; }',
+      },
+    };
+
+    plugin.generateBundle?.(
+      outputOptions as any,
+      bundle as any,
+      false as never
+    );
+
+    expect((bundle['nested/button.js'] as any).code).toContain(
+      'require("./button.wyw-in-js.css");'
+    );
+  });
+
+  it('does not inject css requires when no wyw css asset is emitted for CommonJS chunks', async () => {
+    const { default: wywInJS } = await import('../index');
+
+    const outputOptions = {
+      format: 'cjs',
+      preserveModules: true,
+      preserveModulesRoot: '/project/src',
+    };
+
+    const plugin = wywInJS({ preserveCssPaths: true });
+    plugin.configResolved?.({
+      root: '/project',
+      mode: 'production',
+      command: 'build',
+      base: '/',
+      createResolver: () => jest.fn().mockResolvedValue(undefined),
+      build: {
+        lib: { entry: '/project/src/index.ts', formats: ['cjs'] },
+        cssCodeSplit: true,
+        rollupOptions: { output: outputOptions },
+      },
+    } as any);
+
+    transformMock.mockResolvedValueOnce({
+      code: 'exports.plain = "plain";',
+      sourceMap: null,
+      cssText: '.plain { color: inherit; }',
+      dependencies: [],
+    });
+
+    await plugin.transform?.call(
+      { resolve: jest.fn(), warn: jest.fn() } as any,
+      'exports.plain = "plain";',
+      '/project/src/plain.ts'
+    );
+
+    const bundle = {
+      'plain.js': {
+        type: 'chunk',
+        fileName: 'plain.js',
+        code: '"use strict";exports.plain = "plain";\n',
+        facadeModuleId: '/project/src/plain.ts',
+      },
+    };
+
+    plugin.generateBundle?.(
+      outputOptions as any,
+      bundle as any,
+      false as never
+    );
+
+    expect((bundle['plain.js'] as any).code).toBe(
+      '"use strict";exports.plain = "plain";\n'
+    );
   });
 });

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -52,9 +52,29 @@ type AssetInfoLike = { name?: unknown };
 type AssetFileNames = string | ((assetInfo: AssetInfoLike) => string);
 type RollupOutputLike = {
   assetFileNames?: AssetFileNames;
+  format?: unknown;
   preserveModules?: boolean;
   preserveModulesRoot?: unknown;
 } & Record<string, unknown>;
+
+type OutputAssetLike = {
+  fileName: string;
+  name?: unknown;
+  names?: unknown;
+  originalFileName?: unknown;
+  originalFileNames?: unknown;
+  type: 'asset';
+};
+
+type OutputChunkLike = {
+  code: string;
+  facadeModuleId?: unknown;
+  fileName: string;
+  moduleIds?: unknown;
+  type: 'chunk';
+};
+
+type OutputBundleLike = Record<string, OutputAssetLike | OutputChunkLike>;
 
 type CssReloadTarget = {
   moduleGraph: {
@@ -91,6 +111,186 @@ const normalizeAssetRelativePath = (value: string): string | null => {
 const stripExtension = (value: string): string => {
   const ext = path.posix.extname(value);
   return ext ? value.slice(0, -ext.length) : value;
+};
+
+const getComparableAssetPaths = (
+  value: string,
+  rootDir: string
+): Set<string> => {
+  const variants = new Set<string>();
+  const normalized = normalizeToPosix(value);
+
+  variants.add(normalized);
+
+  if (path.isAbsolute(value) || isWindowsAbsolutePath(normalized)) {
+    if (isInside(value, rootDir)) {
+      const relativeToRoot = normalizeAssetRelativePath(
+        path.relative(rootDir, value)
+      );
+      if (relativeToRoot) {
+        variants.add(relativeToRoot);
+      }
+    }
+
+    return variants;
+  }
+
+  const relativePath = normalizeAssetRelativePath(value);
+  if (relativePath) {
+    variants.add(relativePath);
+  }
+
+  return variants;
+};
+
+const getStringValues = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+
+  return value.filter((item): item is string => typeof item === 'string');
+};
+
+const getOutputAssetNames = (asset: OutputAssetLike): string[] => [
+  ...(typeof asset.name === 'string' ? [asset.name] : []),
+  ...getStringValues(asset.names),
+  ...(typeof asset.originalFileName === 'string'
+    ? [asset.originalFileName]
+    : []),
+  ...getStringValues(asset.originalFileNames),
+];
+
+const isOutputAssetLike = (value: unknown): value is OutputAssetLike =>
+  !!value &&
+  typeof value === 'object' &&
+  (value as { type?: unknown }).type === 'asset' &&
+  typeof (value as { fileName?: unknown }).fileName === 'string';
+
+const isOutputChunkLike = (value: unknown): value is OutputChunkLike =>
+  !!value &&
+  typeof value === 'object' &&
+  (value as { type?: unknown }).type === 'chunk' &&
+  typeof (value as { fileName?: unknown }).fileName === 'string' &&
+  typeof (value as { code?: unknown }).code === 'string';
+
+const getTrackedModuleIdForChunk = (
+  chunk: OutputChunkLike,
+  cssFilesByModuleId: Map<string, string>
+): string | null => {
+  if (
+    typeof chunk.facadeModuleId === 'string' &&
+    cssFilesByModuleId.has(chunk.facadeModuleId)
+  ) {
+    return chunk.facadeModuleId;
+  }
+
+  if (!Array.isArray(chunk.moduleIds)) {
+    return null;
+  }
+
+  const moduleId = chunk.moduleIds.find(
+    (id): id is string => typeof id === 'string' && cssFilesByModuleId.has(id)
+  );
+
+  return moduleId ?? null;
+};
+
+const findWywCssAssetFileName = (
+  bundle: OutputBundleLike,
+  cssFilename: string,
+  rootDir: string
+): string | null => {
+  const expectedNames = getComparableAssetPaths(cssFilename, rootDir);
+
+  for (const item of Object.values(bundle)) {
+    if (isOutputAssetLike(item) && item.fileName.endsWith('.css')) {
+      const isMatch = getOutputAssetNames(item).some((assetName) => {
+        const variants = getComparableAssetPaths(assetName, rootDir);
+        return Array.from(variants).some((variant) =>
+          expectedNames.has(variant)
+        );
+      });
+
+      if (isMatch) {
+        return normalizeToPosix(item.fileName);
+      }
+    }
+  }
+
+  return null;
+};
+
+const getRelativeImportPath = (
+  fromFileName: string,
+  toFileName: string
+): string => {
+  const fromDir = path.posix.dirname(normalizeToPosix(fromFileName));
+  const relativePath = path.posix.relative(
+    fromDir,
+    normalizeToPosix(toFileName)
+  );
+
+  return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
+};
+
+const escapeForRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const hasStaticImport = (code: string, specifier: string): boolean =>
+  new RegExp(
+    `(^|\\n)\\s*import\\s*(?:["']${escapeForRegExp(
+      specifier
+    )}["']|[^\\n;]+\\s+from\\s+["']${escapeForRegExp(specifier)}["'])`,
+    'm'
+  ).test(code);
+
+const hasRequireCall = (code: string, specifier: string): boolean =>
+  new RegExp(
+    `(^|[;\\n])\\s*require\\(\\s*["']${escapeForRegExp(specifier)}["']\\s*\\)`,
+    'm'
+  ).test(code);
+
+const getCssLoadStatement = (format: unknown, specifier: string): string =>
+  format === 'cjs'
+    ? `require(${JSON.stringify(specifier)});\n`
+    : `import ${JSON.stringify(specifier)};\n`;
+
+const hasCssLoadStatement = (
+  code: string,
+  specifier: string,
+  format: unknown
+): boolean =>
+  format === 'cjs'
+    ? hasRequireCall(code, specifier)
+    : hasStaticImport(code, specifier);
+
+const prependCssLoadStatement = (
+  code: string,
+  specifier: string,
+  format: unknown
+): string => {
+  const statement = getCssLoadStatement(format, specifier);
+  let insertAt = 0;
+
+  if (code.startsWith('#!')) {
+    const lineBreakIndex = code.indexOf('\n');
+    if (lineBreakIndex >= 0) {
+      insertAt = lineBreakIndex + 1;
+    } else {
+      return `${code}\n${statement}`;
+    }
+  }
+
+  if (format === 'cjs') {
+    const directiveMatch =
+      /^(?:\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*');)+/.exec(
+        code.slice(insertAt)
+      );
+
+    if (directiveMatch) {
+      insertAt += directiveMatch[0].length;
+    }
+  }
+
+  return `${code.slice(0, insertAt)}${statement}${code.slice(insertAt)}`;
 };
 
 const VITE_FS_PREFIX = '/@fs/';
@@ -261,6 +461,7 @@ export default function wywInJS({
   const filter = createFilter(include, exclude);
   const cssLookup: { [key: string]: string } = {};
   const cssFileLookup: { [key: string]: string } = {};
+  const cssFilesByModuleId = new Map<string, string>();
   const pendingCssReloads = new WeakMap<
     CssReloadTarget,
     { files: Set<string>; timer?: ReturnType<typeof setTimeout> }
@@ -647,6 +848,59 @@ export default function wywInJS({
         .concat(ctx.modules)
         .filter((m): m is ModuleNode => !!m);
     },
+    generateBundle(outputOptions, bundle) {
+      if (config.command !== 'build') return;
+      if (!config.build.lib) return;
+      if (!outputOptions.preserveModules) return;
+      if (config.build.cssCodeSplit === false) return;
+
+      Object.values(bundle as OutputBundleLike).forEach((item) => {
+        if (!isOutputChunkLike(item)) {
+          return;
+        }
+
+        const chunk = item;
+
+        const moduleId = getTrackedModuleIdForChunk(chunk, cssFilesByModuleId);
+        if (!moduleId) {
+          return;
+        }
+
+        const cssFilename = cssFilesByModuleId.get(moduleId);
+        if (!cssFilename) {
+          return;
+        }
+
+        const emittedCssFileName = findWywCssAssetFileName(
+          bundle as OutputBundleLike,
+          cssFilename,
+          config.root
+        );
+        if (!emittedCssFileName) {
+          return;
+        }
+
+        const relativeCssImport = getRelativeImportPath(
+          chunk.fileName,
+          emittedCssFileName
+        );
+        if (
+          hasCssLoadStatement(
+            chunk.code,
+            relativeCssImport,
+            outputOptions.format
+          )
+        ) {
+          return;
+        }
+
+        chunk.code = prependCssLoadStatement(
+          chunk.code,
+          relativeCssImport,
+          outputOptions.format
+        );
+      });
+    },
     async transform(
       code: string,
       url: string,
@@ -711,10 +965,12 @@ export default function wywInJS({
       // 3. cssText is not empty, it means that file was transformed and it contains styles
 
       if (typeof cssText === 'undefined') {
+        cssFilesByModuleId.delete(id);
         return;
       }
 
       if (cssText === '') {
+        cssFilesByModuleId.delete(id);
         /* eslint-disable-next-line consistent-return */
         return {
           code: result.code,
@@ -727,6 +983,7 @@ export default function wywInJS({
       const cssFilename = path
         .normalize(`${id.replace(/\.[jt]sx?$/, '')}.wyw-in-js.css`)
         .replace(/\\/g, path.posix.sep);
+      cssFilesByModuleId.set(id, cssFilename);
 
       const cssRelativePath = path
         .relative(config.root, cssFilename)

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -850,7 +850,6 @@ export default function wywInJS({
     },
     generateBundle(outputOptions, bundle) {
       if (config.command !== 'build') return;
-      if (!config.build.lib) return;
       if (!outputOptions.preserveModules) return;
       if (config.build.cssCodeSplit === false) return;
 


### PR DESCRIPTION
## Summary

Fix preserved-module library output in `@wyw-in-js/vite` so emitted modules keep a valid side-effect link to their matching WyW CSS asset in both ES and CommonJS builds.

## Problem

In Vite library builds with `preserveModules`, WyW-generated CSS assets can still be emitted while the final JavaScript module loses the correct CSS edge.

That leaves preserved output in an inconsistent state:
- the WyW transform ran successfully
- the matching CSS asset exists in the final build output
- the final JS module does not keep a valid link to that CSS asset

This is especially problematic for CommonJS output, where the rewritten chunk can become invalid to load.

## What this changes

- restore the final module-to-CSS edge for preserved-module library output
- keep the emitted link valid for both ES and CommonJS formats
- preserve current `preserveCssPaths` asset layout behavior
- avoid injecting a CSS edge when no matching WyW CSS asset exists

## Validation

- `bun run --filter @wyw-in-js/vite lint`
- `bun run --filter @wyw-in-js/vite test`
- `bun run --filter @wyw-in-js/vite build:types`
- `bun x turbo run build:esm build:lib build:types --filter @wyw-in-js/vite`
- `bun run --filter @wyw-in-js/e2e-vite test`
