### PR TITLE
fix(webpack-loader): stabilize resolver scope for async eval

### DIFF
--- a/packages/transform/src/__tests__/transform.async-resolve-key.test.ts
+++ b/packages/transform/src/__tests__/transform.async-resolve-key.test.ts
@@ -1,0 +1,136 @@
+const getEvalBrokerMock = jest.fn();
+const createRootMock = jest.fn();
+const asyncActionRunnerMock = jest.fn();
+
+jest.mock('../eval/broker', () => ({
+  __esModule: true,
+  getEvalBroker: (...args: unknown[]) => getEvalBrokerMock(...args),
+}));
+
+jest.mock('../transform/Entrypoint', () => ({
+  __esModule: true,
+  Entrypoint: {
+    createRoot: (...args: unknown[]) => createRootMock(...args),
+  },
+}));
+
+jest.mock('../transform/actions/actionRunner', () => ({
+  __esModule: true,
+  asyncActionRunner: (...args: unknown[]) => asyncActionRunnerMock(...args),
+}));
+
+jest.mock('../transform/generators', () => ({
+  __esModule: true,
+  baseHandlers: {},
+}));
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+
+describe('transform asyncResolveKey', () => {
+  beforeEach(() => {
+    getEvalBrokerMock.mockReset().mockReturnValue(undefined);
+    asyncActionRunnerMock.mockReset().mockResolvedValue({
+      code: 'module.exports = 1;',
+      sourceMap: null,
+    });
+    createRootMock.mockReset().mockImplementation((_services, filename) => ({
+      createAction: jest.fn(() => ({})),
+      ignored: false,
+      log: jest.fn(),
+      name: filename,
+    }));
+  });
+
+  it('keeps eval cache key stable when asyncResolveKey stays the same', async () => {
+    const cache = new TransformCacheCollection();
+    const cachedEntrypoint = {
+      dependencies: new Map<string, { resolved: string | null }>(),
+    };
+    const asyncResolveA = async () => null;
+    const asyncResolveB = async () => null;
+
+    await transform(
+      {
+        asyncResolveKey: 'webpack:compiler-a',
+        cache,
+        options: {
+          filename: '/abs/entry-a.tsx',
+          root: '/abs',
+          pluginOptions: {
+            configFile: false,
+          },
+        },
+      },
+      'export default 1;',
+      asyncResolveA
+    );
+
+    const firstKey = getEvalBrokerMock.mock.calls[0][2];
+    cache.add('entrypoints', '/abs/shared.ts', cachedEntrypoint);
+
+    await transform(
+      {
+        asyncResolveKey: 'webpack:compiler-a',
+        cache,
+        options: {
+          filename: '/abs/entry-b.tsx',
+          root: '/abs',
+          pluginOptions: {
+            configFile: false,
+          },
+        },
+      },
+      'export default 1;',
+      asyncResolveB
+    );
+
+    expect(getEvalBrokerMock.mock.calls[1][2]).toBe(firstKey);
+    expect(cache.get('entrypoints', '/abs/shared.ts')).toBe(cachedEntrypoint);
+  });
+
+  it('separates eval cache key when asyncResolveKey changes', async () => {
+    const cache = new TransformCacheCollection();
+    const cachedEntrypoint = {
+      dependencies: new Map<string, { resolved: string | null }>(),
+    };
+
+    await transform(
+      {
+        asyncResolveKey: 'webpack:compiler-a',
+        cache,
+        options: {
+          filename: '/abs/entry-a.tsx',
+          root: '/abs',
+          pluginOptions: {
+            configFile: false,
+          },
+        },
+      },
+      'export default 1;',
+      async () => null
+    );
+
+    const firstKey = getEvalBrokerMock.mock.calls[0][2];
+    cache.add('entrypoints', '/abs/shared.ts', cachedEntrypoint);
+
+    await transform(
+      {
+        asyncResolveKey: 'webpack:compiler-b',
+        cache,
+        options: {
+          filename: '/abs/entry-b.tsx',
+          root: '/abs',
+          pluginOptions: {
+            configFile: false,
+          },
+        },
+      },
+      'export default 1;',
+      async () => null
+    );
+
+    expect(getEvalBrokerMock.mock.calls[1][2]).not.toBe(firstKey);
+    expect(cache.get('entrypoints', '/abs/shared.ts')).toBeUndefined();
+  });
+});

--- a/packages/transform/src/transform.ts
+++ b/packages/transform/src/transform.ts
@@ -79,6 +79,7 @@ const canonicalizeForHash = (value: unknown): unknown => {
 
 const getEvalCacheKey = (
   pluginOptions: ReturnType<typeof loadWywOptions>,
+  asyncResolveKey: string | undefined,
   asyncResolve: (
     what: string,
     importer: string,
@@ -93,7 +94,10 @@ const getEvalCacheKey = (
     globals: canonicalizeForHash(encodeGlobals(evalOptions.globals ?? {})),
     customResolver: getResolverId(evalOptions.customResolver),
     customLoader: getResolverId(evalOptions.customLoader),
-    bundlerResolver: getResolverId(asyncResolve),
+    // Bundlers like webpack can recreate transport resolvers per file. Allow
+    // them to provide a stable scope key so cache/broker reuse tracks resolver
+    // semantics instead of closure identity.
+    bundlerResolver: asyncResolveKey ?? getResolverId(asyncResolve),
     overrideContext: getResolverId(pluginOptions.overrideContext),
     importOverrides: pluginOptions.importOverrides ?? null,
     extensions: pluginOptions.extensions,
@@ -145,7 +149,11 @@ export async function transform(
     services.cache = new TransformCacheCollection();
   }
 
-  const evalCacheKey = getEvalCacheKey(pluginOptions, asyncResolve);
+  const evalCacheKey = getEvalCacheKey(
+    pluginOptions,
+    services.asyncResolveKey,
+    asyncResolve
+  );
   services.cache.setKeySalt(evalCacheKey);
   services.asyncResolve = asyncResolve;
   services.evalBroker = getEvalBroker(services, asyncResolve, evalCacheKey);

--- a/packages/transform/src/transform/helpers/withDefaultServices.ts
+++ b/packages/transform/src/transform/helpers/withDefaultServices.ts
@@ -18,6 +18,7 @@ export const withDefaultServices = ({
   loadAndParseFn = loadAndParse,
   log = rootLog,
   options,
+  asyncResolveKey,
 }: PartialServices): Services => ({
   babel,
   cache,
@@ -26,4 +27,5 @@ export const withDefaultServices = ({
   loadAndParseFn,
   log,
   options,
+  asyncResolveKey,
 });

--- a/packages/transform/src/transform/types.ts
+++ b/packages/transform/src/transform/types.ts
@@ -34,6 +34,7 @@ export type Services = {
     importer: string,
     stack: string[]
   ) => Promise<string | null>;
+  asyncResolveKey?: string;
   evalBroker?: EvalBroker;
 };
 

--- a/packages/transform/src/utils/resolveWithConditions.ts
+++ b/packages/transform/src/utils/resolveWithConditions.ts
@@ -72,14 +72,16 @@ const resolveWithNodeProcess = (
     throw result.error;
   }
 
-  let parsed: {
+  type ResolveResultPayload = {
     error?: { code?: string; message: string };
     resolved?: string;
-  } | null = null;
+  };
+
+  let parsed: ResolveResultPayload | null = null;
   const stdout = result.stdout.trim();
   if (stdout) {
     try {
-      parsed = JSON.parse(stdout) as typeof parsed;
+      parsed = JSON.parse(stdout) as ResolveResultPayload;
     } catch {
       throw new Error(
         [

--- a/packages/webpack-loader/src/__tests__/resource-query.test.ts
+++ b/packages/webpack-loader/src/__tests__/resource-query.test.ts
@@ -18,6 +18,28 @@ jest.mock('@wyw-in-js/transform', () => ({
   disposeEvalBroker: jest.fn(),
 }));
 
+const createHook = <TArgs extends unknown[]>() => {
+  const handlers: Array<(...args: TArgs) => void> = [];
+
+  return {
+    call: (...args: TArgs) => {
+      handlers.forEach((handler) => handler(...args));
+    },
+    tap: (_name: string, handler: (...args: TArgs) => void) => {
+      handlers.push(handler);
+    },
+  };
+};
+
+const createCompiler = () => ({
+  hooks: {
+    done: createHook<[unknown]>(),
+    failed: createHook<[Error]>(),
+    shutdown: createHook<[]>(),
+    watchClose: createHook<[]>(),
+  },
+});
+
 describe('webpack-loader asyncResolve', () => {
   beforeEach(() => {
     transformMock.mockReset();
@@ -100,8 +122,64 @@ describe('webpack-loader asyncResolve', () => {
     expect(addDependency).toHaveBeenCalledWith(resolved);
   });
 
-  it('falls back to the current loader resolver when the stacked root resolver is gone', async () => {
+  it('reuses compiler-scoped asyncResolve and cache across files', async () => {
     const { default: webpackLoader } = await import('../index');
+    const compiler = createCompiler();
+
+    transformMock.mockResolvedValue({
+      code: 'module.exports = 1;',
+      sourceMap: null,
+      cssText: undefined,
+      dependencies: [],
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      webpackLoader.call(
+        {
+          _compiler: compiler,
+          addDependency: jest.fn(),
+          async: jest.fn(),
+          callback: (err: Error | null) => (err ? reject(err) : resolve()),
+          emitWarning: jest.fn(),
+          getOptions: () => ({}),
+          getResolve: () => jest.fn((_ctx, _token, cb) => cb(null, '/abs/a')),
+          resourcePath: '/abs/entry-a.tsx',
+        } as any,
+        'module.exports = 1;',
+        null
+      );
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      webpackLoader.call(
+        {
+          _compiler: compiler,
+          addDependency: jest.fn(),
+          async: jest.fn(),
+          callback: (err: Error | null) => (err ? reject(err) : resolve()),
+          emitWarning: jest.fn(),
+          getOptions: () => ({}),
+          getResolve: () => jest.fn((_ctx, _token, cb) => cb(null, '/abs/b')),
+          resourcePath: '/abs/entry-b.tsx',
+        } as any,
+        'module.exports = 1;',
+        null
+      );
+    });
+
+    expect(transformMock).toHaveBeenCalledTimes(2);
+    expect(transformMock.mock.calls[0][2]).toBe(transformMock.mock.calls[1][2]);
+    expect(transformMock.mock.calls[0][0].cache).toBe(
+      transformMock.mock.calls[1][0].cache
+    );
+    expect(transformMock.mock.calls[0][0].asyncResolveKey).toBe(
+      transformMock.mock.calls[1][0].asyncResolveKey
+    );
+  });
+
+  it('keeps the stacked root resolver alive until compiler completion', async () => {
+    const { default: webpackLoader } = await import('../index');
+    const compiler = createCompiler();
     const resolved = path.resolve('assets/deep.css');
     const addDependencyA = jest.fn();
     const addDependencyB = jest.fn();
@@ -134,6 +212,7 @@ describe('webpack-loader asyncResolve', () => {
     await new Promise<void>((resolve, reject) => {
       webpackLoader.call(
         {
+          _compiler: compiler,
           addDependency: addDependencyA,
           async: jest.fn(),
           callback: (err: Error | null) => (err ? reject(err) : resolve()),
@@ -156,6 +235,7 @@ describe('webpack-loader asyncResolve', () => {
     await new Promise<void>((resolve, reject) => {
       webpackLoader.call(
         {
+          _compiler: compiler,
           addDependency: addDependencyB,
           async: jest.fn(),
           callback: (err: Error | null) => (err ? reject(err) : resolve()),
@@ -169,8 +249,76 @@ describe('webpack-loader asyncResolve', () => {
       );
     });
 
-    expect(resolveModuleA).not.toHaveBeenCalled();
-    expect(resolveModuleB).toHaveBeenCalledTimes(1);
-    expect(addDependencyB).toHaveBeenCalledWith(resolved);
+    expect(resolveModuleA).toHaveBeenCalledTimes(1);
+    expect(resolveModuleB).not.toHaveBeenCalled();
+    expect(addDependencyA).toHaveBeenCalledWith(resolved);
+  });
+
+  it('clears compiler-scoped resolvers when compilation finishes', async () => {
+    const { default: webpackLoader } = await import('../index');
+    const compiler = createCompiler();
+    const resolved = path.resolve('assets/deep.css');
+    const resolveModuleA = jest.fn((_ctx, _token, cb) => cb(null, resolved));
+
+    transformMock.mockImplementation(async (services, _code, asyncResolve) => {
+      if (services.options.filename === '/abs/entry-a.tsx') {
+        return {
+          code: _code,
+          sourceMap: null,
+          cssText: undefined,
+          dependencies: [],
+        };
+      }
+
+      await asyncResolve('./deep.css', '/abs/dependency.ts', [
+        '/abs/dependency.ts',
+        '/abs/entry-a.tsx',
+      ]);
+
+      return {
+        code: _code,
+        sourceMap: null,
+        cssText: undefined,
+        dependencies: [],
+      };
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      webpackLoader.call(
+        {
+          _compiler: compiler,
+          addDependency: jest.fn(),
+          async: jest.fn(),
+          callback: (err: Error | null) => (err ? reject(err) : resolve()),
+          emitWarning: jest.fn(),
+          getOptions: () => ({}),
+          getResolve: () => resolveModuleA,
+          resourcePath: '/abs/entry-a.tsx',
+        } as any,
+        'module.exports = 1;',
+        null
+      );
+    });
+
+    compiler.hooks.done.call({});
+
+    await expect(
+      new Promise<void>((resolve, reject) => {
+        webpackLoader.call(
+          {
+            _compiler: compiler,
+            addDependency: jest.fn(),
+            async: jest.fn(),
+            callback: (err: Error | null) => (err ? reject(err) : resolve()),
+            emitWarning: jest.fn(),
+            getOptions: () => ({}),
+            getResolve: () => jest.fn((_ctx, _token, cb) => cb(null, resolved)),
+            resourcePath: '/abs/entry-b.tsx',
+          } as any,
+          'module.exports = 1;',
+          null
+        );
+      })
+    ).rejects.toThrow('No resolver found');
   });
 });

--- a/packages/webpack-loader/src/index.ts
+++ b/packages/webpack-loader/src/index.ts
@@ -9,11 +9,15 @@ import crypto from 'crypto';
 import { fileURLToPath } from 'url';
 
 import type { RawSourceMap } from 'source-map';
-import type { RawLoaderDefinitionFunction } from 'webpack';
+import type { Compiler, RawLoaderDefinitionFunction, Stats } from 'webpack';
 
 import { logger } from '@wyw-in-js/shared';
 import type { PluginOptions, Preprocessor, Result } from '@wyw-in-js/transform';
-import { transform, TransformCacheCollection } from '@wyw-in-js/transform';
+import {
+  disposeEvalBroker,
+  transform,
+  TransformCacheCollection,
+} from '@wyw-in-js/transform';
 
 import { sharedState } from './WYWinJSDebugPlugin';
 import type { ICache } from './cache';
@@ -51,73 +55,165 @@ export type LoaderOptions = {
 } & Partial<PluginOptions>;
 type Loader = RawLoaderDefinitionFunction<LoaderOptions>;
 
-const cache = new TransformCacheCollection();
-
 type Resolver = (
   what: string,
   importer: string,
-  stack: string[]
+  stack?: string[]
 ) => Promise<string>;
 
-const resolvers: Record<string, Resolver[]> = {};
+type DoneHook = {
+  tap: (name: string, handler: (stats: Stats) => void) => void;
+};
+
+type VoidHook = {
+  tap: (name: string, handler: () => void) => void;
+};
+
+type FailedHook = {
+  tap: (name: string, handler: (error: Error) => void) => void;
+};
+
+type CompilerHooks = {
+  done?: DoneHook;
+  failed?: FailedHook;
+  shutdown?: VoidHook;
+  watchClose?: VoidHook;
+};
+
+type CompilerLike = Compiler & {
+  hooks: CompilerHooks;
+};
+
+type LoaderContextWithCompiler = {
+  _compiler?: CompilerLike;
+};
+
+type ResolverScope = {
+  asyncResolve: Resolver;
+  cache: TransformCacheCollection;
+  dispose: () => void;
+  key: string;
+  replaceResolver: (resourcePath: string, resolver: Resolver) => void;
+};
+
+type CompilerState = ResolverScope & {
+  clearResolvers: () => void;
+  hooksInstalled: boolean;
+};
+
+const COMPILER_SCOPE_NAME = 'WYWinJSResolverScope';
+let compilerScopeId = 0;
+const compilerStates = new WeakMap<CompilerLike, CompilerState>();
 
 const getResolverKey = (importer: string, stack: string[]): string => {
   const root = stack.length ? stack[stack.length - 1] : importer;
   return stripQueryAndHash(root);
 };
 
-const getActiveResolvers = (key: string): Resolver[] => {
-  const entries = resolvers[key];
-  return entries?.length ? entries : [];
-};
+const createResolverScope = (): ResolverScope => {
+  const resolvers = new Map<string, Resolver>();
+  compilerScopeId += 1;
+  const key = `webpack:${compilerScopeId}`;
 
-const createAsyncResolve = (resourcePath: string) => {
-  const currentResolverKey = stripQueryAndHash(resourcePath);
+  return {
+    asyncResolve: (
+      what: string,
+      importer: string,
+      stack: string[] = [importer]
+    ): Promise<string> => {
+      const resolverKeys = [
+        getResolverKey(importer, stack),
+        stripQueryAndHash(importer),
+      ].filter((candidate, idx, all) => all.indexOf(candidate) === idx);
 
-  return (
-    what: string,
-    importer: string,
-    stack: string[] = [importer]
-  ): Promise<string> => {
-    const rootResolverKey = getResolverKey(importer, stack);
-    const rootResolvers = getActiveResolvers(rootResolverKey);
-    const resolver =
-      rootResolvers.length > 0
-        ? rootResolvers
-        : getActiveResolvers(currentResolverKey);
+      const selectedResolvers = resolverKeys
+        .map((resolverKey) => resolvers.get(resolverKey))
+        .filter((resolver): resolver is Resolver => Boolean(resolver));
 
-    if (resolver.length === 0) {
-      throw new Error('No resolver found');
-    }
+      if (selectedResolvers.length === 0) {
+        throw new Error('No resolver found');
+      }
 
-    // Every resolver should return the same result, but we need to call all of them
-    // to ensure that all side effects are executed (e.g. adding dependencies)
-    return Promise.all(resolver.map((r) => r(what, importer, stack))).then(
-      (results) => {
+      // Root and importer resolver side effects both matter for dependency
+      // tracking, so keep them aligned and verify they agree on the answer.
+      return Promise.all(
+        selectedResolvers.map((resolver) => resolver(what, importer, stack))
+      ).then((results) => {
         const firstResult = results[0];
-        if (results.some((r) => r !== firstResult)) {
+        if (results.some((result) => result !== firstResult)) {
           throw new Error('Resolvers returned different results');
         }
 
         return firstResult;
-      }
-    );
+      });
+    },
+    cache: new TransformCacheCollection(),
+    dispose: () => {
+      resolvers.clear();
+    },
+    key,
+    replaceResolver: (resourcePath: string, resolver: Resolver) => {
+      resolvers.set(stripQueryAndHash(resourcePath), resolver);
+    },
   };
 };
 
-function addResolver(resourcePath: string, resolver: Resolver) {
-  if (!resolvers[resourcePath]) {
-    resolvers[resourcePath] = [];
+const disposeCompilerState = (state: CompilerState) => {
+  state.clearResolvers();
+  disposeEvalBroker(state.cache);
+};
+
+const getCompilerState = (compiler: CompilerLike): CompilerState => {
+  const cached = compilerStates.get(compiler);
+  if (cached) {
+    return cached;
   }
 
-  resolvers[resourcePath].push(resolver);
-
-  return () => {
-    resolvers[resourcePath] = resolvers[resourcePath].filter(
-      (r) => r !== resolver
-    );
+  // Resolver identity must stay stable across files within one compiler or we
+  // churn both the shared transform cache salt and the eval broker/runner.
+  const scope = createResolverScope();
+  const state: CompilerState = {
+    ...scope,
+    clearResolvers: scope.dispose,
+    dispose: () => disposeCompilerState(state),
+    hooksInstalled: false,
   };
-}
+
+  const installHooks = () => {
+    if (state.hooksInstalled) return;
+    state.hooksInstalled = true;
+
+    compiler.hooks.done?.tap(COMPILER_SCOPE_NAME, () => {
+      state.clearResolvers();
+    });
+    compiler.hooks.failed?.tap(COMPILER_SCOPE_NAME, () => {
+      state.clearResolvers();
+    });
+    compiler.hooks.watchClose?.tap(COMPILER_SCOPE_NAME, () => {
+      state.dispose();
+      compilerStates.delete(compiler);
+    });
+    compiler.hooks.shutdown?.tap(COMPILER_SCOPE_NAME, () => {
+      state.dispose();
+      compilerStates.delete(compiler);
+    });
+  };
+
+  installHooks();
+  compilerStates.set(compiler, state);
+  return state;
+};
+
+const createInvocationScope = (): ResolverScope => {
+  const scope = createResolverScope();
+  return {
+    ...scope,
+    dispose: () => {
+      scope.dispose();
+      disposeEvalBroker(scope.cache);
+    },
+  };
+};
 
 const webpack5Loader: Loader = function webpack5LoaderPlugin(
   content,
@@ -188,7 +284,12 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
       }
     });
 
-  const removeResolver = addResolver(this.resourcePath, (what, importer) => {
+  const { _compiler: compiler } = this as LoaderContextWithCompiler;
+  const compilerState = compiler
+    ? getCompilerState(compiler)
+    : createInvocationScope();
+
+  compilerState.replaceResolver(this.resourcePath, (what, importer) => {
     const importerPath = stripQueryAndHash(importer);
     const context = path.isAbsolute(importerPath)
       ? path.dirname(importerPath)
@@ -203,7 +304,11 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
       return result;
     });
   });
-  const asyncResolve = createAsyncResolve(this.resourcePath);
+  const {
+    asyncResolve,
+    cache: transformCache,
+    key: asyncResolveKey,
+  } = compilerState;
 
   logger('loader %s', this.resourcePath);
 
@@ -230,7 +335,8 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
       preprocessor,
       root: process.cwd(),
     },
-    cache,
+    asyncResolveKey,
+    cache: transformCache,
     emitWarning: (message: string) => this.emitWarning(new Error(message)),
     eventEmitter: sharedState.emitter,
   };
@@ -312,7 +418,11 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
       }
     )
     .catch((err: Error) => this.callback(err))
-    .finally(removeResolver);
+    .finally(() => {
+      if (!compiler) {
+        compilerState.dispose();
+      }
+    });
 };
 
 export default webpack5Loader;


### PR DESCRIPTION
## Summary
- Keep webpack eval resolver identity stable across files by using compiler-scoped resolver state.
- Pass a stable asyncResolveKey into transform so cache/broker reuse tracks resolver scope instead of per-file closure identity.
- Preserve root/importer resolver side effects and clear resolver entries on compiler lifecycle hooks.

## Why
The v2 async evaluator included the bundler resolver function identity in the eval cache key. Webpack creates that resolver closure per loader invocation, so a new file could churn the shared transform cache salt and recreate the eval broker/runner.

## Checks
- bun test packages/transform/src/__tests__/transform.async-resolve-key.test.ts
- bun test packages/webpack-loader/src/__tests__/resource-query.test.ts
- bun run --filter @wyw-in-js/transform build:types
- bun run --filter @wyw-in-js/webpack-loader build:types
- bun run --filter @wyw-in-js/webpack-loader lint