### PR TITLE
fix(transform): cheap-gate dependency invalidation by mtime

### DIFF
--- a/.changeset/cheap-mtime-gate.md
+++ b/.changeset/cheap-mtime-gate.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Avoid rereading and rehashing unchanged dependency graphs during entrypoint cache invalidation while preserving stale-dependency detection.

--- a/packages/transform/src/__tests__/cache.test.ts
+++ b/packages/transform/src/__tests__/cache.test.ts
@@ -17,6 +17,7 @@ type MockEntrypoint = {
 };
 
 const mockedReadFileSync = jest.spyOn(fs, 'readFileSync');
+const mockedStatSync = jest.spyOn(fs, 'statSync');
 
 const createErrnoError = (
   code: string,
@@ -53,12 +54,17 @@ const setupCacheWithEntrypoint = (
 describe('TransformCacheCollection', () => {
   afterAll(() => {
     mockedReadFileSync.mockRestore();
+    mockedStatSync.mockRestore();
   });
 
   beforeEach(() => {
     mockedReadFileSync.mockReset();
     mockedReadFileSync.mockImplementation(() => {
       throw new Error('Unexpected readFileSync call.');
+    });
+    mockedStatSync.mockReset();
+    mockedStatSync.mockImplementation(() => {
+      throw createErrnoError('ENOENT');
     });
   });
 
@@ -209,6 +215,48 @@ describe('TransformCacheCollection', () => {
       expect(cache.has('entrypoints', parentName)).toBe(false); // Parent evicted
       expect(cache.has('entrypoints', depName)).toBe(false); // Dependency invalidated
       expect(mockedReadFileSync).toHaveBeenCalledWith(depName, 'utf8');
+    });
+
+    it('does not read unchanged leaf dependency content when mtime is unchanged', () => {
+      const depName = 'dep.js';
+      const depContent = 'export const b = 2;';
+      const parentName = 'parent.js';
+      const parentContent = 'import { b } from "./dep.js"; console.log(b);';
+
+      const { entrypoint: depEntrypoint } = setupCacheWithEntrypoint(
+        depName,
+        depContent
+      );
+
+      const parentDeps = new Map<
+        string,
+        Pick<IEntrypointDependency, 'resolved'>
+      >([['./dep.js', { resolved: depName }]]);
+      const { cache } = setupCacheWithEntrypoint(
+        parentName,
+        parentContent,
+        parentDeps
+      );
+
+      cache.add('entrypoints', depName, depEntrypoint as any);
+
+      mockedStatSync.mockImplementation((path) => {
+        if (path === depName) {
+          return { mtimeMs: 123 } as fs.Stats;
+        }
+
+        throw new Error(`Unexpected statSync call: ${String(path)}`);
+      });
+
+      cache.invalidateIfChanged(depName, depContent, undefined, 'fs');
+
+      const invalidated = cache.invalidateIfChanged(parentName, parentContent);
+
+      expect(invalidated).toBe(false);
+      expect(cache.has('entrypoints', parentName)).toBe(true);
+      expect(cache.has('entrypoints', depName)).toBe(true);
+      expect(mockedReadFileSync).not.toHaveBeenCalledWith(depName, 'utf8');
+      expect(mockedStatSync).toHaveBeenCalledWith(depName);
     });
 
     it('should invalidate parent when an invalidation-only dependency changed', () => {
@@ -714,8 +762,8 @@ describe('TransformCacheCollection', () => {
       expect(cache.has('entrypoints', fileA)).toBe(true);
       expect(cache.has('entrypoints', fileB)).toBe(true);
       expect(mockedReadFileSync).toHaveBeenCalledWith(fileB, 'utf8');
-      expect(mockedReadFileSync).toHaveBeenCalledWith(fileA, 'utf8');
-      expect(mockedReadFileSync).toHaveBeenCalledTimes(2);
+      expect(mockedReadFileSync).not.toHaveBeenCalledWith(fileA, 'utf8');
+      expect(mockedReadFileSync).toHaveBeenCalledTimes(1);
     });
 
     it('should invalidate parent when dependency content changed', () => {
@@ -853,7 +901,7 @@ describe('TransformCacheCollection', () => {
       expect(cache.has('entrypoints', fileB)).toBe(false);
       expect(cache.has('entrypoints', fileA)).toBe(true);
       expect(mockedReadFileSync).toHaveBeenCalledWith(fileA, 'utf8');
-      expect(mockedReadFileSync).toHaveBeenCalledWith(fileB, 'utf8');
+      expect(mockedReadFileSync).not.toHaveBeenCalledWith(fileB, 'utf8');
     });
   });
 

--- a/packages/transform/src/__tests__/stale-dep-watch-cache.test.ts
+++ b/packages/transform/src/__tests__/stale-dep-watch-cache.test.ts
@@ -82,6 +82,98 @@ const createErrnoError = (
 };
 
 describe('stale dependency detection in watch mode', () => {
+  it('invalidates cached prepare entrypoint when only a dependency changes on disk', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-prepare-stale-'));
+    const parentFile = path.join(root, 'parent.ts');
+    const depFile = path.join(root, 'dep.ts');
+
+    fs.writeFileSync(depFile, dedent`export const val = 'old';`);
+    fs.writeFileSync(
+      parentFile,
+      dedent`
+        import { val } from './dep';
+        export const result = val;
+      `
+    );
+
+    const cache = new TransformCacheCollection();
+
+    const depServices = createServices(cache, depFile);
+    const depCode = fs.readFileSync(depFile, 'utf-8');
+    Entrypoint.createRoot(depServices, depFile, ['val'], depCode);
+
+    const parentServices = createServices(cache, parentFile);
+    const parentCode = fs.readFileSync(parentFile, 'utf-8');
+    const firstEntrypoint = Entrypoint.createRoot(
+      parentServices,
+      parentFile,
+      ['result'],
+      parentCode
+    );
+    firstEntrypoint.addDependency({
+      only: ['val'],
+      resolved: depFile,
+      source: './dep',
+    });
+
+    fs.writeFileSync(depFile, dedent`export const val = 'new';`);
+
+    const secondEntrypoint = Entrypoint.createRoot(
+      parentServices,
+      parentFile,
+      ['result'],
+      parentCode
+    );
+
+    expect(secondEntrypoint).not.toBe(firstEntrypoint);
+    expect(secondEntrypoint.generation).toBe(firstEntrypoint.generation + 1);
+    expect(cache.has('entrypoints', depFile)).toBe(false);
+  });
+
+  it('reuses cached prepare entrypoint when dependency is unchanged', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-prepare-fresh-'));
+    const parentFile = path.join(root, 'parent.ts');
+    const depFile = path.join(root, 'dep.ts');
+
+    fs.writeFileSync(depFile, dedent`export const val = 'same';`);
+    fs.writeFileSync(
+      parentFile,
+      dedent`
+        import { val } from './dep';
+        export const result = val;
+      `
+    );
+
+    const cache = new TransformCacheCollection();
+
+    const depServices = createServices(cache, depFile);
+    const depCode = fs.readFileSync(depFile, 'utf-8');
+    Entrypoint.createRoot(depServices, depFile, ['val'], depCode);
+
+    const parentServices = createServices(cache, parentFile);
+    const parentCode = fs.readFileSync(parentFile, 'utf-8');
+    const firstEntrypoint = Entrypoint.createRoot(
+      parentServices,
+      parentFile,
+      ['result'],
+      parentCode
+    );
+    firstEntrypoint.addDependency({
+      only: ['val'],
+      resolved: depFile,
+      source: './dep',
+    });
+
+    const secondEntrypoint = Entrypoint.createRoot(
+      parentServices,
+      parentFile,
+      ['result'],
+      parentCode
+    );
+
+    expect(secondEntrypoint).toBe(firstEntrypoint);
+  });
+
   it('getEntrypoint detects stale evaluated entrypoint when file changed on disk', () => {
     // Directly tests the getEntrypoint short-circuit at module.ts:477.
     // When an entrypoint is cached as evaluated with sufficient evaluatedOnly,

--- a/packages/transform/src/cache.ts
+++ b/packages/transform/src/cache.ts
@@ -218,63 +218,18 @@ export class TransformCacheCollection<
       visitedFiles.add(filename);
       const invalidateOnDependencyChange =
         fileEntrypoint?.invalidateOnDependencyChange;
-
-      const dependenciesToCheck = new Map<
-        string,
-        { resolved: string | null }
-      >();
-
-      for (const [key, dependency] of fileEntrypoint?.dependencies ?? []) {
-        dependenciesToCheck.set(key, dependency);
-      }
-
-      for (const [
-        key,
-        dependency,
-      ] of fileEntrypoint?.invalidationDependencies ?? []) {
-        if (!dependenciesToCheck.has(key)) {
-          dependenciesToCheck.set(key, dependency);
-        }
-      }
-
-      for (const dependencyFilename of this.getCachedDependencies(filename)) {
-        if (
-          ![...dependenciesToCheck.values()].some(
-            (dependency) => dependency.resolved === dependencyFilename
-          )
-        ) {
-          dependenciesToCheck.set(dependencyFilename, {
-            resolved: dependencyFilename,
-          });
-        }
-      }
+      const dependenciesToCheck = this.getDependenciesToCheck(
+        filename,
+        fileEntrypoint
+      );
 
       for (const [, dependency] of dependenciesToCheck) {
         const dependencyFilename = dependency.resolved;
 
         if (dependencyFilename) {
-          let dependencyContent: string;
-          try {
-            dependencyContent = fs.readFileSync(
-              stripQueryAndHash(dependencyFilename),
-              'utf8'
-            );
-          } catch (error) {
-            if (!isMissingFileError(error)) {
-              throw error;
-            }
-
-            this.invalidateForFile(dependencyFilename);
-            anyDepChanged = true;
-            // eslint-disable-next-line no-continue
-            continue;
-          }
-
-          const dependencyChanged = this.invalidateIfChanged(
+          const dependencyChanged = this.didDependencyChange(
             dependencyFilename,
-            dependencyContent,
             visitedFiles,
-            'fs',
             changedFiles
           );
 
@@ -335,6 +290,130 @@ export class TransformCacheCollection<
     }
 
     return false;
+  }
+
+  private getDependenciesToCheck(
+    filename: string,
+    fileEntrypoint?: TEntrypoint
+  ): Map<string, { resolved: string | null }> {
+    const dependenciesToCheck = new Map<string, { resolved: string | null }>();
+
+    for (const [key, dependency] of fileEntrypoint?.dependencies ?? []) {
+      dependenciesToCheck.set(key, dependency);
+    }
+
+    for (const [key, dependency] of fileEntrypoint?.invalidationDependencies ??
+      []) {
+      if (!dependenciesToCheck.has(key)) {
+        dependenciesToCheck.set(key, dependency);
+      }
+    }
+
+    for (const dependencyFilename of this.getCachedDependencies(filename)) {
+      if (
+        ![...dependenciesToCheck.values()].some(
+          (dependency) => dependency.resolved === dependencyFilename
+        )
+      ) {
+        dependenciesToCheck.set(dependencyFilename, {
+          resolved: dependencyFilename,
+        });
+      }
+    }
+
+    return dependenciesToCheck;
+  }
+
+  private didDependencyChange(
+    dependencyFilename: string,
+    visitedFiles: Set<string>,
+    changedFiles: Set<string>
+  ): boolean {
+    if (changedFiles.has(dependencyFilename)) {
+      return true;
+    }
+
+    if (visitedFiles.has(dependencyFilename)) {
+      return false;
+    }
+
+    const strippedDependencyFilename = stripQueryAndHash(dependencyFilename);
+    const cachedMtime = this.fileMtimes.get(dependencyFilename);
+    const cachedEntrypoint = this.get('entrypoints', dependencyFilename);
+
+    if (cachedMtime !== undefined) {
+      let currentMtime: number;
+
+      try {
+        currentMtime = fs.statSync(strippedDependencyFilename).mtimeMs;
+      } catch (error) {
+        if (!isMissingFileError(error)) {
+          throw error;
+        }
+
+        this.invalidateForFile(dependencyFilename);
+        changedFiles.add(dependencyFilename);
+        return true;
+      }
+
+      if (currentMtime === cachedMtime) {
+        const nestedDependencies = this.getDependenciesToCheck(
+          dependencyFilename,
+          cachedEntrypoint
+        );
+
+        // A cached file without a cached entrypoint was invalidated earlier.
+        if (!cachedEntrypoint && nestedDependencies.size === 0) {
+          return true;
+        }
+
+        if (nestedDependencies.size === 0) {
+          return false;
+        }
+
+        const nextVisitedFiles = new Set(visitedFiles);
+        nextVisitedFiles.add(dependencyFilename);
+
+        for (const [, nestedDependency] of nestedDependencies) {
+          if (
+            nestedDependency.resolved &&
+            this.didDependencyChange(
+              nestedDependency.resolved,
+              nextVisitedFiles,
+              changedFiles
+            )
+          ) {
+            this.invalidateForFile(dependencyFilename);
+            changedFiles.add(dependencyFilename);
+            return true;
+          }
+        }
+
+        return false;
+      }
+    }
+
+    let dependencyContent: string;
+
+    try {
+      dependencyContent = fs.readFileSync(strippedDependencyFilename, 'utf8');
+    } catch (error) {
+      if (!isMissingFileError(error)) {
+        throw error;
+      }
+
+      this.invalidateForFile(dependencyFilename);
+      changedFiles.add(dependencyFilename);
+      return true;
+    }
+
+    return this.invalidateIfChanged(
+      dependencyFilename,
+      dependencyContent,
+      visitedFiles,
+      'fs',
+      changedFiles
+    );
   }
 
   public setCacheDependencies(


### PR DESCRIPTION
## Summary
This keeps the current stale-dependency correctness contract, but removes the expensive part of cache invalidation for unchanged files.

## Root cause
TransformCacheCollection.invalidateIfChanged() recursively reread and rehashed every cached dependency while createEntrypoint() was revalidating filesystem-backed entrypoints. On large graphs this turned cache hits into repeated full-graph disk walks and caused multi-x slowdowns reported after upgrading from 1.0.6.

## What changed
- check dependency freshness through cached mtimes before reading file contents
- recurse into dependency graphs only when a dependency mtime changed or the file disappeared
- keep the existing invalidation semantics for dependency-only changes, transitive chains, cycles, query/hash stripping, and missing-file invalidation
- add regressions for unchanged leaf deps and prepare-cache dependency-only invalidation

## Impact
Unchanged dependency graphs stop paying the full reread/rehash cost on every filesystem-backed entrypoint revalidation, while stale-dependency detection stays intact.

## Validation
- bun test src