### PR TITLE
fix(transform): keep class declarations local (#293)

### DIFF
--- a/.changeset/shaggy-points-cough.md
+++ b/.changeset/shaggy-points-cough.md
@@ -1,0 +1,4 @@
+'@wyw-in-js/transform': patch
+---
+
+Fix shaker export stripping for exported classes that must remain as local declarations when surviving exports reference them.

--- a/packages/transform/src/__tests__/shaker.test.ts
+++ b/packages/transform/src/__tests__/shaker.test.ts
@@ -320,6 +320,20 @@ describe('shaker', () => {
     expect(code).not.toContain('exports.fallback');
   });
 
+  it('should keep class declarations local when surviving exports instantiate them', () => {
+    const code = run(['fragment', 'BADGE_COLOR'])`
+      export class TagProcessor {}
+
+      export const fragment = new TagProcessor();
+      export const BADGE_COLOR = '#c00';
+    `;
+
+    expect(code).toContain('class TagProcessor');
+    expect(code).toContain('exports.fragment');
+    expect(code).toContain('exports.BADGE_COLOR');
+    expect(code).not.toContain('exports.TagProcessor');
+  });
+
   it('should keep declaration when a dead export is referenced by a surviving export', () => {
     // Regression: the shaker's outerReferences filter treats the init expression
     // of a dead export as a forDeleting candidate. When isDevMode's init

--- a/packages/transform/src/plugins/shaker.ts
+++ b/packages/transform/src/plugins/shaker.ts
@@ -317,7 +317,7 @@ function stripExportKeepDeclaration(
     declaration.isClassDeclaration() ||
     declaration.isTSEnumDeclaration()
   ) {
-    exportDeclaration.replaceWith(t.cloneNode(declaration.node, true));
+    exportDeclaration.replaceWith(declaration.node);
     return [path];
   }
 


### PR DESCRIPTION
Fixes #293.

## Summary

The shaker crashed when a dead exported class still had to remain as a local declaration because a surviving export instantiated it. In that path, `stripExportKeepDeclaration` replaced the `ExportNamedDeclaration` with a cloned declaration node. Babel then attempted to register a second block-scoped binding for the same class name while replacing the export wrapper, producing `Duplicate declaration "TagProcessor"` / `"Parser"`.

This PR reuses the existing declaration node when stripping `export` from function/class/enum declarations, avoiding the duplicate scope registration. Variable declarations keep their existing clone/splitting behavior.

## Changes

- Preserve local class/function/enum declarations by moving the existing declaration node instead of cloning it.
- Add a shaker regression test for the `TagProcessor` repro shape from #293.
- Add a patch Changeset for `@wyw-in-js/transform`.

## Verification

- `bun test packages/transform/src/__tests__/shaker.test.ts`
- `bun run --filter @wyw-in-js/transform test`
- `bun run --filter @wyw-in-js/transform lint` exits 0 with existing member-ordering warnings outside touched files
- `bun run --filter @wyw-in-js/shared build:types`
- `bun run --filter @wyw-in-js/processor-utils build:types`
- `bun run --filter @wyw-in-js/transform build:types`
