### PR TITLE
fix(transform): redirect vm context console to stderr with tagged prefixes

### DIFF
--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -2,6 +2,7 @@
 /* global BigInt */
 import fs from 'node:fs';
 import { Console } from 'node:console';
+import { Writable } from 'node:stream';
 import vm from 'node:vm';
 import path from 'node:path';
 import NativeModule, { createRequire } from 'node:module';
@@ -43,11 +44,20 @@ class LruCache {
 const NOOP = () => {};
 
 // stdout is reserved for the JSON IPC protocol; host-side logs must not share it.
-const runnerConsole = new Console({
-  stdout: process.stderr,
-  stderr: process.stderr,
+const prefixStream = (getPrefix) =>
+  new Writable({
+    write(chunk, _enc, cb) {
+      const p = getPrefix();
+      const s = chunk.toString();
+      process.stderr.write(p + s.replaceAll('\n', '\n' + p), cb);
+    },
+  });
+
+// require'd modules outside vm use host console — must not write to stdout (IPC channel).
+global.console = new Console({
+  stdout: prefixStream(() => '[wyw-runner:host stdout] '),
+  stderr: prefixStream(() => '[wyw-runner:host stderr] '),
 });
-global.console = runnerConsole;
 
 const VITE_VIRTUAL_PREFIX = '/@';
 const REACT_REFRESH_VIRTUAL_ID = '/@react-refresh';
@@ -736,6 +746,12 @@ const createVmContext = async (filename, features, globals) => {
     __filename: filename,
     ...envContext,
     ...globals,
+  });
+  // Evaluated code must never write to stdout — it is the IPC channel.
+  const vmIdent = () => `vm(${path.basename(baseContext.__filename ?? '?')})`;
+  baseContext.console = new Console({
+    stdout: prefixStream(() => `[wyw-runner:${vmIdent()} stdout] `),
+    stderr: prefixStream(() => `[wyw-runner:${vmIdent()} stderr] `),
   });
   const context = vm.createContext(baseContext);
   return {


### PR DESCRIPTION
Upstream (https://github.com/Anber/wyw-in-js/commit/78932ed34b3c545498eee3f2d31e770946f99979) redirected host-side `global.console` to stderr,
preventing require'd modules from corrupting the JSON IPC channel on
stdout. However, code evaluated inside the vm sandbox (`vm.createContext`)
still inherited the original `console` bound to `process.stdout`. Any
`console.log()` in evaluated CSS-in-JS files (or their transitive
imports resolved inside the vm) would inject arbitrary text into the
JSON-line IPC protocol, causing "Failed to parse message" errors in
the broker's line-buffered parser.

This was the root cause of intermittent IPC corruption on large projects
where theme files or utility modules contained debug logging — the
broker would see a partial JSON line interleaved with console output.

Changes:
- Inject a tagged `Console` into `baseContext` in `createVmContext()`,
  so the vm sandbox console writes to stderr, not stdout.
- Replace the plain stderr redirect with `prefixStream` — a thin
  Writable wrapper that prepends a tag to every line, making it
  trivial to distinguish host vs vm output and identify the source file:
    [wyw-runner:host stdout] ...        — require'd modules outside vm
    [wyw-runner:vm(Button.tsx) stdout] ... — evaluated code inside vm
- The vm prefix reads `baseContext.__filename` dynamically via a getter,
  so it stays correct when the context is reused across INIT cycles
  with different entrypoints (canReuseContext path).