### PR TITLE
fix(transform): drop dead export property chains (#292)

### DIFF
--- a/.changeset/bright-pens-brake.md
+++ b/.changeset/bright-pens-brake.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Fix eval shaking for chained dead export property assignments that reference export aliases.

--- a/packages/transform/src/__tests__/issue-292.variable-export-alias.test.ts
+++ b/packages/transform/src/__tests__/issue-292.variable-export-alias.test.ts
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import dedent from 'dedent';
+
+import { transformSync } from '../transform';
+
+const resolveWithExtensions = (candidate: string) => {
+  if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+    return candidate;
+  }
+
+  const extensions = ['.ts', '.tsx', '.js', '.jsx', '.cjs', '.mjs'];
+  for (const ext of extensions) {
+    const withExt = `${candidate}${ext}`;
+    if (fs.existsSync(withExt) && fs.statSync(withExt).isFile()) {
+      return withExt;
+    }
+  }
+
+  return null;
+};
+
+it('does not evaluate dead export property chains that reference aliases', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-292-'));
+  const entryFile = path.join(root, 'main.ts');
+  const processorFile = path.resolve(
+    __dirname,
+    '__fixtures__',
+    'test-css-processor.js'
+  );
+
+  try {
+    fs.writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+
+        const CompA = () => {};
+        CompA.dark = css\`color: #321;\`;
+        export const DefaultComp = CompA;
+
+        export const Mono = () => {};
+        Mono.dark = DefaultComp.dark;
+
+        export const Duo = () => {};
+        Duo.dark = Mono.dark;
+      `
+    );
+
+    const result = transformSync(
+      {
+        options: {
+          filename: entryFile,
+          root,
+          pluginOptions: {
+            configFile: false,
+            tagResolver: (source, tag) => {
+              if (source === 'test-css-processor' && tag === 'css') {
+                return processorFile;
+              }
+
+              return null;
+            },
+            babelOptions: {
+              babelrc: false,
+              configFile: false,
+              presets: [
+                ['@babel/preset-env', { loose: true }],
+                '@babel/preset-react',
+                '@babel/preset-typescript',
+              ],
+            },
+          },
+        },
+      },
+      fs.readFileSync(entryFile, 'utf8'),
+      (what, importer) => {
+        if (what === 'test-css-processor') {
+          return processorFile;
+        }
+
+        if (what.startsWith('.') || path.isAbsolute(what)) {
+          const resolved = resolveWithExtensions(
+            path.resolve(path.dirname(importer), what)
+          );
+          if (resolved) {
+            return resolved;
+          }
+        }
+
+        throw new Error(`Unable to resolve ${JSON.stringify(what)}`);
+      }
+    );
+
+    expect(result.cssText).toContain('color:#321');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/transform/src/__tests__/shaker.test.ts
+++ b/packages/transform/src/__tests__/shaker.test.ts
@@ -261,6 +261,41 @@ describe('shaker', () => {
     expect(code).not.toContain('Primary.play');
   });
 
+  it('should drop chained property assignments for dead exports', () => {
+    const code = run(['__wywPreval'])`
+      var CompA = function CompA() {};
+      CompA.dark = "m1e5nhk3";
+      export var DefaultComp = CompA;
+      export var Mono = function Mono() {};
+      Mono.dark = DefaultComp.dark;
+      export var Duo = function Duo() {};
+      Duo.dark = Mono.dark;
+      exports.__wywPreval = {};
+    `;
+
+    expect(code).toContain('__wywPreval');
+    expect(code).not.toContain('CompA');
+    expect(code).not.toContain('DefaultComp');
+    expect(code).not.toContain('Mono');
+    expect(code).not.toContain('Duo');
+  });
+
+  it('should keep property assignments read by surviving code', () => {
+    const code = run(['__wywPreval'])`
+      export var Mono = function Mono() {};
+      Mono.dark = "m1e5nhk3";
+      const _exp = /*#__PURE__*/() => Mono.dark;
+      exports.__wywPreval = {
+        _exp: _exp,
+      };
+    `;
+
+    expect(code).toContain('var Mono');
+    expect(code).toContain('Mono.dark = "m1e5nhk3"');
+    expect(code).toContain('() => Mono.dark');
+    expect(code).not.toContain('exports.Mono');
+  });
+
   it('should drop imports when default and named exports share the same binding', () => {
     const code = run(['__wywPreval'])`
       import { jsxDEV as _jsxDEV } from 'react/jsx-dev-runtime';

--- a/packages/transform/src/plugins/shaker.ts
+++ b/packages/transform/src/plugins/shaker.ts
@@ -207,6 +207,61 @@ const isWithinAliveExport = (
 ): boolean =>
   [...aliveExports].some((alive) => alive === ref || alive.isAncestor(ref));
 
+const getOnlyPropertyAssignmentStatements = (
+  binding: Binding,
+  aliveExports: Set<NodePath>
+): Set<NodePath> | null => {
+  const statements = new Set<NodePath>();
+  const references = binding.referencePaths.filter((ref) => !isRemoved(ref));
+  const constantViolations = binding.constantViolations.filter(
+    (ref) => !isRemoved(ref)
+  );
+
+  if (references.length === 0 || constantViolations.length > 0) {
+    return null;
+  }
+
+  for (const ref of references) {
+    const statement = getPropertyAssignmentStatement(
+      ref,
+      binding.identifier.name
+    );
+    if (!statement || isWithinAliveExport(statement, aliveExports)) {
+      return null;
+    }
+
+    statements.add(statement);
+  }
+
+  return statements;
+};
+
+function getExportDeclarationBindingNames(path: NodePath): string[] {
+  const exportDeclaration = path.findParent((p) =>
+    p.isExportNamedDeclaration()
+  ) as NodePath<ExportNamedDeclaration> | null;
+  const declaration = exportDeclaration?.get('declaration');
+
+  if (!declaration?.node) {
+    return [];
+  }
+
+  if (declaration.isVariableDeclaration()) {
+    return Object.keys(declaration.getOuterBindingIdentifiers());
+  }
+
+  if (
+    declaration.isFunctionDeclaration() ||
+    declaration.isClassDeclaration() ||
+    declaration.isTSEnumDeclaration()
+  ) {
+    const { id } = declaration.node;
+    return id ? [id.name] : [];
+  }
+
+  return [];
+}
+
 function getExportPathsForVariableDeclaration(
   declaration: NodePath<VariableDeclaration>,
   exports: Exports
@@ -646,6 +701,20 @@ export default function shakerPlugin(
         }
 
         const deleted = new Set<NodePath>();
+        const strippedBindingNames = new Set<string>();
+
+        const collectStrippedBindingNames = (
+          path: NodePath,
+          binding: Binding | undefined
+        ): string[] =>
+          [
+            binding?.identifier.name,
+            ...getExportDeclarationBindingNames(path),
+          ].filter((name): name is string => Boolean(name));
+
+        const rememberStrippedBindings = (names: string[]) => {
+          names.forEach((name) => strippedBindingNames.add(name));
+        };
 
         let dereferenced: NodePath<Identifier>[] = [];
         let changed = true;
@@ -701,6 +770,11 @@ export default function shakerPlugin(
               dereferenced.push(path);
             }
 
+            const strippedBindingCandidates = collectStrippedBindingNames(
+              path,
+              binding
+            );
+
             const strippedEnum =
               !deleted.has(path) && hasRuntimeReferencesToEnum(path)
                 ? stripExportKeepDeclaration(
@@ -712,6 +786,7 @@ export default function shakerPlugin(
                 : null;
 
             if (strippedEnum) {
+              rememberStrippedBindings(strippedBindingCandidates);
               strippedEnum.forEach((stalePath) => {
                 deleted.add(stalePath);
               });
@@ -731,6 +806,7 @@ export default function shakerPlugin(
                 : null;
 
             if (strippedWithBlocking) {
+              rememberStrippedBindings(strippedBindingCandidates);
               strippedWithBlocking.forEach((stalePath) => {
                 deleted.add(stalePath);
               });
@@ -764,6 +840,7 @@ export default function shakerPlugin(
                   : null;
 
               if (strippedWithoutBlocking) {
+                rememberStrippedBindings(strippedBindingCandidates);
                 strippedWithoutBlocking.forEach((stalePath) => {
                   deleted.add(stalePath);
                 });
@@ -855,6 +932,42 @@ export default function shakerPlugin(
             ) {
               if (queueForDeleting(binding.path)) {
                 changed = true;
+              }
+            }
+          }
+
+          for (const name of strippedBindingNames) {
+            const strippedBinding = file.scope.getBinding(name);
+            if (strippedBinding && !isRemoved(strippedBinding.path)) {
+              const statements = getOnlyPropertyAssignmentStatements(
+                strippedBinding,
+                aliveExports
+              );
+
+              if (statements) {
+                for (const statement of statements) {
+                  if (queueForDeleting(statement)) {
+                    changed = true;
+                  }
+                }
+
+                if (strippedBinding.path.isVariableDeclarator()) {
+                  const id = strippedBinding.path.get('id');
+                  if (
+                    !id.isArrayPattern() &&
+                    !id.isObjectPattern() &&
+                    !isRemoved(id) &&
+                    !forDeletingSet.has(id) &&
+                    queueForDeleting(id)
+                  ) {
+                    changed = true;
+                  }
+                } else if (
+                  !forDeletingSet.has(strippedBinding.path) &&
+                  queueForDeleting(strippedBinding.path)
+                ) {
+                  changed = true;
+                }
               }
             }
           }


### PR DESCRIPTION
Fixes #292.

## What changed
- Teach the transform shaker to revisit exports whose export wrapper was stripped and remove chained dead static property assignments when those assignments are the only remaining references.
- Keep property assignments intact when surviving eval code still reads them.
- Add a full transform regression for the reported `DefaultComp is not defined` shape and focused shaker coverage for both dead and live property chains.
- Add a patch changeset for `@wyw-in-js/transform`.

## Root cause
The eval shaker could strip the `DefaultComp` export alias while leaving a dead assignment chain such as `Mono.dark = DefaultComp.dark`. The prepared eval module then tried to execute the surviving assignment even though `DefaultComp` no longer existed.

## Validation
- `bun run --filter @wyw-in-js/transform test` - 1053 pass
- `bun run --filter @wyw-in-js/transform lint` - exit 0, existing member-ordering warnings only
- `bun run --filter @wyw-in-js/transform build:types`
- `git diff --check`