### PR TITLE
feat(transform): add Oxc config foundation

### DIFF
--- a/.changeset/oxc-config-foundation.md
+++ b/.changeset/oxc-config-foundation.md
@@ -1,0 +1,8 @@
+---
+'@wyw-in-js/shared': patch
+'@wyw-in-js/transform': patch
+---
+
+Add the public Oxc configuration foundation without changing the current Babel-backed runtime path.
+
+This introduces `oxcOptions`, per-rule `EvalRule.oxcOptions`, and the opt-in `hybrid` eval resolver mode contract. The default resolver remains `bundler`, and the new hybrid resolver strategy is scaffolded for later Oxc parser/evaluator cutover work.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,7 @@ export type {
   ImportLoaders,
   ImportOverride,
   ImportOverrides,
+  OxcOptions,
   TagResolverMeta,
   StrictOptions,
   EvalRule,

--- a/packages/shared/src/options/types.ts
+++ b/packages/shared/src/options/types.ts
@@ -1,4 +1,4 @@
-import type { TransformOptions } from '@babel/core';
+import type { TransformOptions as BabelTransformOptions } from '@babel/core';
 import type { File } from '@babel/types';
 
 import type { IVariableContext } from '../IVariableContext';
@@ -34,7 +34,7 @@ export type EvaluatorConfig = {
 };
 
 export type Evaluator = (
-  evalConfig: TransformOptions,
+  evalConfig: BabelTransformOptions,
   ast: File,
   code: string,
   config: EvaluatorConfig,
@@ -48,7 +48,17 @@ export type Evaluator = (
 
 export type EvalRule = {
   action: Evaluator | 'ignore' | string;
-  babelOptions?: TransformOptions;
+  /**
+   * @deprecated Use `oxcOptions` for the Oxc-first transform path. Babel
+   * options are kept for the current Babel-backed implementation until the
+   * evaluator cutover is complete.
+   */
+  babelOptions?: BabelTransformOptions;
+  /**
+   * Per-rule Oxc options for the Oxc-first transform path. Kept inert until
+   * the evaluator/parser cutover wires Oxc execution in later slices.
+   */
+  oxcOptions?: OxcOptions;
   test?: RegExp | ((path: string, code: string) => boolean);
 };
 
@@ -111,7 +121,7 @@ export type ImportLoader =
 
 export type ImportLoaders = Record<string, ImportLoader | false>;
 
-export type EvalResolverMode = 'bundler' | 'node' | 'custom';
+export type EvalResolverMode = 'bundler' | 'hybrid' | 'node' | 'custom';
 
 export type EvalRequireMode = 'warn-and-run' | 'error' | 'off';
 
@@ -136,7 +146,11 @@ export type EvalWarning = {
 };
 
 export type EvalOptionsV2 = {
-  resolver?: EvalResolverMode; // default: 'bundler'
+  /**
+   * Default is `bundler`. `hybrid` is an opt-in mode whose intended
+   * precedence is customResolver -> safe Oxc subset -> bundler -> node.
+   */
+  resolver?: EvalResolverMode;
   customResolver?: (
     specifier: string,
     importer: string,
@@ -174,8 +188,30 @@ export type CodeRemoverOptions = {
   hocs?: Record<string, string[]>;
 };
 
+export type OxcOptions = {
+  /**
+   * Parser-level Oxc options. The first slice only preserves this contract.
+   */
+  parser?: Record<string, unknown>;
+  /**
+   * Resolver-level Oxc options. Bundler-aware resolution remains authoritative
+   * unless `eval.resolver` explicitly opts into `hybrid`.
+   */
+  resolver?: Record<string, unknown>;
+  /**
+   * Transform-level Oxc options. Babel options remain supported for the
+   * current compatibility path until cutover.
+   */
+  transform?: Record<string, unknown>;
+};
+
 export type StrictOptions = {
-  babelOptions: TransformOptions;
+  /**
+   * @deprecated Use `oxcOptions` for the Oxc-first transform path. Babel
+   * options are kept for the current Babel-backed implementation until the
+   * evaluator cutover is complete.
+   */
+  babelOptions: BabelTransformOptions;
   classNameSlug?: string | ClassNameFn;
   codeRemover?: CodeRemoverOptions;
   conditionNames?: string[];
@@ -193,6 +229,11 @@ export type StrictOptions = {
     context: Partial<VmContext>,
     filename: string
   ) => Partial<VmContext>;
+  /**
+   * Oxc-first transform options. This is preserved beside `babelOptions` in
+   * the foundation slice and becomes authoritative after the Oxc cutover.
+   */
+  oxcOptions: OxcOptions;
   rules: EvalRule[];
   tagResolver?: (
     source: string,

--- a/packages/transform/src/__tests__/loadWywOptions.test.ts
+++ b/packages/transform/src/__tests__/loadWywOptions.test.ts
@@ -11,6 +11,42 @@ describe('loadWywOptions', () => {
     process.chdir(initialCwd);
   });
 
+  it('keeps bundler resolution as the default and preserves Oxc options', () => {
+    const oxcOptions = {
+      parser: { sourceType: 'module' },
+      resolver: { conditionNames: ['import', 'default'] },
+      transform: { jsx: 'automatic' },
+    };
+
+    const options = loadWywOptions({
+      configFile: false,
+      oxcOptions,
+      rules: [
+        {
+          action: 'ignore',
+          oxcOptions,
+        },
+      ],
+    });
+
+    expect(options.eval?.resolver).toBe('bundler');
+    expect(options.oxcOptions).toBe(oxcOptions);
+    expect(options.rules[0].oxcOptions).toBe(oxcOptions);
+  });
+
+  it('accepts hybrid resolver mode without changing the default', () => {
+    const defaultOptions = loadWywOptions({ configFile: false });
+    const hybridOptions = loadWywOptions({
+      configFile: false,
+      eval: {
+        resolver: 'hybrid',
+      },
+    });
+
+    expect(defaultOptions.eval?.resolver).toBe('bundler');
+    expect(hybridOptions.eval?.resolver).toBe('hybrid');
+  });
+
   it('autodiscovers wyw-in-js.config.mjs files', () => {
     const root = mkdtempSync(path.join(tmpdir(), 'wyw-options-'));
     const configFile = path.join(root, 'wyw-in-js.config.mjs');

--- a/packages/transform/src/__tests__/resolverStrategy.test.ts
+++ b/packages/transform/src/__tests__/resolverStrategy.test.ts
@@ -1,0 +1,80 @@
+import {
+  classifyHybridResolverSpecifier,
+  defaultBundlerOwnedSpecifierPrefixes,
+  getResolverPrecedence,
+} from '../eval/resolverStrategy';
+
+describe('resolverStrategy', () => {
+  it('documents resolver precedence without changing bundler default behavior', () => {
+    expect(getResolverPrecedence('bundler')).toEqual([
+      'customResolver',
+      'bundlerResolver',
+      'nodeFallback',
+    ]);
+
+    expect(getResolverPrecedence('hybrid')).toEqual([
+      'customResolver',
+      'safeOxcResolver',
+      'bundlerResolver',
+      'nodeFallback',
+    ]);
+
+    expect(getResolverPrecedence('custom')).toEqual(['customResolver']);
+    expect(getResolverPrecedence('node')).toEqual(['nodeFallback']);
+  });
+
+  it.each(defaultBundlerOwnedSpecifierPrefixes)(
+    'routes bundler-owned prefix %s to the bundler resolver',
+    (prefix) => {
+      expect(classifyHybridResolverSpecifier(`${prefix}module`)).toEqual({
+        reason: 'bundler-owned-prefix',
+        route: 'bundler',
+      });
+    }
+  );
+
+  it('routes query and hash specifiers to the bundler resolver', () => {
+    expect(classifyHybridResolverSpecifier('./asset.svg?raw')).toEqual({
+      reason: 'query-or-hash',
+      route: 'bundler',
+    });
+
+    expect(classifyHybridResolverSpecifier('./asset.svg#icon')).toEqual({
+      reason: 'query-or-hash',
+      route: 'bundler',
+    });
+  });
+
+  it('routes relative specifiers to the Oxc-safe subset', () => {
+    expect(classifyHybridResolverSpecifier('./tokens')).toEqual({
+      reason: 'safe-relative-specifier',
+      route: 'oxc',
+    });
+
+    expect(classifyHybridResolverSpecifier('../tokens')).toEqual({
+      reason: 'safe-relative-specifier',
+      route: 'oxc',
+    });
+  });
+
+  it.each(['@scope/pkg', 'react', '#internal', '/src/app'])(
+    'routes ambiguous specifier %s to the bundler resolver',
+    (specifier) => {
+      expect(classifyHybridResolverSpecifier(specifier)).toEqual({
+        reason: 'ambiguous-specifier',
+        route: 'bundler',
+      });
+    }
+  );
+
+  it('allows projects to mark additional prefixes as bundler-owned', () => {
+    expect(
+      classifyHybridResolverSpecifier('@app/virtual-entry', {
+        bundlerOwnedPrefixes: ['@app/'],
+      })
+    ).toEqual({
+      reason: 'bundler-owned-prefix',
+      route: 'bundler',
+    });
+  });
+});

--- a/packages/transform/src/eval/resolverStrategy.ts
+++ b/packages/transform/src/eval/resolverStrategy.ts
@@ -1,0 +1,80 @@
+import type { EvalResolverMode } from '@wyw-in-js/shared';
+
+export type HybridResolverRoute = 'bundler' | 'oxc';
+
+export type HybridResolverReason =
+  | 'ambiguous-specifier'
+  | 'bundler-owned-prefix'
+  | 'query-or-hash'
+  | 'safe-relative-specifier';
+
+export type HybridResolverDecision = {
+  reason: HybridResolverReason;
+  route: HybridResolverRoute;
+};
+
+export type HybridResolverClassifierOptions = {
+  bundlerOwnedPrefixes?: readonly string[];
+};
+
+export const defaultBundlerOwnedSpecifierPrefixes = [
+  '\0',
+  '/@',
+  'virtual:',
+] as const;
+
+export const getResolverPrecedence = (
+  mode: EvalResolverMode
+): readonly string[] => {
+  if (mode === 'hybrid') {
+    return [
+      'customResolver',
+      'safeOxcResolver',
+      'bundlerResolver',
+      'nodeFallback',
+    ];
+  }
+
+  if (mode === 'bundler') {
+    return ['customResolver', 'bundlerResolver', 'nodeFallback'];
+  }
+
+  if (mode === 'custom') {
+    return ['customResolver'];
+  }
+
+  return ['nodeFallback'];
+};
+
+export const classifyHybridResolverSpecifier = (
+  specifier: string,
+  {
+    bundlerOwnedPrefixes = defaultBundlerOwnedSpecifierPrefixes,
+  }: HybridResolverClassifierOptions = {}
+): HybridResolverDecision => {
+  if (bundlerOwnedPrefixes.some((prefix) => specifier.startsWith(prefix))) {
+    return {
+      reason: 'bundler-owned-prefix',
+      route: 'bundler',
+    };
+  }
+
+  if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+    return {
+      reason: 'ambiguous-specifier',
+      route: 'bundler',
+    };
+  }
+
+  if (/[?#]/.test(specifier)) {
+    return {
+      reason: 'query-or-hash',
+      route: 'bundler',
+    };
+  }
+
+  return {
+    reason: 'safe-relative-specifier',
+    route: 'oxc',
+  };
+};

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -28,7 +28,7 @@ export {
   UnprocessedEntrypointError,
 } from './transform/actions/UnprocessedEntrypointError';
 export * from './types';
-export type { PluginOptions, Preprocessor } from './types';
+export type { PluginOptions, Preprocessor, Result } from './types';
 export { EvaluatedEntrypoint } from './transform/EvaluatedEntrypoint';
 export type { IEvaluatedEntrypoint } from './transform/EvaluatedEntrypoint';
 export { parseFile } from './transform/Entrypoint.helpers';

--- a/packages/transform/src/transform/helpers/loadWywOptions.ts
+++ b/packages/transform/src/transform/helpers/loadWywOptions.ts
@@ -137,6 +137,7 @@ export function loadWywOptions(
     ignore,
     rules,
     babelOptions = {},
+    oxcOptions = {},
     importLoaders: overridesImportLoaders,
     ...rest
   } = overrides;
@@ -199,6 +200,7 @@ export function loadWywOptions(
     ],
     babelOptions,
     highPriorityPlugins: ['module-resolver'],
+    oxcOptions,
     ...config,
     ...rest,
     eval: {

--- a/packages/transform/src/transform/syntax.ts
+++ b/packages/transform/src/transform/syntax.ts
@@ -1,0 +1,54 @@
+export type SyntaxEngine = 'babel' | 'oxc';
+
+export type SyntaxSourceLocation = {
+  column: number;
+  line: number;
+};
+
+export type SyntaxSourceRange = {
+  end: SyntaxSourceLocation;
+  start: SyntaxSourceLocation;
+};
+
+export type ParsedModule<TAst = unknown> = {
+  ast: TAst;
+  code: string;
+  engine: SyntaxEngine;
+  filename: string;
+};
+
+export type ModuleImport = {
+  imported: string;
+  source: string;
+};
+
+export type ModuleReexport = {
+  exported: string;
+  source: string;
+};
+
+export type ModuleAnalysis = {
+  exports: readonly string[];
+  imports: readonly ModuleImport[];
+  reexports: readonly ModuleReexport[];
+};
+
+export type EmittedModule<TSourceMap = unknown> = {
+  code: string;
+  map?: TSourceMap | null;
+};
+
+export type SyntaxAdapter<
+  TAst = unknown,
+  TParseOptions = unknown,
+  TEmitOptions = unknown,
+> = {
+  engine: SyntaxEngine;
+  analyze(module: ParsedModule<TAst>): ModuleAnalysis;
+  emit(module: ParsedModule<TAst>, options?: TEmitOptions): EmittedModule;
+  parse(
+    code: string,
+    filename: string,
+    options?: TParseOptions
+  ): ParsedModule<TAst>;
+};

--- a/packages/transform/src/utils/resolveWithConditions.ts
+++ b/packages/transform/src/utils/resolveWithConditions.ts
@@ -15,6 +15,11 @@ type ResolveFilenameModuleImplementation = {
   ) => string;
 };
 
+type NodeConditionalResolveResult = {
+  error?: { code?: string; message: string };
+  resolved?: string;
+};
+
 const NODE_CONDITIONAL_RESOLVE_SCRIPT = String.raw`
 const fs = require('node:fs');
 const Module = require('node:module');
@@ -72,16 +77,11 @@ const resolveWithNodeProcess = (
     throw result.error;
   }
 
-  type ResolveResultPayload = {
-    error?: { code?: string; message: string };
-    resolved?: string;
-  };
-
-  let parsed: ResolveResultPayload | null = null;
+  let parsed: NodeConditionalResolveResult | null = null;
   const stdout = result.stdout.trim();
   if (stdout) {
     try {
-      parsed = JSON.parse(stdout) as ResolveResultPayload;
+      parsed = JSON.parse(stdout) as NodeConditionalResolveResult;
     } catch {
       throw new Error(
         [

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -24,6 +24,7 @@ import type {
   Preprocessor,
   Result as TransformResult,
   TransformCacheCollection as TransformCacheCollectionType,
+  WYWTransformDiagnostic,
 } from '@wyw-in-js/transform';
 import * as transformPkg from '@wyw-in-js/transform';
 
@@ -1086,7 +1087,7 @@ export default function wywInJS({
         asyncResolve
       );
 
-      result.diagnostics?.forEach((diagnostic) => {
+      result.diagnostics?.forEach((diagnostic: WYWTransformDiagnostic) => {
         this.warn({
           id: diagnostic.filename,
           loc: diagnostic.start


### PR DESCRIPTION
## Summary

Adds the first Oxc migration foundation slice without changing the current Babel-backed runtime path.

- Adds the public `oxcOptions` contract beside existing `babelOptions`, including per-rule `EvalRule.oxcOptions`.
- Adds opt-in `eval.resolver: 'hybrid'` while keeping `bundler` as the default resolver mode.
- Scaffolds the internal hybrid resolver strategy so bundler-owned, query/hash, bare, root-absolute, and ambiguous specifiers remain bundler-authoritative.
- Adds internal syntax abstraction seams (`SyntaxAdapter`, `ParsedModule`, `ModuleAnalysis`) for later parser/evaluator cutover work.
- Adds a changeset for `@wyw-in-js/shared` and `@wyw-in-js/transform`.

## Validation

- `bun run --filter @wyw-in-js/shared build:types`
- `bun run --filter @wyw-in-js/transform build:types`
- `bun test packages/transform/src/__tests__/loadWywOptions.test.ts packages/transform/src/__tests__/resolverStrategy.test.ts`
- `bun test packages/transform/src/__tests__/module.test.ts -t "ESM resolver order"`
- `git diff --check`

## Notes

A full `bun run --filter @wyw-in-js/transform test` run still reports existing `conditionNames` failures unrelated to this config/scaffold slice. The targeted resolver contract tests above pass.
