### PR TITLE
feat(transform): add opt-in static import value inlining

### DIFF
--- a/.changeset/static-import-values.md
+++ b/.changeset/static-import-values.md
@@ -3,4 +3,4 @@
 "@wyw-in-js/shared": patch
 ---
 
-Inline statically resolvable imported literals, fixed objects, zero-argument helper returns, compound component alias metadata, and primitive processor metadata during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.
+Inline statically resolvable imported literals, fixed objects, zero-argument helper returns, compound component alias metadata, primitive processor metadata, and static metadata helper chains during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.

--- a/.changeset/static-import-values.md
+++ b/.changeset/static-import-values.md
@@ -3,4 +3,4 @@
 "@wyw-in-js/shared": patch
 ---
 
-Inline statically resolvable imported literals, fixed objects, and primitive processor metadata during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.
+Inline statically resolvable imported literals, fixed objects, zero-argument helper returns, and primitive processor metadata during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.

--- a/.changeset/static-import-values.md
+++ b/.changeset/static-import-values.md
@@ -2,4 +2,4 @@
 "@wyw-in-js/transform": patch
 ---
 
-Inline statically resolvable imported literals and fixed objects during Oxc pre-evaluation.
+Inline statically resolvable imported literals, fixed objects, and primitive processor metadata during Oxc pre-evaluation.

--- a/.changeset/static-import-values.md
+++ b/.changeset/static-import-values.md
@@ -4,3 +4,5 @@
 ---
 
 Inline statically resolvable imported literals, fixed objects, compiled TypeScript enum objects, zero-argument helper returns, compound component alias metadata, same-module and post-declaration alias metadata, primitive processor metadata, and static metadata helper chains during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.
+
+Cache per-file static metadata pre-evaluation results so multiple static exports from the same module do not repeat the same processor pre-evaluation work.

--- a/.changeset/static-import-values.md
+++ b/.changeset/static-import-values.md
@@ -1,5 +1,6 @@
 ---
 "@wyw-in-js/transform": patch
+"@wyw-in-js/shared": patch
 ---
 
-Inline statically resolvable imported literals, fixed objects, and primitive processor metadata during Oxc pre-evaluation.
+Inline statically resolvable imported literals, fixed objects, and primitive processor metadata during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.

--- a/.changeset/static-import-values.md
+++ b/.changeset/static-import-values.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/transform": patch
+---
+
+Inline statically resolvable imported literals and fixed objects during Oxc pre-evaluation.

--- a/.changeset/static-import-values.md
+++ b/.changeset/static-import-values.md
@@ -3,6 +3,6 @@
 "@wyw-in-js/shared": patch
 ---
 
-Inline statically resolvable imported literals, fixed objects, compiled TypeScript enum objects, zero-argument helper returns, compound component alias metadata, same-module and post-declaration alias metadata, primitive processor metadata, and static metadata helper chains during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.
+Inline statically resolvable imported literals, fixed objects, compiled TypeScript enum objects, zero-argument helper returns, compound component alias metadata, same-module and post-declaration alias metadata, primitive processor metadata, and static metadata helper chains during Oxc pre-evaluation. The optimization is controlled by the opt-in `features.staticImportValues` flag.
 
 Cache per-file static metadata pre-evaluation results so multiple static exports from the same module do not repeat the same processor pre-evaluation work.

--- a/.changeset/static-import-values.md
+++ b/.changeset/static-import-values.md
@@ -3,4 +3,4 @@
 "@wyw-in-js/shared": patch
 ---
 
-Inline statically resolvable imported literals, fixed objects, zero-argument helper returns, compound component alias metadata, same-module alias metadata, primitive processor metadata, and static metadata helper chains during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.
+Inline statically resolvable imported literals, fixed objects, zero-argument helper returns, compound component alias metadata, same-module and post-declaration alias metadata, primitive processor metadata, and static metadata helper chains during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.

--- a/.changeset/static-import-values.md
+++ b/.changeset/static-import-values.md
@@ -3,4 +3,4 @@
 "@wyw-in-js/shared": patch
 ---
 
-Inline statically resolvable imported literals, fixed objects, zero-argument helper returns, and primitive processor metadata during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.
+Inline statically resolvable imported literals, fixed objects, zero-argument helper returns, compound component alias metadata, and primitive processor metadata during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.

--- a/.changeset/static-import-values.md
+++ b/.changeset/static-import-values.md
@@ -3,4 +3,4 @@
 "@wyw-in-js/shared": patch
 ---
 
-Inline statically resolvable imported literals, fixed objects, zero-argument helper returns, compound component alias metadata, same-module and post-declaration alias metadata, primitive processor metadata, and static metadata helper chains during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.
+Inline statically resolvable imported literals, fixed objects, compiled TypeScript enum objects, zero-argument helper returns, compound component alias metadata, same-module and post-declaration alias metadata, primitive processor metadata, and static metadata helper chains during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.

--- a/.changeset/static-import-values.md
+++ b/.changeset/static-import-values.md
@@ -3,4 +3,4 @@
 "@wyw-in-js/shared": patch
 ---
 
-Inline statically resolvable imported literals, fixed objects, zero-argument helper returns, compound component alias metadata, primitive processor metadata, and static metadata helper chains during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.
+Inline statically resolvable imported literals, fixed objects, zero-argument helper returns, compound component alias metadata, same-module alias metadata, primitive processor metadata, and static metadata helper chains during Oxc pre-evaluation. The optimization is controlled by the default-enabled `features.staticImportValues` flag.

--- a/apps/website/pages/feature-flags.mdx
+++ b/apps/website/pages/feature-flags.mdx
@@ -71,15 +71,27 @@ The `softErrors` is disabled by default. It is designed to provide a more lenien
 
 # `staticImportValues` Feature
 
-The `staticImportValues` feature is enabled by default. It lets the Oxc transform inline imported values that can be proven static, such as primitives, arrays, and plain objects, without sending those bindings through build-time evaluation. Disable it when the extra static analysis is not useful for a project or when comparing build performance with and without the optimization.
+The `staticImportValues` feature is disabled by default. It lets the Oxc transform inline values that can be proven static, such as primitives, `null`, arrays, and plain objects, without sending those bindings through build-time evaluation.
+
+Enable it when your project has many style interpolations that point at static design tokens, constant objects, constant arrays, compiled enum objects, or simple static metadata chains. In those cases, WyW-in-JS can skip some eval work and can avoid importing token-only modules during eval.
+
+Keep it disabled when a project has few static imports, when most candidate modules are runtime-heavy, or when you are comparing build performance with and without the extra static analysis. The pass has to parse and resolve extra modules before it can prove that a value is safe, so codebases with little static data may see extra build overhead.
+
+## Limitations
+
+The resolver is intentionally conservative. If it cannot prove a value is static and serializable, WyW-in-JS falls back to the existing eval path.
+
+It does not inline arbitrary runtime-created values. Functions, classes, symbols, getters, non-plain objects, mutable bindings, dynamic imports, unresolved imports, cycles, side-effectful module shapes, and ambiguous computed or namespace access stay in eval.
 
 ```js
 {
   features: {
-    staticImportValues: false,
+    staticImportValues: true,
   },
 }
 ```
+
+You can also use `WYW_STATIC_IMPORT_VALUES=1` to force the feature on for local validation or performance comparison. `0`, `false`, `no`, and `off` force it off.
 
 # `useWeakRefInEval` Feature
 

--- a/apps/website/pages/feature-flags.mdx
+++ b/apps/website/pages/feature-flags.mdx
@@ -69,6 +69,18 @@ so `happy-dom` is loaded via `import()` and works on Node 22+.
 
 The `softErrors` is disabled by default. It is designed to provide a more lenient evaluation of styles and values that are interpolated in styles. This flag is useful for debugging and prevents the build from failing even if some files cannot be processed with WyW-in-JS.
 
+# `staticImportValues` Feature
+
+The `staticImportValues` feature is enabled by default. It lets the Oxc transform inline imported values that can be proven static, such as primitives, arrays, and plain objects, without sending those bindings through build-time evaluation. Disable it when the extra static analysis is not useful for a project or when comparing build performance with and without the optimization.
+
+```js
+{
+  features: {
+    staticImportValues: false,
+  },
+}
+```
+
 # `useWeakRefInEval` Feature
 
 The `useWeakRefInEval` feature is enabled by default. With it on, WyW-in-JS wraps evaluated modules in `WeakRef` to reduce memory usage during long-running builds. Garbage collection can reclaim these weak references in some environments, which may surface as `EvalError: Module X is disposed` when a disposed module is accessed again. If you encounter that error pattern, disable this flag to keep strong references (at the cost of higher memory usage).

--- a/bun.lock
+++ b/bun.lock
@@ -429,6 +429,7 @@
       "name": "@wyw-in-js/transform",
       "version": "1.0.8",
       "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
         "@wyw-in-js/processor-utils": "workspace:*",
         "@wyw-in-js/shared": "workspace:*",
         "cosmiconfig": "^8.0.0",

--- a/packages/transform/.eslintrc.cjs
+++ b/packages/transform/.eslintrc.cjs
@@ -3,6 +3,9 @@ const path = require('node:path');
 module.exports = {
   extends: ['@wyw-in-js/eslint-config/library'],
   ignorePatterns: ['src/__tests__/legacy-babel-reference/**'],
+  rules: {
+    '@typescript-eslint/member-ordering': 'off',
+  },
   overrides: [
     {
       files: [

--- a/packages/transform/scripts/perf-complex-scenarios.ts
+++ b/packages/transform/scripts/perf-complex-scenarios.ts
@@ -45,6 +45,7 @@ type ScenarioDefinition = {
 type ScenarioRun = {
   cssBytes: number;
   cssFiles: number;
+  methodCounts: Record<string, number>;
   methodTotals: Record<string, number>;
   wallMs: number;
 };
@@ -87,6 +88,7 @@ const SUMMARY_METHODS = [
   'transform:preeval:processTemplate:processors',
   'transform:preeval:removeDangerousCode',
   'transform:evaluator',
+  'transform:evalFile',
   'transform:emitCommonJS',
 ] as const;
 
@@ -632,6 +634,7 @@ class PerfRecorder {
       }
 
       if (type === 'start') {
+        this.counts.set(method, (this.counts.get(method) ?? 0) + 1);
         const stack = this.stacks.get(method) ?? [];
         stack.push(performance.now());
         this.stacks.set(method, stack);
@@ -655,9 +658,15 @@ class PerfRecorder {
     () => {}
   );
 
+  private readonly counts = new Map<string, number>();
+
   private readonly stacks = new Map<string, number[]>();
 
   private readonly totals = new Map<string, number>();
+
+  public countsSnapshot() {
+    return Object.fromEntries(this.counts.entries());
+  }
 
   public snapshot() {
     return Object.fromEntries(
@@ -777,6 +786,7 @@ const runScenarioOnce = async (
   return {
     cssBytes,
     cssFiles,
+    methodCounts: recorder.countsSnapshot(),
     methodTotals: recorder.snapshot(),
     wallMs: round(performance.now() - startedAt),
   };
@@ -884,7 +894,9 @@ const printSummary = (
     'lookup'.padStart(10),
     'procs'.padStart(10),
     'danger'.padStart(10),
-    'eval'.padStart(10),
+    'shake'.padStart(10),
+    'eval ms'.padStart(10),
+    'eval #'.padStart(8),
   ].join(' ');
 
   console.log(header);
@@ -896,6 +908,12 @@ const printSummary = (
       SUMMARY_METHODS.map((method) => [
         method,
         round(mean(summary.runs.map((run) => run.methodTotals[method] ?? 0))),
+      ])
+    );
+    const counts = Object.fromEntries(
+      SUMMARY_METHODS.map((method) => [
+        method,
+        round(mean(summary.runs.map((run) => run.methodCounts[method] ?? 0))),
       ])
     );
 
@@ -921,6 +939,8 @@ const printSummary = (
           10
         ),
         `${means['transform:evaluator'].toFixed(1)}`.padStart(10),
+        `${means['transform:evalFile'].toFixed(1)}`.padStart(10),
+        `${counts['transform:evalFile'].toFixed(1)}`.padStart(8),
       ].join(' ')
     );
 

--- a/packages/transform/src/__tests__/__fixtures__/test-styled-processor.js
+++ b/packages/transform/src/__tests__/__fixtures__/test-styled-processor.js
@@ -1,0 +1,110 @@
+const {
+  TaggedTemplateProcessor,
+  validateParams,
+} = require('@wyw-in-js/processor-utils');
+const { ValueType, hasEvalMeta } = require('@wyw-in-js/shared');
+
+class StyledProcessor extends TaggedTemplateProcessor {
+  constructor(params, ...args) {
+    validateParams(params, ['callee', '*', '...'], StyledProcessor.SKIP);
+    validateParams(
+      params,
+      ['callee', ['call', 'member'], ['template', 'call']],
+      'Invalid styled processor usage'
+    );
+
+    const [tag, tagOp, template] = params;
+    if (template[0] === 'call') {
+      throw StyledProcessor.SKIP;
+    }
+
+    super([tag, template], ...args);
+
+    if (tagOp[0] === 'member') {
+      [, this.component] = tagOp;
+      return;
+    }
+
+    const value = tagOp[1];
+    if (value.kind === ValueType.CONST && typeof value.value === 'string') {
+      this.component = value.value;
+      return;
+    }
+
+    this.component = {
+      node: value.ex,
+      source: value.source,
+    };
+    this.dependencies.push(value);
+  }
+
+  get asSelector() {
+    return `.${this.className}`;
+  }
+
+  get value() {
+    const t = this.astService;
+    const extended =
+      typeof this.component === 'string'
+        ? t.nullLiteral()
+        : t.callExpression(t.identifier(this.component.node.name), []);
+
+    return t.objectExpression([
+      t.objectProperty(
+        t.stringLiteral('displayName'),
+        t.stringLiteral(this.displayName)
+      ),
+      t.objectProperty(
+        t.stringLiteral('__wyw_meta'),
+        t.objectExpression([
+          t.objectProperty(
+            t.stringLiteral('className'),
+            t.stringLiteral(this.className)
+          ),
+          t.objectProperty(t.stringLiteral('extends'), extended),
+        ])
+      ),
+    ]);
+  }
+
+  addInterpolation() {
+    throw new Error('test styled processor does not support interpolations');
+  }
+
+  doEvaltimeReplacement() {
+    this.replacer(this.value, false);
+  }
+
+  doRuntimeReplacement() {
+    this.replacer(
+      this.astService.callExpression(this.callee, [
+        this.astService.nullLiteral(),
+      ]),
+      true
+    );
+  }
+
+  extractRules(valueCache, cssText, loc) {
+    let selector = `.${this.className}`;
+    let value =
+      typeof this.component === 'string'
+        ? null
+        : valueCache.get(this.component.node.name);
+
+    while (hasEvalMeta(value)) {
+      selector += `.${value.__wyw_meta.className}`;
+      value = value.__wyw_meta.extends;
+    }
+
+    return {
+      [selector]: {
+        cssText,
+        className: this.className,
+        displayName: this.displayName,
+        start: loc?.start ?? null,
+      },
+    };
+  }
+}
+
+module.exports = { default: StyledProcessor };

--- a/packages/transform/src/__tests__/applyOxcProcessors.test.ts
+++ b/packages/transform/src/__tests__/applyOxcProcessors.test.ts
@@ -100,7 +100,11 @@ describe('applyOxcProcessors', () => {
     let resolverCalls = 0;
     const cachedOptions: Pick<
       StrictOptions,
-      'classNameSlug' | 'displayName' | 'extensions' | 'evaluate' | 'tagResolver'
+      | 'classNameSlug'
+      | 'displayName'
+      | 'extensions'
+      | 'evaluate'
+      | 'tagResolver'
     > = {
       displayName: false,
       evaluate: true,
@@ -122,8 +126,18 @@ describe('applyOxcProcessors', () => {
       \`;
     `;
 
-    const first = applyOxcProcessors(source, fileContext, cachedOptions, () => {});
-    const second = applyOxcProcessors(source, fileContext, cachedOptions, () => {});
+    const first = applyOxcProcessors(
+      source,
+      fileContext,
+      cachedOptions,
+      () => {}
+    );
+    const second = applyOxcProcessors(
+      source,
+      fileContext,
+      cachedOptions,
+      () => {}
+    );
 
     expect(first.processors).toHaveLength(1);
     expect(second.processors).toHaveLength(1);
@@ -454,7 +468,7 @@ describe('applyOxcProcessors', () => {
         }
         const obj = copyAndExtend({ a: 1 }, { a: 2 });
         export const title = css\`
-          color: ${"${obj.a}"};
+          color: ${'${obj.a}'};
         \`;
       `,
       fileContext,
@@ -614,9 +628,9 @@ describe('applyOxcProcessors', () => {
       () => {}
     );
 
-    expect(result.processors[0]?.dependencies.map((item) => item.ex.name)).toEqual(
-      ['_exp']
-    );
+    expect(
+      result.processors[0]?.dependencies.map((item) => item.ex.name)
+    ).toEqual(['_exp']);
     expect(result.processors[0]?.dependencies[0]).toMatchObject({
       importedFrom: ['./base'],
       kind: ValueType.LAZY,
@@ -647,7 +661,9 @@ describe('applyOxcProcessors', () => {
       'var React = _interopRequireWildcard(require("react"));'
     );
     expect(result.code).toContain('const _exp = () => (Component);');
-    expect(result.code).toContain('export const styles = /*#__PURE__*/__callRuntime(_exp());');
+    expect(result.code).toContain(
+      'export const styles = /*#__PURE__*/__callRuntime(_exp());'
+    );
   });
 
   it('keeps runtime helpers referenced only from function parameter defaults', () => {
@@ -682,9 +698,7 @@ describe('applyOxcProcessors', () => {
       true
     );
 
-    expect(result.code).toContain(
-      "import SelectOption from './SelectOption';"
-    );
+    expect(result.code).toContain("import SelectOption from './SelectOption';");
     expect(result.code).toContain('const formatOptionLabelDefault =');
     expect(result.code).toContain(
       'formatOptionLabel = formatOptionLabelDefault'
@@ -710,7 +724,7 @@ describe('applyOxcProcessors', () => {
     );
   });
 
-  it("throws when it cannot derive a display name from ownership or filename", () => {
+  it('throws when it cannot derive a display name from ownership or filename', () => {
     expect(() =>
       applyOxcProcessors(
         `

--- a/packages/transform/src/__tests__/applyOxcProcessors.test.ts
+++ b/packages/transform/src/__tests__/applyOxcProcessors.test.ts
@@ -716,9 +716,7 @@ describe('applyOxcProcessors', () => {
       (processor) => processor.doRuntimeReplacement()
     );
 
-    expect(result.code).toContain(
-      'import { __styles } from "@griffel/react";'
-    );
+    expect(result.code).toContain('import { __styles } from "@griffel/react";');
     expect(result.code).toContain(
       "export const useStyles = /*#__PURE__*/__styles('x');"
     );

--- a/packages/transform/src/__tests__/barrel-optimization.test.ts
+++ b/packages/transform/src/__tests__/barrel-optimization.test.ts
@@ -6,6 +6,7 @@ import { TransformCacheCollection } from '../cache';
 import { Entrypoint } from '../transform/Entrypoint';
 import { syncActionRunner } from '../transform/actions/actionRunner';
 import { baseProcessingHandlers } from '../transform/generators/baseProcessingHandlers';
+import { processEntrypoint } from '../transform/generators/processEntrypoint';
 import { syncResolveImports } from '../transform/generators/resolveImports';
 import { loadWywOptions } from '../transform/helpers/loadWywOptions';
 import { withDefaultServices } from '../transform/helpers/withDefaultServices';
@@ -131,6 +132,7 @@ const runEntrypoint = (
 
   const handlers = {
     ...baseProcessingHandlers,
+    processEntrypoint,
     resolveImports(this: IResolveImportsAction) {
       return syncResolveImports.call(this, resolve);
     },

--- a/packages/transform/src/__tests__/collectOxcExportsAndImports.test.ts
+++ b/packages/transform/src/__tests__/collectOxcExportsAndImports.test.ts
@@ -127,7 +127,9 @@ describe('collectOxcExportsAndImports', () => {
   });
 
   it('collects require-backed namespace reexports from the compiled CommonJS corpus', () => {
-    expect(runFixture('re-export_named_namespace.input.ts').reexports).toMatchObject([
+    expect(
+      runFixture('re-export_named_namespace.input.ts').reexports
+    ).toMatchObject([
       { exported: 'ns', imported: '*', source: 'unknown-package' },
     ]);
 

--- a/packages/transform/src/__tests__/collectOxcTemplateDependencies.test.ts
+++ b/packages/transform/src/__tests__/collectOxcTemplateDependencies.test.ts
@@ -1,0 +1,21 @@
+import { evaluateOxcStaticExpression } from '../utils/collectOxcTemplateDependencies';
+
+describe('evaluateOxcStaticExpression', () => {
+  it('does not treat unresolved typeof operands as static undefined', () => {
+    expect(
+      evaluateOxcStaticExpression('typeof missingGlobal', '/test.ts')
+    ).toBe(undefined);
+    expect(
+      evaluateOxcStaticExpression(
+        "typeof missingGlobal ? 'fallback' : 'runtime'",
+        '/test.ts'
+      )
+    ).toBe(undefined);
+  });
+
+  it('still treats process.env property access as build-time undefined', () => {
+    expect(
+      evaluateOxcStaticExpression('typeof process.env.NODE_ENV', '/test.ts')
+    ).toBe('undefined');
+  });
+});

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -21,6 +21,7 @@ import {
   EvalBroker,
   stripEntrypointGlobalsFromRunnerContext,
 } from '../eval/broker';
+import { serializeValue } from '../eval/serialize';
 
 const createPluginOptions = (overrides: PartialOptions = {}) =>
   loadWywOptions({
@@ -74,6 +75,10 @@ const getPrivateBroker = (broker: EvalBroker) =>
     lastHappyDomEnabled: boolean;
     lastInitKey: string | null;
     onlyByModule: Map<string, string[]>;
+    ensureImportsMapping: (
+      id: string,
+      imports: Map<string, string[]> | null | undefined
+    ) => void;
     ensureRunner: () => Promise<void>;
     handleRunnerStderr: (chunk: Buffer) => void;
     initIsolatedRunner: (
@@ -2837,6 +2842,519 @@ describe('EvalBroker', () => {
     );
     const resultB = await broker.evaluate(epB);
     expect(resultB.values?.get('s')).toBe(24);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('reuses evaluated variant modules when broker sends narrow serialized exports', async () => {
+    // Regression test for cache poisoning:
+    //
+    // Session 1 evaluates dep.js as a module variant (only includes __wywPreval,
+    // so isFullModuleLoad is false). The variant has all exports (x, y).
+    //
+    // Session 2 only needs `x` from dep.js. The broker sends serialized exports
+    // { x: ... } (narrow slice). The runner must NOT create a narrow
+    // SyntheticModule — it should reuse the evaluated variant that has both x and y.
+    //
+    // Session 3 needs both x and y from dep.js. If the runner created a narrow
+    // SyntheticModule in session 2 and returned it, session 3's link would fail
+    // because the SyntheticModule doesn't have y. With the fix, the evaluated
+    // variant is returned instead.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const dep = join(root, 'dep.js');
+    writeFileSync(dep, 'export const x = 10;\nexport const y = 20;\n');
+
+    const barrel = join(root, 'barrel.js');
+    writeFileSync(
+      barrel,
+      "export { x, y } from './dep.js';\n"
+    );
+
+    // Session 1: imports both x and y → forces full eval of dep.js
+    const entryA = join(root, 'entry-a.js');
+    writeFileSync(
+      entryA,
+      [
+        "import { x, y } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  sum: () => x + y,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session 2: imports only x → broker can serve serialized exports
+    const entryB = join(root, 'entry-b.js');
+    writeFileSync(
+      entryB,
+      [
+        "import { x } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  val: () => x,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session 3: imports both x and y again → must not fail
+    const entryC = join(root, 'entry-c.js');
+    writeFileSync(
+      entryC,
+      [
+        "import { x, y } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  diff: () => y - x,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, entryA);
+    const broker = new EvalBroker(services, asyncResolve);
+
+    const epA = Entrypoint.createRoot(
+      services,
+      entryA,
+      ['__wywPreval'],
+      readFileSync(entryA, 'utf-8')
+    );
+    const resultA = await broker.evaluate(epA);
+    expect(resultA.values?.get('sum')).toBe(30);
+
+    const epB = Entrypoint.createRoot(
+      services,
+      entryB,
+      ['__wywPreval'],
+      readFileSync(entryB, 'utf-8')
+    );
+    const resultB = await broker.evaluate(epB);
+    expect(resultB.values?.get('val')).toBe(10);
+
+    const epC = Entrypoint.createRoot(
+      services,
+      entryC,
+      ['__wywPreval'],
+      readFileSync(entryC, 'utf-8')
+    );
+    const resultC = await broker.evaluate(epC);
+    expect(resultC.values?.get('diff')).toBe(10);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not create narrow SyntheticModule when barrel re-exports more than importer needs', async () => {
+    // Reproduces the real-world failure: design-system.ts (barrel) re-exports
+    // fontFamily+fontWeight+textStyles from typography.ts. Session A evaluates
+    // the full chain. Session B's entrypoint only needs fontWeight+textStyles,
+    // so the broker may serve serialized exports for typography with just those
+    // 2 keys. But the barrel's SourceTextModule still has
+    // `import { fontFamily, fontWeight, textStyles } from './typography.js'`
+    // — it needs fontFamily too. If the runner creates a narrow SyntheticModule
+    // for typography, the barrel's link fails.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const typography = join(root, 'typography.js');
+    writeFileSync(
+      typography,
+      [
+        'export const fontFamily = "sans-serif";',
+        'export const fontWeight = 400;',
+        'export const textStyles = { body: "14px" };',
+      ].join('\n')
+    );
+
+    const barrel = join(root, 'barrel.js');
+    writeFileSync(
+      barrel,
+      [
+        "export { fontFamily, fontWeight, textStyles } from './typography.js';",
+        'export const layout = { gap: 8 };',
+      ].join('\n')
+    );
+
+    // Session A: imports fontFamily + fontWeight + textStyles from barrel
+    // → typography.js is prepared with all 3 exports, evaluated as variant
+    const entryA = join(root, 'entry-a.js');
+    writeFileSync(
+      entryA,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  font: () => `${fontFamily} ${fontWeight} ${JSON.stringify(textStyles)}`,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session B: imports only fontWeight + textStyles from barrel
+    // → broker may serve serialized exports for typography (only fontWeight, textStyles)
+    // → barrel's code still imports fontFamily from typography → must not fail
+    const entryB = join(root, 'entry-b.js');
+    writeFileSync(
+      entryB,
+      [
+        "import { fontWeight, textStyles } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  weight: () => fontWeight,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session C: imports fontFamily again → must not fail
+    const entryC = join(root, 'entry-c.js');
+    writeFileSync(
+      entryC,
+      [
+        "import { fontFamily, fontWeight } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  info: () => `${fontFamily}/${fontWeight}`,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, entryA, {
+      features: { staticImportValues: true },
+    });
+    const broker = new EvalBroker(services, asyncResolve);
+
+    const epA = Entrypoint.createRoot(
+      services,
+      entryA,
+      ['__wywPreval'],
+      readFileSync(entryA, 'utf-8')
+    );
+    const resultA = await broker.evaluate(epA);
+    expect(resultA.values?.get('font')).toMatchInlineSnapshot(
+      `"sans-serif 400 {"body":"14px"}"`
+    );
+
+    const epB = Entrypoint.createRoot(
+      services,
+      entryB,
+      ['__wywPreval'],
+      readFileSync(entryB, 'utf-8')
+    );
+    const resultB = await broker.evaluate(epB);
+    expect(resultB.values?.get('weight')).toBe(400);
+
+    const epC = Entrypoint.createRoot(
+      services,
+      entryC,
+      ['__wywPreval'],
+      readFileSync(entryC, 'utf-8')
+    );
+    const resultC = await broker.evaluate(epC);
+    expect(resultC.values?.get('info')).toMatchInlineSnapshot(
+      `"sans-serif/400"`
+    );
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not reuse a narrower evaluated variant for wider serialized exports', async () => {
+    // Mirrors the 4df6e915 Fibery dump:
+    //
+    // 1. typography.js is evaluated as a narrow variant with fontWeight only.
+    // 2. typography.js is evaluated as a wider variant with fontFamily,
+    //    fontWeight and textStyles.
+    // 3. A later load gets serialized exports for that wider set, with a hash
+    //    that is not itself cached as a SourceTextModule variant.
+    //
+    // The runner must not satisfy step 3 by returning the first evaluated
+    // variant for the source path if that variant lacks the serialized export
+    // set.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const typography = join(root, 'typography.js');
+    const entryNarrow = join(root, 'entry-narrow.js');
+    const entryWide = join(root, 'entry-wide.js');
+    const entrySerializedWide = join(root, 'entry-serialized-wide.js');
+
+    writeFileSync(
+      entryNarrow,
+      [
+        "import { fontWeight } from './typography.js';",
+        'export const __wywPreval = {',
+        '  value: () => fontWeight,',
+        '};',
+      ].join('\n')
+    );
+    writeFileSync(
+      entryWide,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './typography.js';",
+        'export const __wywPreval = {',
+        '  value: () => `${fontFamily}:${fontWeight}:${textStyles.body}`,',
+        '};',
+      ].join('\n')
+    );
+    writeFileSync(
+      entrySerializedWide,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './typography.js';",
+        'export const __wywPreval = {',
+        '  value: () => `${fontFamily}/${fontWeight}/${textStyles.body}`,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, entryNarrow, {
+      features: { staticImportValues: true },
+    });
+    const broker = new EvalBroker(services, asyncResolve);
+    const privateBroker = getPrivateBroker(broker);
+    const originalLoadModule = privateBroker.loadModule.bind(privateBroker);
+    const loadCalls: Array<{
+      id: string;
+      importerId?: string | null;
+      request?: string | null;
+    }> = [];
+
+    privateBroker.loadModule = jest.fn(async (payload) => {
+      loadCalls.push(payload);
+
+      const withImports = (
+        id: string,
+        result: {
+          code: string;
+          imports: Map<string, string[]> | null;
+          only: string[];
+          hash: string;
+          exports?: Record<string, ReturnType<typeof serializeValue>>;
+        }
+      ) => {
+        privateBroker.ensureImportsMapping(id, result.imports);
+        return result;
+      };
+
+      if (payload.id === entryNarrow) {
+        return withImports(entryNarrow, {
+          code: readFileSync(entryNarrow, 'utf-8'),
+          imports: new Map([['./typography.js', ['fontWeight']]]),
+          only: ['__wywPreval'],
+          hash: 'entry-narrow',
+        });
+      }
+
+      if (payload.id === entryWide) {
+        return withImports(entryWide, {
+          code: readFileSync(entryWide, 'utf-8'),
+          imports: new Map([
+            ['./typography.js', ['fontFamily', 'fontWeight', 'textStyles']],
+          ]),
+          only: ['__wywPreval'],
+          hash: 'entry-wide',
+        });
+      }
+
+      if (payload.id === entrySerializedWide) {
+        return withImports(entrySerializedWide, {
+          code: readFileSync(entrySerializedWide, 'utf-8'),
+          imports: new Map([
+            ['./typography.js', ['fontFamily', 'fontWeight', 'textStyles']],
+          ]),
+          only: ['__wywPreval'],
+          hash: 'entry-serialized-wide',
+        });
+      }
+
+      if (payload.id === typography && payload.importerId === entryNarrow) {
+        return withImports(typography, {
+          code: 'export const fontWeight = 400;',
+          imports: null,
+          only: ['fontWeight'],
+          hash: 'typography-narrow-font-weight',
+        });
+      }
+
+      if (payload.id === typography && payload.importerId === entryWide) {
+        return withImports(typography, {
+          code: [
+            'export const fontFamily = "Inter";',
+            'export const fontWeight = 400;',
+            'export const textStyles = { body: "14px" };',
+          ].join('\n'),
+          imports: null,
+          only: ['fontFamily', 'fontWeight', 'textStyles'],
+          hash: 'typography-wide-source',
+        });
+      }
+
+      if (
+        payload.id === typography &&
+        payload.importerId === entrySerializedWide
+      ) {
+        return withImports(typography, {
+          code: '',
+          imports: null,
+          only: ['fontFamily', 'fontWeight', 'textStyles'],
+          hash: 'typography-wide-serialized-exports',
+          exports: {
+            fontFamily: serializeValue('Inter'),
+            fontWeight: serializeValue(400),
+            textStyles: serializeValue({ body: '14px' }),
+          },
+        });
+      }
+
+      return originalLoadModule(payload);
+    });
+
+    try {
+      const narrow = Entrypoint.createRoot(
+        services,
+        entryNarrow,
+        ['__wywPreval'],
+        readFileSync(entryNarrow, 'utf-8')
+      );
+      const narrowResult = await broker.evaluate(narrow);
+      expect(narrowResult.values?.get('value')).toBe(400);
+
+      const wide = Entrypoint.createRoot(
+        services,
+        entryWide,
+        ['__wywPreval'],
+        readFileSync(entryWide, 'utf-8')
+      );
+      const wideResult = await broker.evaluate(wide);
+      expect(wideResult.values?.get('value')).toBe('Inter:400:14px');
+
+      const serializedWide = Entrypoint.createRoot(
+        services,
+        entrySerializedWide,
+        ['__wywPreval'],
+        readFileSync(entrySerializedWide, 'utf-8')
+      );
+      const serializedWideResult = await broker.evaluate(serializedWide);
+      expect(serializedWideResult.values?.get('value')).toBe(
+        'Inter/400/14px'
+      );
+      expect(loadCalls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: typography,
+            importerId: entrySerializedWide,
+          }),
+        ])
+      );
+    } finally {
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps wide barrel dependency imports when a later narrow variant finishes', async () => {
+    // Models the Fibery failure shape:
+    //
+    // - design-system.ts is a barrel that can be prepared as multiple variants.
+    // - A wide variant imports fontFamily/fontWeight/textStyles from typography.
+    // - A later narrow variant of the same source imports only fontWeight.
+    // - Because importsByModule is keyed only by source path, the narrow map can
+    //   replace the wide map while the wide SourceTextModule is still linking.
+    // - When that wide module then loads typography, the dependency must still
+    //   be prepared with the wide export set.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const entry = join(root, 'entry.js');
+    const barrel = join(root, 'design-system.js');
+    const typography = join(root, 'typography.js');
+    const theme = join(root, 'theme.js');
+
+    writeFileSync(
+      theme,
+      [
+        'export const themeVars = globalThis.__wywThemeVars || { text: "black" };',
+      ].join('\n')
+    );
+    writeFileSync(
+      typography,
+      [
+        "import { themeVars } from './theme.js';",
+        'export const fontFamily = "Inter";',
+        'export const fontWeight = 400;',
+        'export const textStyles = { body: themeVars.text };',
+      ].join('\n')
+    );
+    writeFileSync(
+      barrel,
+      [
+        "export { fontFamily, fontWeight, textStyles } from './typography.js';",
+      ].join('\n')
+    );
+    writeFileSync(
+      entry,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './design-system.js';",
+        'export const __wywPreval = {',
+        '  value: () => `${fontFamily}:${fontWeight}:${textStyles.body}`,',
+        '};',
+      ].join('\n')
+    );
+
+    const services = createServices(root, entry);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const privateBroker = getPrivateBroker(broker);
+
+    privateBroker.importsByModule.set(
+      entry,
+      new Map([
+        ['./design-system.js', ['fontFamily', 'fontWeight', 'textStyles']],
+      ])
+    );
+
+    const wideBarrel = await privateBroker.loadModule({
+      id: barrel,
+      importerId: entry,
+      request: './design-system.js',
+    });
+
+    expect(wideBarrel.imports?.get('./typography.js')).toEqual([
+      'fontFamily',
+      'fontWeight',
+      'textStyles',
+    ]);
+
+    // Simulate a concurrent/narrow barrel variant completing after the wide
+    // variant. Current code replaces the source-path import map with this
+    // narrower map, which can make the still-linking wide variant load a
+    // typography module that is missing fontFamily/textStyles.
+    privateBroker.ensureImportsMapping(
+      barrel,
+      new Map([['./typography.js', ['fontWeight']]])
+    );
+
+    const typographyForWideBarrel = await privateBroker.loadModule({
+      id: typography,
+      importerId: barrel,
+      request: './typography.js',
+    });
+
+    expect(typographyForWideBarrel.only).toEqual(
+      expect.arrayContaining(['fontFamily', 'fontWeight', 'textStyles'])
+    );
+    expect(typographyForWideBarrel.code).toContain('fontFamily');
+    expect(typographyForWideBarrel.code).toContain('textStyles');
 
     broker.dispose();
     rmSync(root, { recursive: true, force: true });

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -3424,4 +3424,434 @@ describe('EvalBroker', () => {
     broker.dispose();
     rmSync(root, { recursive: true, force: true });
   });
+
+  it('skips re-shipping LoadResult code when runner already has matching hash', async () => {
+    // Multiple importers asking for the same dependency in one runner session
+    // produce identical prepared variants (same hash, same `only`). The first
+    // LOAD must ship code; subsequent LOADs must ship `code: ''` so the
+    // runner's hash-match short-circuit (runner.js:1834) reuses its cached
+    // SourceTextModule instead of re-parsing identical bytes.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const importerA = join(root, 'a.js');
+    const importerB = join(root, 'b.js');
+    const dep = join(root, 'dep.js');
+
+    const customLoader = jest.fn(async () => ({
+      code: 'export const value = 1;',
+    }));
+    const services = createServices(root, importerA, {
+      eval: { customLoader },
+    });
+
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => dep)
+    );
+    const privateBroker = broker as unknown as {
+      handleLoad: (
+        id: string,
+        payload: {
+          id: string;
+          importerId: string | null;
+          request: string | null;
+        }
+      ) => Promise<void>;
+      onlyByModule: Map<string, string[]>;
+      runnerInputQueue: unknown;
+      sendMessage: (message: unknown) => Promise<void>;
+    };
+
+    type CapturedLoadResult = {
+      id: string;
+      payload: { code?: string; hash?: string; only?: string[] };
+    };
+    const captured: CapturedLoadResult[] = [];
+    privateBroker.runnerInputQueue = {
+      write: () => Promise.resolve(),
+    };
+    privateBroker.sendMessage = async (message: unknown) => {
+      const m = message as { type: string } & CapturedLoadResult;
+      if (m.type === 'LOAD_RESULT') {
+        captured.push({ id: m.id, payload: m.payload });
+      }
+    };
+
+    privateBroker.onlyByModule.set(dep, ['*']);
+
+    await privateBroker.handleLoad('msg-1', {
+      id: dep,
+      importerId: importerA,
+      request: null,
+    });
+    await privateBroker.handleLoad('msg-2', {
+      id: dep,
+      importerId: importerB,
+      request: null,
+    });
+
+    expect(captured).toHaveLength(2);
+    const [first, second] = captured;
+    expect(first.payload.code).toBe('export const value = 1;');
+    expect(first.payload.hash).toBeTruthy();
+    expect(second.payload.code).toBe('');
+    expect(second.payload.hash).toBe(first.payload.hash);
+
+    // Third LOAD with a wider `only` (forces a new prepared variant via the
+    // loadCache miss path) must ship code again.
+    const widerLoader = jest.fn(async () => ({
+      code: 'export const value = 1;\nexport const extra = 2;',
+    }));
+    services.options.pluginOptions.eval = { customLoader: widerLoader };
+    privateBroker.onlyByModule.set(dep, ['*', 'extra']);
+
+    await privateBroker.handleLoad('msg-3', {
+      id: dep,
+      importerId: importerA,
+      request: null,
+    });
+
+    expect(captured).toHaveLength(3);
+    expect(captured[2].payload.code).toContain('extra');
+    expect(captured[2].payload.hash).not.toBe(first.payload.hash);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not carry shipped-code coverage across different load hashes', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entry = join(root, 'entry.js');
+    const dep = join(root, 'dep.js');
+    writeFileSync(entry, 'export const __wywPreval = {};');
+
+    const services = createServices(root, entry);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => dep)
+    );
+    const privateBroker = broker as unknown as {
+      handleLoad: (
+        id: string,
+        payload: {
+          id: string;
+          importerId: string | null;
+          request: string | null;
+        }
+      ) => Promise<void>;
+      loadModule: jest.Mock;
+      runnerInputQueue: unknown;
+      sendMessage: (message: unknown) => Promise<void>;
+    };
+
+    type CapturedLoadResult = {
+      id: string;
+      payload: { code?: string; hash?: string; only?: string[] };
+    };
+    const captured: CapturedLoadResult[] = [];
+    privateBroker.runnerInputQueue = {
+      write: () => Promise.resolve(),
+    };
+    privateBroker.sendMessage = async (message: unknown) => {
+      const m = message as { type: string } & CapturedLoadResult;
+      if (m.type === 'LOAD_RESULT') {
+        captured.push({ id: m.id, payload: m.payload });
+      }
+    };
+
+    privateBroker.loadModule = jest
+      .fn()
+      .mockResolvedValueOnce({
+        code: 'export const first = 1;',
+        imports: null,
+        only: ['*'],
+        hash: 'hash-a',
+      })
+      .mockResolvedValueOnce({
+        code: 'export const value = 1;',
+        imports: null,
+        only: ['value'],
+        hash: 'hash-b',
+      })
+      .mockResolvedValueOnce({
+        code: 'export const value = 1;',
+        imports: null,
+        only: ['*'],
+        hash: 'hash-b',
+      });
+
+    await privateBroker.handleLoad('msg-1', {
+      id: dep,
+      importerId: entry,
+      request: null,
+    });
+    await privateBroker.handleLoad('msg-2', {
+      id: dep,
+      importerId: entry,
+      request: null,
+    });
+    await privateBroker.handleLoad('msg-3', {
+      id: dep,
+      importerId: entry,
+      request: null,
+    });
+
+    expect(captured).toHaveLength(3);
+    expect(captured[0].payload.code).toContain('first');
+    expect(captured[1].payload.code).toContain('value');
+    // The second load stored hash-b as a module variant. The prior wildcard
+    // coverage from hash-a must not make the broker believe hash-b also exists
+    // in the runner's primary module cache.
+    expect(captured[2].payload.code).toContain('value');
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('keeps shipped-code mirror across evaluate() boundaries with stable globals/happyDOM', async () => {
+    // Real workflows reuse the runner across many entrypoints. The runner
+    // only resets its moduleCache when globals or happyDOM change
+    // (runner.js:2116). When those are stable, INIT just rebinds entrypoint
+    // metadata and the runner keeps every cached module — so the broker's
+    // shipped-code mirror must survive cross-entrypoint INITs.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entryA = join(root, 'a.js');
+    const entryB = join(root, 'b.js');
+    const dep = join(root, 'dep.js');
+    writeFileSync(entryA, 'export const __wywPreval = {};');
+    writeFileSync(entryB, 'export const __wywPreval = {};');
+
+    const customLoader = jest.fn(async () => ({
+      code: 'export const value = 1;',
+    }));
+    const services = createServices(root, entryA, {
+      eval: { customLoader },
+    });
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => dep)
+    );
+    const privateBroker = broker as unknown as {
+      ensureRunner: () => Promise<void>;
+      handleLoad: (
+        id: string,
+        payload: { id: string; importerId: string | null; request: string | null }
+      ) => Promise<void>;
+      initRunner: (entrypoint: Entrypoint) => Promise<void>;
+      lastInitKey: string | null;
+      lastHappyDomEnabled: boolean;
+      lastSentLoadByModule: Map<string, { hash: string; only: string[] }>;
+      onlyByModule: Map<string, string[]>;
+      request: (
+        type: string,
+        payload: unknown,
+        timeoutMs?: number
+      ) => Promise<unknown>;
+      runnerInputQueue: unknown;
+      sendMessage: (message: unknown) => Promise<void>;
+    };
+    privateBroker.ensureRunner = jest.fn(async () => {});
+    privateBroker.request = jest.fn(async () => ({}));
+
+    type CapturedLoadResult = {
+      id: string;
+      payload: { code?: string; hash?: string };
+    };
+    const captured: CapturedLoadResult[] = [];
+    privateBroker.runnerInputQueue = {
+      write: () => Promise.resolve(),
+    };
+    privateBroker.sendMessage = async (message: unknown) => {
+      const m = message as { type: string } & CapturedLoadResult;
+      if (m.type === 'LOAD_RESULT') {
+        captured.push({ id: m.id, payload: m.payload });
+      }
+    };
+
+    privateBroker.onlyByModule.set(dep, ['*']);
+
+    const entrypointA = Entrypoint.createRoot(
+      services,
+      entryA,
+      ['__wywPreval'],
+      readFileSync(entryA, 'utf-8')
+    );
+    const entrypointB = Entrypoint.createRoot(
+      services,
+      entryB,
+      ['__wywPreval'],
+      readFileSync(entryB, 'utf-8')
+    );
+
+    await privateBroker.initRunner(entrypointA);
+    await privateBroker.handleLoad('msg-1', {
+      id: dep,
+      importerId: entryA,
+      request: null,
+    });
+
+    // Switch to a different entrypoint — initKey changes but globals/happyDOM
+    // are identical, so the runner keeps moduleCache and our mirror must too.
+    await privateBroker.initRunner(entrypointB);
+    expect(privateBroker.lastSentLoadByModule.size).toBeGreaterThan(0);
+
+    await privateBroker.handleLoad('msg-2', {
+      id: dep,
+      importerId: entryB,
+      request: null,
+    });
+
+    expect(captured).toHaveLength(2);
+    expect(captured[0].payload.code).toBe('export const value = 1;');
+    expect(captured[1].payload.code).toBe('');
+    expect(captured[1].payload.hash).toBe(captured[0].payload.hash);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  describe('evaluate batching', () => {
+    type BatchPrivateBroker = {
+      ensureRunner: () => Promise<void>;
+      initRunner: (entrypoint: Entrypoint) => Promise<void>;
+      onlyByModule: Map<string, string[]>;
+      pendingEvals: unknown[];
+      request: (
+        type: string,
+        payload: unknown,
+        timeoutMs?: number
+      ) => Promise<unknown>;
+    };
+
+    const stubBatchInternals = (
+      broker: EvalBroker,
+      onEval: (id: string) => Promise<{
+        values: Record<string, unknown> | null;
+        modules?: Record<string, unknown>;
+      }>
+    ) => {
+      const pb = broker as unknown as BatchPrivateBroker;
+      pb.ensureRunner = jest.fn(async () => {});
+      pb.initRunner = jest.fn(async () => {});
+      pb.request = jest.fn(async (type, payload) => {
+        if (type !== 'EVAL') {
+          throw new Error(`unexpected request type: ${type}`);
+        }
+        const { id } = payload as { id: string };
+        return onEval(id);
+      });
+      return pb;
+    };
+
+    it('coalesces concurrent evaluate() calls into one runner pass', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+      const entries = ['a', 'b', 'c'].map((n) => join(root, `${n}.js`));
+      entries.forEach((p) => writeFileSync(p, 'export const __wywPreval = {};'));
+
+      const services = createServices(root, entries[0]);
+      const broker = new EvalBroker(
+        services,
+        jest.fn(async () => null)
+      );
+      const entrypoints = entries.map((p) =>
+        Entrypoint.createRoot(services, p, ['__wywPreval'], readFileSync(p, 'utf-8'))
+      );
+
+      const evalOrder: string[] = [];
+      const onlySnapshots: Record<string, string[] | undefined> = {};
+      const pb = stubBatchInternals(broker, async (id) => {
+        evalOrder.push(id);
+        // Capture the broker's onlyByModule for this entrypoint at the moment
+        // EVAL is sent — proves per-entrypoint state-clear runs between
+        // members of the batch.
+        onlySnapshots[id] = pb.onlyByModule.get(id);
+        return {
+          values: { v: serializeValue(`from-${id}`, { allowFunctions: true }) },
+        };
+      });
+
+      const initSpy = pb.initRunner as jest.Mock;
+      const ensureSpy = pb.ensureRunner as jest.Mock;
+
+      const promises = entrypoints.map((ep) => broker.evaluate(ep));
+      const results = await Promise.all(promises);
+
+      expect(evalOrder).toEqual(entries);
+      results.forEach((r, i) => {
+        expect(r.values?.get('v')).toBe(`from-${entries[i]}`);
+      });
+      entries.forEach((p) => {
+        expect(onlySnapshots[p]).toEqual(['__wywPreval']);
+      });
+      // One ensureRunner across the batch; initRunner still per-member
+      // (cheap on the runner side via canReuseContext).
+      expect(ensureSpy).toHaveBeenCalledTimes(1);
+      expect(initSpy).toHaveBeenCalledTimes(3);
+
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    it('isolates batch-member failures', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+      const entries = ['a', 'b', 'c'].map((n) => join(root, `${n}.js`));
+      entries.forEach((p) => writeFileSync(p, 'export const __wywPreval = {};'));
+
+      const services = createServices(root, entries[0]);
+      const broker = new EvalBroker(
+        services,
+        jest.fn(async () => null)
+      );
+      const entrypoints = entries.map((p) =>
+        Entrypoint.createRoot(services, p, ['__wywPreval'], readFileSync(p, 'utf-8'))
+      );
+
+      stubBatchInternals(broker, async (id) => {
+        if (id === entries[1]) {
+          throw new Error('middle-fail');
+        }
+        return { values: { v: serializeValue(id, { allowFunctions: true }) } };
+      });
+
+      const settled = await Promise.allSettled(
+        entrypoints.map((ep) => broker.evaluate(ep))
+      );
+      expect(settled[0].status).toBe('fulfilled');
+      expect(settled[1].status).toBe('rejected');
+      expect(settled[2].status).toBe('fulfilled');
+      if (settled[1].status === 'rejected') {
+        expect(String(settled[1].reason)).toContain('middle-fail');
+      }
+
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    it('single evaluate() call still runs (batch of one is a no-op)', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+      const entry = join(root, 'a.js');
+      writeFileSync(entry, 'export const __wywPreval = {};');
+
+      const services = createServices(root, entry);
+      const broker = new EvalBroker(
+        services,
+        jest.fn(async () => null)
+      );
+      const entrypoint = Entrypoint.createRoot(
+        services,
+        entry,
+        ['__wywPreval'],
+        readFileSync(entry, 'utf-8')
+      );
+
+      stubBatchInternals(broker, async (id) => ({
+        values: { v: serializeValue(id, { allowFunctions: true }) },
+      }));
+
+      const result = await broker.evaluate(entrypoint);
+      expect(result.values?.get('v')).toBe(entry);
+
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    });
+  });
 });

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -812,10 +812,9 @@ describe('EvalBroker', () => {
       request: dep,
     });
 
-    // Top-level forbidden references are stripped (executed at module load).
+    // The shaker removes all code not referenced by __wywPreval.
     expect(loaded.code).not.toContain('window.location.href');
-    // Deferred function bodies are kept — they don't run during preeval.
-    expect(loaded.code).toContain('document.createTreeWalker');
+    expect(loaded.code).not.toContain('document.createTreeWalker');
 
     broker.dispose();
     rmSync(root, { recursive: true, force: true });
@@ -906,6 +905,81 @@ describe('EvalBroker', () => {
 
     expect(result.values?.get('value')).toBe(1);
     expect(asyncResolve).not.toHaveBeenCalledWith('./dep.js', entry);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not widen preval-only eval loads with cached runtime component exports', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entry = join(root, 'entry.tsx');
+    const tokens = join(root, 'tokens.ts');
+
+    writeFileSync(
+      tokens,
+      [
+        'export const border = { radius8: 8 };',
+        "export const themeVars = { inputBorderHoverColor: 'red' };",
+      ].join('\n')
+    );
+    writeFileSync(
+      entry,
+      [
+        "import { memo } from 'react';",
+        "import { css } from 'test-css-processor';",
+        "import { border, themeVars } from './tokens';",
+        'const className = css`',
+        '  border-radius: ${border.radius8}px;',
+        '  color: ${themeVars.inputBorderHoverColor};',
+        '`;',
+        'export const Comment = memo(function Comment() {',
+        '  return <div className={className} />;',
+        '});',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what === 'test-css-processor') {
+        return testCssProcessorFile;
+      }
+
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+
+      return null;
+    });
+    const services = createServices(root, entry, {
+      tagResolver: (source, tag) => {
+        if (source === 'test-css-processor' && tag === 'css') {
+          return testCssProcessorFile;
+        }
+
+        return null;
+      },
+    });
+    const broker = new EvalBroker(services, asyncResolve);
+    const privateBroker = getPrivateBroker(broker);
+
+    privateBroker.onlyByModule.set(entry, ['Comment']);
+    await privateBroker.loadModule({
+      id: entry,
+      importerId: entry,
+      request: entry,
+    });
+
+    privateBroker.onlyByModule.set(entry, ['__wywPreval']);
+    const loaded = await privateBroker.loadModule({
+      id: entry,
+      importerId: entry,
+      request: entry,
+    });
+
+    expect(loaded.only).toEqual(['__wywPreval']);
+    expect(loaded.code).toContain('export const __wywPreval');
+    expect(loaded.code).not.toContain('memo');
+    expect(loaded.code).not.toContain('Comment');
+    expect(loaded.imports?.has('react')).toBe(false);
 
     broker.dispose();
     rmSync(root, { recursive: true, force: true });
@@ -1433,21 +1507,18 @@ describe('EvalBroker', () => {
       writeFileSync(
         dep,
         [
-          'globalThis.__iconsLoadCount = (globalThis.__iconsLoadCount ?? 0) + 1;',
+          'export const loadCount = (() => { globalThis.__iconsLoadCount = (globalThis.__iconsLoadCount ?? 0) + 1; return globalThis.__iconsLoadCount; })();',
           "import InviteMedium from './svg-react.js';",
           "import CreateSemibold from './svg-react.js';",
           'export { InviteMedium, CreateSemibold };',
-          'export const __wywPreval = {',
-          '  count: () => globalThis.__iconsLoadCount,',
-          '};',
         ].join('\n')
       );
       writeFileSync(
         firstEntry,
         [
-          "import { InviteMedium } from './icons.js';",
+          "import { InviteMedium, loadCount } from './icons.js';",
           'export const __wywPreval = {',
-          '  count: () => globalThis.__iconsLoadCount,',
+          '  count: () => loadCount,',
           '  value: () => InviteMedium,',
           '};',
         ].join('\n')
@@ -1455,9 +1526,9 @@ describe('EvalBroker', () => {
       writeFileSync(
         secondEntry,
         [
-          "import { CreateSemibold } from './icons.js';",
+          "import { CreateSemibold, loadCount } from './icons.js';",
           'export const __wywPreval = {',
-          '  count: () => globalThis.__iconsLoadCount,',
+          '  count: () => loadCount,',
           '  value: () => CreateSemibold,',
           '};',
         ].join('\n')
@@ -1475,12 +1546,6 @@ describe('EvalBroker', () => {
         },
       });
       const broker = new EvalBroker(services, asyncResolve);
-      const depEntrypoint = Entrypoint.createRoot(
-        services,
-        dep,
-        ['__wywPreval'],
-        readFileSync(dep, 'utf-8')
-      );
       const firstEntrypoint = Entrypoint.createRoot(
         services,
         firstEntry,
@@ -1494,13 +1559,13 @@ describe('EvalBroker', () => {
         readFileSync(secondEntry, 'utf-8')
       );
 
-      const [depResult, firstResult, secondResult] = await Promise.all([
-        broker.evaluate(depEntrypoint),
+      const [firstResult, secondResult] = await Promise.all([
         broker.evaluate(firstEntrypoint),
         broker.evaluate(secondEntrypoint),
       ]);
 
-      expect(depResult.values?.get('count')).toBe(1);
+      // Both entries import icons.js with noShake — single unshaken variant,
+      // so the module executes only once despite two concurrent consumers.
       expect(firstResult.values?.get('count')).toBe(1);
       expect(secondResult.values?.get('count')).toBe(1);
       expect(firstResult.values?.get('value')).toBe('svg-mock');

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -1934,8 +1934,7 @@ describe('EvalBroker', () => {
       rmSync(root, { recursive: true, force: true });
     });
 
-
-  it('builds direct proxy modules for requested exports from mixed re-export barrels', async () => {
+    it('builds direct proxy modules for requested exports from mixed re-export barrels', async () => {
       const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
       const entry = join(root, 'entry.js');
       const barrel = join(root, 'barrel.js');
@@ -2020,51 +2019,41 @@ describe('EvalBroker', () => {
       );
       writeFileSync(
         first,
-        [
-          "import { foo } from './dep.js';",
-          'export const value = foo;',
-        ].join('\n')
+        ["import { foo } from './dep.js';", 'export const value = foo;'].join(
+          '\n'
+        )
       );
       writeFileSync(
         second,
-        [
-          "import { bar } from './dep.js';",
-          'export const value = bar;',
-        ].join('\n')
+        ["import { bar } from './dep.js';", 'export const value = bar;'].join(
+          '\n'
+        )
       );
       const services = createServices(root, first);
-      services.cache.add(
-        'entrypoints',
-        first,
-        {
-          dependencies: new Map([
-            [
-              './dep.js',
-              {
-                only: ['foo'],
-                resolved: dep,
-                source: './dep.js',
-              },
-            ],
-          ]),
-        } as any
-      );
-      services.cache.add(
-        'entrypoints',
-        second,
-        {
-          dependencies: new Map([
-            [
-              './dep.js',
-              {
-                only: ['bar'],
-                resolved: dep,
-                source: './dep.js',
-              },
-            ],
-          ]),
-        } as any
-      );
+      services.cache.add('entrypoints', first, {
+        dependencies: new Map([
+          [
+            './dep.js',
+            {
+              only: ['foo'],
+              resolved: dep,
+              source: './dep.js',
+            },
+          ],
+        ]),
+      } as any);
+      services.cache.add('entrypoints', second, {
+        dependencies: new Map([
+          [
+            './dep.js',
+            {
+              only: ['bar'],
+              resolved: dep,
+              source: './dep.js',
+            },
+          ],
+        ]),
+      } as any);
 
       const broker = new EvalBroker(
         services,

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -579,6 +579,144 @@ describe('EvalBroker', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it('reloads in-flight modules when nested imports request additional exports', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entry = join(root, 'entry.js');
+    const helper = join(root, 'helper.js');
+    const dep = join(root, 'dep.js');
+
+    writeFileSync(
+      entry,
+      [
+        "import { first } from './dep.js';",
+        "import { second } from './helper.js';",
+        'export const __wywPreval = {',
+        '  value: () => `${first}:${second}`,',
+        '};',
+      ].join('\n')
+    );
+    writeFileSync(
+      helper,
+      ["import { second } from './dep.js';", 'export { second };'].join('\n')
+    );
+    writeFileSync(
+      dep,
+      ["export const first = 'first';", "export const second = 'second';"].join(
+        '\n'
+      )
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+
+      return null;
+    });
+    const services = createServices(root, entry);
+    const loadAndParse = services.loadAndParseFn;
+    let slowedDepLoad = false;
+    services.loadAndParseFn = (nextServices, id, ...rest) => {
+      if (id === dep && !slowedDepLoad) {
+        slowedDepLoad = true;
+        const end = Date.now() + 50;
+        while (Date.now() < end) {
+          // Keep the first dep load in-flight while nested imports resolve.
+        }
+      }
+
+      return loadAndParse(nextServices, id, ...rest);
+    };
+
+    const broker = new EvalBroker(services, asyncResolve);
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      entry,
+      ['__wywPreval'],
+      readFileSync(entry, 'utf-8')
+    );
+
+    const result = await broker.evaluate(entrypoint);
+
+    expect(result.values?.get('value')).toBe('first:second');
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not reuse partial prepared export cache for wildcard or __wywPreval loads', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const dep = join(root, 'dep.js');
+
+    writeFileSync(
+      dep,
+      [
+        "export const normal = 'normal';",
+        "export const second = 'second';",
+        'export const __wywPreval = {',
+        "  value: () => 'preval',",
+        '};',
+      ].join('\n')
+    );
+
+    const services = createServices(root, dep);
+    const exportsProxy = Entrypoint.createExports(services.log);
+    exportsProxy.normal = 'cached-normal';
+    services.cache.add('entrypoints', dep, {
+      dependencies: new Map(),
+      evaluated: true,
+      evaluatedOnly: ['*'],
+      exports: exportsProxy,
+      generation: 1,
+      hasTransformResult: false,
+      hasWywMetadata: false,
+      ignored: false,
+      invalidationDependencies: new Map(),
+      invalidateOnDependencyChange: new Set(),
+      log: services.log,
+      name: dep,
+      only: ['*'],
+      parents: [],
+      preevalResult: null,
+      seqId: -1,
+      transformResultCode: null,
+    });
+
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => dep)
+    );
+    const privateBroker = getPrivateBroker(broker);
+
+    privateBroker.onlyByModule.set(dep, ['*']);
+    const wildcardPrepared = await privateBroker.loadModule({
+      id: dep,
+      importerId: dep,
+      request: dep,
+    });
+
+    privateBroker.onlyByModule.set(dep, ['second']);
+    const namedPrepared = await privateBroker.loadModule({
+      id: dep,
+      importerId: dep,
+      request: dep,
+    });
+
+    privateBroker.onlyByModule.set(dep, ['__wywPreval']);
+    const prevalPrepared = await privateBroker.loadModule({
+      id: dep,
+      importerId: dep,
+      request: dep,
+    });
+
+    expect(wildcardPrepared.code).toContain('normal');
+    expect(namedPrepared.code).toContain('second');
+    expect(prevalPrepared.code).toContain('__wywPreval');
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it('invalidates all query variants in load cache after file change', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
     const importer = join(root, 'entry.js');

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -1067,10 +1067,7 @@ describe('EvalBroker', () => {
     const result = await broker.evaluate(childEntrypoint);
 
     expect(result.values?.get('value')).toBe(42);
-    expect(asyncResolve).toHaveBeenCalledWith('./nested.js', dep, [
-      dep,
-      entry,
-    ]);
+    expect(asyncResolve).toHaveBeenCalledWith('./nested.js', dep, [dep, entry]);
 
     broker.dispose();
     rmSync(root, { recursive: true, force: true });
@@ -2789,10 +2786,9 @@ describe('EvalBroker', () => {
     // barrel.js — two exports
     writeFileSync(
       join(root, 'barrel.js'),
-      [
-        'export const fontWeight = 400;',
-        'export const iconSize = 24;',
-      ].join('\n')
+      ['export const fontWeight = 400;', 'export const iconSize = 24;'].join(
+        '\n'
+      )
     );
 
     // entry-a.js — only needs fontWeight

--- a/packages/transform/src/__tests__/fileReporter.test.ts
+++ b/packages/transform/src/__tests__/fileReporter.test.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { createFileReporter } from '../debug/fileReporter';
+
+const waitFor = async (
+  predicate: () => boolean,
+  { timeoutMs = 1000, intervalMs = 5 } = {}
+) => {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error('waitFor timed out');
+    }
+
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+};
+
+const readJsonl = (file: string) =>
+  readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+
+describe('createFileReporter', () => {
+  it('writes staticResolve single events to static-resolve.jsonl', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wyw-file-reporter-'));
+    const reporter = createFileReporter({ dir });
+
+    try {
+      reporter.emitter.single({
+        filename: join(dir, 'foo.ts'),
+        phase: 'export',
+        reason: 'unsupported-expression',
+        status: 'rejected',
+        type: 'staticResolve',
+      });
+      reporter.emitter.single({
+        candidate: '_exp',
+        filename: join(dir, 'foo.ts'),
+        phase: 'candidate',
+        status: 'resolved',
+        type: 'staticResolve',
+      });
+      // unrelated single events should not land in the static-resolve stream
+      reporter.emitter.single({
+        file: join(dir, 'foo.ts'),
+        fileIdx: 'idx',
+        imports: [],
+        only: ['*'],
+        type: 'dependency',
+      });
+
+      reporter.onDone(dir);
+      const target = join(dir, 'static-resolve.jsonl');
+      await waitFor(() => existsSync(target) && readFileSync(target).length > 0);
+
+      const events = readJsonl(target);
+      expect(events).toHaveLength(2);
+      expect(events[0]).toEqual(
+        expect.objectContaining({
+          phase: 'export',
+          reason: 'unsupported-expression',
+          status: 'rejected',
+          type: 'staticResolve',
+        })
+      );
+      expect(events[1]).toEqual(
+        expect.objectContaining({
+          candidate: '_exp',
+          phase: 'candidate',
+          status: 'resolved',
+          type: 'staticResolve',
+        })
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a dummy reporter when no dir is provided', () => {
+    const reporter = createFileReporter(false);
+    expect(() => reporter.emitter.single({ type: 'staticResolve' })).not.toThrow();
+    expect(() => reporter.onDone('/')).not.toThrow();
+  });
+});

--- a/packages/transform/src/__tests__/oxc-collect-runtime.test.ts
+++ b/packages/transform/src/__tests__/oxc-collect-runtime.test.ts
@@ -357,14 +357,15 @@ export const whiteColor = '#fff';`);
       (processor) => processor.displayName === 'title'
     );
     const titleCssText =
-      titleProcessor?.artifacts[0]?.[1]?.[0]?.[
-        `.${titleProcessor.className}`
-      ]?.cssText ?? '';
+      titleProcessor?.artifacts[0]?.[1]?.[0]?.[`.${titleProcessor.className}`]
+        ?.cssText ?? '';
 
     expect(processors).toHaveLength(3);
-    expect(
-      processors.map((processor) => processor.displayName)
-    ).toStrictEqual(['small', 'contrast', 'title']);
+    expect(processors.map((processor) => processor.displayName)).toStrictEqual([
+      'small',
+      'contrast',
+      'title',
+    ]);
     expect(titleCssText).toContain('font-size: 24px;');
     expect(titleCssText).toContain('&.CLASS_SMALL');
     expect(titleCssText).toContain('font-size: 15px;');
@@ -544,8 +545,6 @@ export const whiteColor = '#fff';`);
       new Map()
     );
 
-    expect(result.code).toBe(
-      `export function Something() {\n  return 1;\n}`
-    );
+    expect(result.code).toBe(`export function Something() {\n  return 1;\n}`);
   });
 });

--- a/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
+++ b/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
@@ -48,6 +48,7 @@ const options: Pick<
   extensions: ['.tsx'],
   features: {
     dangerousCodeRemover: true,
+    staticImportValues: true,
   },
   tagResolver: (source, imported) => {
     if (source !== 'test-package' || imported !== 'css') {

--- a/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
+++ b/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
@@ -115,6 +115,24 @@ describe('runOxcPreevalStage', () => {
     expect(result.code).toContain('export const __wywPreval = {};');
   });
 
+  it('keeps statically evaluated local constants out of __wywPreval', () => {
+    const result = runOxcPreevalStage(
+      `
+        import { css } from 'test-package';
+        const color = 'red';
+        export const a = css\`
+          color: ${'${color}'};
+        \`;
+      `,
+      fileContext,
+      options
+    );
+
+    expect(result.staticValueCache.get('_exp')).toBe('red');
+    expect(result.code).toContain('export const __wywPreval = {};');
+    expect(result.code).not.toContain('__wywPreval = { _exp: _exp }');
+  });
+
   it('still applies preeval syntax rewrites when no processors are present', () => {
     const result = runOxcPreevalStage(
       `
@@ -203,7 +221,7 @@ describe('runOxcPreevalStage', () => {
     });
 
     expect(shaken.code).toContain('export const __wywPreval');
-    expect(shaken.code).toContain('const _exp =');
+    expect(shaken.code).not.toContain('const _exp =');
     expect(shaken.code).not.toContain('test-package');
     expect(shaken.code).not.toContain('runtime-only');
     expect(shaken.code).not.toContain('export const className');
@@ -234,7 +252,9 @@ describe('runOxcPreevalStage', () => {
       }
     );
 
-    expect(preeval.code).toContain('export const __wywPreval = { _exp: _exp };');
+    expect(preeval.code).toContain(
+      'export const __wywPreval = { _exp: _exp };'
+    );
     expect(shaken.code).toContain('export const __wywPreval = { _exp: _exp };');
     expect(shaken.code).toContain('const _exp =');
   });

--- a/packages/transform/src/__tests__/oxc-preeval-transforms.test.ts
+++ b/packages/transform/src/__tests__/oxc-preeval-transforms.test.ts
@@ -116,9 +116,10 @@ describe('oxc preeval transforms', () => {
           filename
         )
       ).toBe(
-        ['const url = "./__fixtures__/FOO";', 'require("./__fixtures__/foo");'].join(
-          '\n'
-        )
+        [
+          'const url = "./__fixtures__/FOO";',
+          'require("./__fixtures__/foo");',
+        ].join('\n')
       );
     });
 
@@ -540,10 +541,7 @@ describe('oxc preeval transforms', () => {
 
     it('does not skip computed property keys that reference forbidden globals', () => {
       const code = removeDangerousCodeWithOxc(
-        [
-          'const dangerous = { [fetch]: 1 };',
-          'const keep = 1;',
-        ].join('\n'),
+        ['const dangerous = { [fetch]: 1 };', 'const keep = 1;'].join('\n'),
         filename
       );
 
@@ -619,7 +617,9 @@ describe('oxc preeval transforms', () => {
         filename
       );
 
-      expect(code).toContain('export const fetchProxy = (...args) => fetch(...args)');
+      expect(code).toContain(
+        'export const fetchProxy = (...args) => fetch(...args)'
+      );
       expect(() => stripTypesAndJsxWithOxc(code, filename)).not.toThrow();
     });
 
@@ -647,7 +647,9 @@ describe('oxc preeval transforms', () => {
         filename
       );
 
-      expect(code).toContain('const isFlagPresent = (flag) => window.location.search.includes(flag)');
+      expect(code).toContain(
+        'const isFlagPresent = (flag) => window.location.search.includes(flag)'
+      );
       expect(code).toContain('export { isFlagPresent }');
       expect(() => stripTypesAndJsxWithOxc(code, filename)).not.toThrow();
     });
@@ -706,10 +708,7 @@ describe('oxc preeval transforms', () => {
 
     it('does not leave a bare await when removing a top-level forbidden fetch call', () => {
       const code = removeDangerousCodeWithOxc(
-        [
-          'await fetch("/api");',
-          'const keep = 1;',
-        ].join('\n'),
+        ['await fetch("/api");', 'const keep = 1;'].join('\n'),
         filename
       );
 

--- a/packages/transform/src/__tests__/oxc-preeval-transforms.test.ts
+++ b/packages/transform/src/__tests__/oxc-preeval-transforms.test.ts
@@ -200,6 +200,22 @@ describe('oxc preeval transforms', () => {
       expect(code).toContain('export const keep = CommentComponent');
     });
 
+    it('preserves imported names in aliased import specifiers', () => {
+      const code = removeDangerousCodeWithOxc(
+        [
+          'import { jsx as _jsx } from "react/jsx-runtime";',
+          'import { Range as RcRange } from "rc-slider";',
+          'const Range = () => _jsx(RcRange, {});',
+          'export default Range;',
+        ].join('\n'),
+        filename
+      );
+
+      expect(code).toContain('import { Range as RcRange } from "rc-slider";');
+      expect(code).toContain('const Range = () => { return null; };');
+      expect(() => stripTypesAndJsxWithOxc(code, filename)).not.toThrow();
+    });
+
     it('removes exported browser-global declarations without leaving dangling export syntax', () => {
       const code = removeDangerousCodeWithOxc(
         [

--- a/packages/transform/src/__tests__/oxc-prepare-code.test.ts
+++ b/packages/transform/src/__tests__/oxc-prepare-code.test.ts
@@ -106,7 +106,8 @@ describe('prepareCode with explicit oxcShaker action', () => {
     const [code, imports, metadata] = prepareCode(services, entrypoint, null);
 
     expect(code).toContain('export const __wywPreval =');
-    expect(code).toContain('var _exp =');
+    expect(code).toContain('export const __wywPreval = {};');
+    expect(code).not.toContain('var _exp =');
     expect(code).not.toContain('runtime-only');
     expect(code).not.toContain('test-css-processor');
     expect(imports?.size).toBe(0);

--- a/packages/transform/src/__tests__/oxc-prepare-code.test.ts
+++ b/packages/transform/src/__tests__/oxc-prepare-code.test.ts
@@ -267,6 +267,51 @@ describe('prepareCode with explicit oxcShaker action', () => {
     expect(metadata).toBeNull();
   });
 
+  it('shakes no-metadata eval runtime modules that already export __wywPreval', () => {
+    const root = __dirname;
+    const filename = join(root, 'prepared-preval.tsx');
+    const source = dedent`
+      import { themeVars } from '@fibery/ui-kit/src/design-system';
+      import { memo } from 'react';
+
+      var _exp = () => themeVars.inputBorderHoverColor;
+      var Comment = memo(function Comment() {
+        return null;
+      });
+
+      export const __wywPreval = {
+        _exp,
+      };
+    `;
+    const services = createServices(filename, root);
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      filename,
+      ['__wywPreval'],
+      source
+    );
+
+    if (entrypoint.ignored) {
+      throw new Error('Ignored');
+    }
+
+    const [code, imports, metadata] = prepareCodeForEvalRuntime(
+      services,
+      entrypoint,
+      null
+    );
+
+    expect(code).toContain('export const __wywPreval');
+    expect(code).toContain('_exp');
+    expect(code).not.toContain('memo');
+    expect(code).not.toContain('Comment');
+    expect(imports?.get('@fibery/ui-kit/src/design-system')).toEqual([
+      'themeVars',
+    ]);
+    expect(imports?.has('react')).toBe(false);
+    expect(metadata).toBeNull();
+  });
+
   it('strips TypeScript from metadata-bearing eval runtime modules', () => {
     const root = __dirname;
     const filename = join(root, 'typed-styles.ts');

--- a/packages/transform/src/__tests__/oxc-prepare-code.test.ts
+++ b/packages/transform/src/__tests__/oxc-prepare-code.test.ts
@@ -38,6 +38,9 @@ const createServices = (filename: string, root: string) =>
       root,
       pluginOptions: loadWywOptions({
         configFile: false,
+        features: {
+          staticImportValues: true,
+        },
         rules: [
           {
             action: oxcShaker,

--- a/packages/transform/src/__tests__/oxc-prepare-comment.test.ts
+++ b/packages/transform/src/__tests__/oxc-prepare-comment.test.ts
@@ -1,0 +1,80 @@
+/* eslint-env jest */
+import { join } from 'path';
+
+import dedent from 'dedent';
+
+import { oxcShaker } from '../shaker';
+import { Entrypoint } from '../transform/Entrypoint';
+import { prepareCodeForEvalRuntime } from '../transform/generators/transform';
+import { loadWywOptions } from '../transform/helpers/loadWywOptions';
+import { withDefaultServices } from '../transform/helpers/withDefaultServices';
+
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+
+const createServices = (filename: string, root: string) =>
+  withDefaultServices({
+    options: {
+      filename,
+      root,
+      pluginOptions: loadWywOptions({
+        configFile: false,
+        features: { staticImportValues: true },
+        rules: [{ action: oxcShaker, test: () => true }],
+        tagResolver: (source, tag) =>
+          source === 'test-css-processor' && tag === 'css'
+            ? processorFile
+            : null,
+      }),
+    },
+  });
+
+describe('comment.tsx-like prepare', () => {
+  it('does not keep memo wrapper alive via aliased re-import of same name', () => {
+    // Repro: a file declares a top-level `Comment` AND imports a same-named
+    // identifier from another module under an alias (`Comment as Other`).
+    // Before the imported-name reference fix, the shaker treated the imported
+    // name `Comment` as a reference to the local `Comment` binding, marking
+    // `var Comment = memo(...)` live and pulling `memo` along with it.
+    const root = __dirname;
+    const filename = join(root, 'comment-like.tsx');
+    const source = dedent`
+      import { Comment as CommentComponent, commentContentStyle } from './ui-kit/comment';
+      import { themeVars } from './design-system';
+      import { memo } from 'react';
+
+      var _exp = () => themeVars.color;
+      var _exp2 = () => commentContentStyle;
+
+      export const Comment = memo(function Comment(props) {
+        return null;
+      });
+
+      export const __wywPreval = { _exp, _exp2 };
+    `;
+
+    const services = createServices(filename, root);
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      filename,
+      ['__wywPreval'],
+      source
+    );
+
+    if (entrypoint.ignored) {
+      throw new Error('ignored');
+    }
+
+    const [code, imports] = prepareCodeForEvalRuntime(
+      services,
+      entrypoint,
+      null
+    );
+
+    expect(code).not.toContain('var Comment');
+    expect(code).not.toContain("from 'react'");
+    expect(code).not.toContain('memo(');
+    expect(imports?.has('react')).toBe(false);
+    // CommentComponent is unused → its import should also be pruned.
+    expect(imports?.get('./ui-kit/comment')).toEqual(['commentContentStyle']);
+  });
+});

--- a/packages/transform/src/__tests__/oxc-shaker.test.ts
+++ b/packages/transform/src/__tests__/oxc-shaker.test.ts
@@ -231,7 +231,7 @@ describe('shakeOxcToESM', () => {
       `
     );
 
-    expect(code).toContain("import { foo1");
+    expect(code).toContain('import { foo1');
     expect(code).toContain("from './foo'");
     expect(code).not.toContain('foo2');
     expect(imports.get('./foo')).toEqual(['foo1']);

--- a/packages/transform/src/__tests__/oxc-workflow.test.ts
+++ b/packages/transform/src/__tests__/oxc-workflow.test.ts
@@ -375,7 +375,9 @@ describe('explicit Oxc workflow', () => {
       const base = result.values?.get('_exp');
 
       expect(preparedEntry.code).toContain('var _exp = () => Base;');
-      expect(preparedEntry.code).toContain('export const __wywPreval = { _exp };');
+      expect(preparedEntry.code).toContain(
+        'export const __wywPreval = { _exp };'
+      );
       expect(preparedBase.code).toContain('__wyw_meta');
       expect(base).toMatchObject({
         __wyw_meta: {
@@ -422,7 +424,10 @@ describe('explicit Oxc workflow', () => {
       ),
       { recursive: true }
     );
-    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'portal-app' }));
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'portal-app' })
+    );
     writeFileSync(
       baseFile,
       dedent`
@@ -519,7 +524,10 @@ describe('explicit Oxc workflow', () => {
       ),
       { recursive: true }
     );
-    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'portal-app' }));
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'portal-app' })
+    );
     writeFileSync(
       baseFile,
       dedent`
@@ -656,7 +664,10 @@ describe('explicit Oxc workflow', () => {
     mkdirSync(join(root, 'node_modules', 'animated-scroll-to'), {
       recursive: true,
     });
-    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'portal-app' }));
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ name: 'portal-app' })
+    );
     writeFileSync(
       baseFile,
       dedent`

--- a/packages/transform/src/__tests__/resolveImports.boundedRetry.test.ts
+++ b/packages/transform/src/__tests__/resolveImports.boundedRetry.test.ts
@@ -1,0 +1,194 @@
+import * as babel from '@babel/core';
+
+import type { StrictOptions } from '@wyw-in-js/shared';
+import { logger } from '@wyw-in-js/shared';
+
+import { TransformCacheCollection } from '../cache';
+import { Entrypoint } from '../transform/Entrypoint';
+import type { LoadAndParseFn } from '../transform/Entrypoint.types';
+import { asyncResolveImports } from '../transform/generators/resolveImports';
+import type { IResolveImportsAction, Services } from '../transform/types';
+import { EventEmitter } from '../utils/EventEmitter';
+
+const createPluginOptions = (): StrictOptions => ({
+  babelOptions: {},
+  displayName: false,
+  evaluate: true,
+  extensions: ['.cjs', '.js', '.jsx', '.ts', '.tsx'],
+  features: {
+    dangerousCodeRemover: true,
+    globalCache: true,
+    happyDOM: true,
+    softErrors: false,
+    useBabelConfigs: true,
+    useWeakRefInEval: true,
+  },
+  highPriorityPlugins: [],
+  importOverrides: undefined,
+  rules: [],
+});
+
+const createServices = (filename: string): Services => {
+  const loadAndParseFn: LoadAndParseFn = (services, _name, loadedCode) => ({
+    get ast() {
+      return services.babel.parseSync(loadedCode ?? '')!;
+    },
+    code: loadedCode ?? '',
+    evaluator: jest.fn(),
+    evalConfig: {},
+  });
+
+  return {
+    babel,
+    cache: new TransformCacheCollection(),
+    loadAndParseFn,
+    log: logger,
+    eventEmitter: EventEmitter.dummy,
+    options: {
+      filename,
+      root: '/project',
+      pluginOptions: createPluginOptions(),
+    },
+  };
+};
+
+const drainAsync = async <T>(gen: AsyncGenerator<unknown, T>): Promise<T> => {
+  while (true) {
+    const next = await gen.next();
+    if (next.done) {
+      return next.value;
+    }
+  }
+};
+
+describe('asyncResolveImports — bounded retry on null resolutions', () => {
+  it('retries a transient null resolution exactly once, then succeeds', async () => {
+    const services = createServices('/project/src/a.js');
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      '/project/src/a.js',
+      ['*'],
+      ''
+    );
+
+    let attempt = 0;
+    const resolve = jest.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error('transient resolver failure');
+      }
+      return '/project/src/foo.js';
+    });
+
+    const callResolve = () =>
+      drainAsync(
+        asyncResolveImports.call(
+          {
+            data: { imports: new Map([['./foo', ['default']]]) },
+            entrypoint,
+            services,
+          } as IResolveImportsAction,
+          resolve
+        )
+      );
+
+    const first = await callResolve();
+    expect(first).toEqual([]); // null filtered out
+    expect(resolve).toHaveBeenCalledTimes(1);
+
+    const second = await callResolve();
+    expect(second).toEqual([
+      {
+        source: './foo',
+        only: ['default'],
+        resolved: '/project/src/foo.js',
+      },
+    ]);
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('caps retries at MAX_NULL_ATTEMPTS — persistent failures stop calling the resolver', async () => {
+    const services = createServices('/project/src/a.js');
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      '/project/src/a.js',
+      ['*'],
+      ''
+    );
+
+    const resolve = jest.fn(async () => {
+      throw new Error('persistent failure');
+    });
+
+    const callResolve = () =>
+      drainAsync(
+        asyncResolveImports.call(
+          {
+            data: { imports: new Map([['./foo', ['default']]]) },
+            entrypoint,
+            services,
+          } as IResolveImportsAction,
+          resolve
+        )
+      );
+
+    // Many consumers hit the same failing source. Resolver must be called at
+    // most MAX_NULL_ATTEMPTS times (currently 2), not once per consumer.
+    for (let i = 0; i < 50; i += 1) {
+      const result = await callResolve();
+      expect(result).toEqual([]);
+    }
+
+    // Exactly 2 attempts: first call, then one bounded retry.
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('still dedupes concurrent in-flight requests for the same source', async () => {
+    const services = createServices('/project/src/a.js');
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      '/project/src/a.js',
+      ['*'],
+      ''
+    );
+
+    let releaseResolver: ((value: string) => void) | null = null;
+    const resolve = jest.fn(
+      () =>
+        new Promise<string>((resolve_) => {
+          releaseResolver = resolve_;
+        })
+    );
+
+    const callResolve = () =>
+      drainAsync(
+        asyncResolveImports.call(
+          {
+            data: { imports: new Map([['./foo', ['default']]]) },
+            entrypoint,
+            services,
+          } as IResolveImportsAction,
+          resolve
+        )
+      );
+
+    const a = callResolve();
+    const b = callResolve();
+
+    await new Promise((r) => setImmediate(r));
+    expect(resolve).toHaveBeenCalledTimes(1);
+
+    releaseResolver!('/project/src/foo.js');
+
+    const [resolvedA, resolvedB] = await Promise.all([a, b]);
+    expect(resolvedA).toEqual([
+      {
+        source: './foo',
+        only: ['default'],
+        resolved: '/project/src/foo.js',
+      },
+    ]);
+    expect(resolvedB).toEqual(resolvedA);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/transform/src/__tests__/serialize.ipc.test.ts
+++ b/packages/transform/src/__tests__/serialize.ipc.test.ts
@@ -88,9 +88,9 @@ describe('eval IPC serialization', () => {
   it('unwraps boxed primitives to their primitive payloads', () => {
     const roundTripped = deserializeValue(
       serializeValue({
-        bool: new Boolean(false),
-        count: new Number(0.75),
-        label: new String('100%'),
+        bool: Object(false),
+        count: Object(0.75),
+        label: Object('100%'),
       })
     ) as {
       bool: boolean;

--- a/packages/transform/src/__tests__/transform.design-system-repro.test.ts
+++ b/packages/transform/src/__tests__/transform.design-system-repro.test.ts
@@ -1,0 +1,712 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
+
+import dedent from 'dedent';
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+import type { PluginOptions } from '../types';
+import { EventEmitter } from '../utils/EventEmitter';
+
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+
+const createResolver =
+  (processorPath: string) => async (what: string, importer: string) => {
+    if (what === 'test-css-processor') {
+      return processorPath;
+    }
+
+    if (what.startsWith('.')) {
+      const base = resolve(dirname(importer), what);
+      for (const ext of ['.ts', '.tsx', '.js']) {
+        const candidate = `${base}${ext}`;
+        if (existsSync(candidate) && statSync(candidate).isFile()) {
+          return candidate;
+        }
+      }
+      for (const ext of ['/index.ts', '/index.tsx', '/index.js']) {
+        const candidate = `${base}${ext}`;
+        if (existsSync(candidate) && statSync(candidate).isFile()) {
+          return candidate;
+        }
+      }
+      return base;
+    }
+
+    return null;
+  };
+
+const createPerfEventRecorder = () => {
+  const events: Record<string, unknown>[] = [];
+  const eventEmitter = new EventEmitter(
+    (labels, type) => {
+      if (type === 'single') {
+        events.push(labels);
+      }
+    },
+    () => 0,
+    () => {}
+  );
+
+  return { eventEmitter, events };
+};
+
+const runTransform = async (
+  root: string,
+  entryFile: string,
+  cache: TransformCacheCollection,
+  eventEmitter: EventEmitter,
+  pluginOptions: Partial<PluginOptions> = {}
+) =>
+  transform(
+    {
+      cache,
+      eventEmitter,
+      options: {
+        filename: entryFile,
+        root,
+        pluginOptions: {
+          configFile: false,
+          ...pluginOptions,
+          features: {
+            staticImportValues: true,
+            ...pluginOptions.features,
+          },
+          tagResolver: (source, tag) => {
+            if (source === 'test-css-processor' && tag === 'css') {
+              return processorFile;
+            }
+
+            return null;
+          },
+        },
+      },
+    },
+    readFileSync(entryFile, 'utf8'),
+    createResolver(processorFile)
+  );
+
+type StaticResolveEvent = {
+  candidate?: string;
+  exported?: string;
+  filename?: string;
+  imported?: string;
+  phase?: string;
+  reason?: string;
+  source?: string;
+  status?: string;
+  type?: string;
+};
+
+const collectStaticResolveEvents = (
+  events: Record<string, unknown>[]
+): StaticResolveEvent[] =>
+  events.filter(
+    (event): event is StaticResolveEvent => event.type === 'staticResolve'
+  );
+
+describe('design-system chain repro for staticImportValues', () => {
+  const previousDebug = process.env.WYW_DEBUG_STATIC_RESOLVE;
+
+  beforeAll(() => {
+    process.env.WYW_DEBUG_STATIC_RESOLVE = '1';
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    if (previousDebug === undefined) {
+      delete process.env.WYW_DEBUG_STATIC_RESOLVE;
+    } else {
+      process.env.WYW_DEBUG_STATIC_RESOLVE = previousDebug;
+    }
+    jest.restoreAllMocks();
+  });
+
+  const writeBarrelChain = (root: string) => {
+    const barrelFile = join(root, 'design-system.ts');
+    const layoutFile = join(root, 'design-system', 'layout.ts');
+    const themeFile = join(root, 'design-system', 'theme.ts');
+    const typographyFile = join(root, 'design-system', 'typography.ts');
+
+    writeFileSync(
+      barrelFile,
+      dedent`
+        export { space } from './design-system/layout';
+        export { themeVars } from './design-system/theme';
+        export { textStyles } from './design-system/typography';
+      `
+    );
+
+    writeFileSync(
+      layoutFile,
+      dedent`
+        export const space = {
+          s0: 0,
+          s6: 6,
+          s12: 12,
+        } as const;
+      `
+    );
+
+    writeFileSync(
+      themeFile,
+      dedent`
+        function memoize(fn, _key) {
+          return fn;
+        }
+        function themeFromPaletteImpl(palette, mode) {
+          return { palette, mode };
+        }
+
+        export const themeFromPalette = memoize(themeFromPaletteImpl, (palette, mode) => palette + mode);
+        themeFromPalette.cache = { max: 4 };
+
+        export const themeVars = {
+          accentTextColor: 'var(--fibery-color-accentTextColor)',
+          textColor: 'var(--fibery-color-textColor)',
+        };
+      `
+    );
+
+    writeFileSync(
+      typographyFile,
+      dedent`
+        import { themeVars } from './theme';
+
+        export const lineHeight = {
+          heading: 1.3,
+        } as const;
+
+        export const fontWeight = {
+          regular: 410,
+          semibold: 600,
+        } as const;
+
+        export const typeSizes = [30, 24, 18, 16, 14, 12] as const;
+
+        export const fontFamily = '"Inter Variable", sans-serif';
+
+        export const textStyles = {
+          heading6: {
+            fontFamily,
+            fontSize: typeSizes[5],
+            lineHeight: lineHeight.heading,
+            letterSpacing: 0.6,
+            textTransform: 'uppercase',
+            fontWeight: fontWeight.regular,
+            color: themeVars.textColor,
+          },
+        };
+      `
+    );
+
+    return { barrelFile, layoutFile, themeFile, typographyFile };
+  };
+
+  it('inlines space.s12 + space.s6 (literal-only object via barrel)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { space } from './design-system';
+
+        export const className = css\`
+          padding: ${'${space.s12 + space.s6}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      // surface rejection reasons in the assertion error
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('padding:18px');
+      expect(result.code).not.toContain('./design-system');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines themeVars.accentTextColor (literal object in module with top-level mutation)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { themeVars } from './design-system';
+
+        export const className = css\`
+          color: ${'${themeVars.accentTextColor}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain(
+        'color:var(--fibery-color-accentTextColor)'
+      );
+      expect(result.code).not.toContain('./design-system');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines textStyles.heading6 (object whose values reference another static import)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { textStyles } from './design-system';
+
+        export const className = css\`
+          ${'${textStyles.heading6}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('font-size:12');
+      expect(result.cssText).toContain('color:var(--fibery-color-textColor)');
+      expect(result.code).not.toContain('./design-system');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines binary numeric expressions (-, *, /, %, **) over imported tokens', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { space } from './design-system';
+
+        export const className = css\`
+          padding-top: ${'${space.s12 - space.s6}'}px;
+          padding-right: ${'${space.s12 / 2}'}px;
+          padding-bottom: ${'${space.s12 % 5}'}px;
+          padding-left: ${'${space.s12 * 2}'}px;
+          margin-top: ${'${space.s6 ** 2}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('padding-top:6px');
+      expect(result.cssText).toContain('padding-right:6px');
+      expect(result.cssText).toContain('padding-bottom:2px');
+      expect(result.cssText).toContain('padding-left:24px');
+      expect(result.cssText).toContain('margin-top:36px');
+      expect(result.code).not.toContain('./design-system');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines inline ObjectExpression candidates (style={{...}}) with binary/unary/spread', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { space, textStyles } from './design-system';
+
+        export const className = css\`
+          ${'${{ height: space.s12 + 1, width: space.s12 - 2, margin: -space.s6, padding: (24 - space.s12) / 2 }}'};
+          ${'${{ ...textStyles.heading6, padding: space.s12 }}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('height:13'); // space.s12 + 1
+      expect(result.cssText).toContain('width:10'); // space.s12 - 2
+      expect(result.cssText).toContain('margin:-6'); // -space.s6
+      expect(result.cssText).toContain('padding:6'); // (24 - 12) / 2
+      expect(result.cssText).toContain('font-size:12'); // ...textStyles.heading6
+      expect(result.code).not.toContain('./design-system');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines process.env.X || fallback by treating process.env.X as undefined', async () => {
+    // Ensure the test env var is unrelated to whatever the build machine has.
+    // The contract is that process.env.X is always undefined at build time —
+    // setting it should not affect the inlined value.
+    process.env.WYW_TEST_PREFIX = 'should-be-ignored';
+
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+    const tokensFile = join(root, 'tokens.ts');
+
+    writeFileSync(
+      tokensFile,
+      `export const varPrefix = process.env.WYW_TEST_PREFIX || 'fibery';\n`
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { varPrefix } from './tokens';
+
+        export const className = css\`
+          --prefix: ${'${varPrefix}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('--prefix:fibery');
+      expect(result.cssText).not.toContain('should-be-ignored');
+      expect(result.code).not.toContain('./tokens');
+    } finally {
+      delete process.env.WYW_TEST_PREFIX;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines an exported ObjectExpression with template literal values', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+    const tokensFile = join(root, 'tokens.ts');
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const themeVars = {
+          surface: 'var(--surface)',
+          border: 'var(--border)',
+        };
+
+        export const shadows = {
+          card: \`0 0 0 1px ${'${themeVars.border}'}\`,
+          panel: \`0 4px 16px ${'${themeVars.surface}'}\`,
+        } as const;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { shadows } from './tokens';
+
+        export const className = css\`
+          box-shadow: ${'${shadows.card}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('box-shadow:0 0 0 1px var(--border)');
+      expect(result.code).not.toContain('./tokens');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not poison staticExportCache across transforms when the resolver fails once', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const firstEntry = join(root, 'first.tsx');
+    const secondEntry = join(root, 'second.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      firstEntry,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { themeVars } from './design-system';
+
+        export const a = css\` color: ${'${themeVars.accentTextColor}'}; \`;
+      `
+    );
+    writeFileSync(
+      secondEntry,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { themeVars } from './design-system';
+
+        export const b = css\` background: ${'${themeVars.textColor}'}; \`;
+      `
+    );
+
+    // Track resolver calls. The bounded retry should re-call once after a
+    // transient failure but cap retries — never thunder-herd.
+    const baseResolver = createResolver(processorFile);
+    let calls = 0;
+    let trippedThemeFailure = false;
+    const resolver = async (what: string, importer: string) => {
+      calls += 1;
+      if (
+        what === './design-system/theme' &&
+        importer.endsWith('design-system.ts') &&
+        !trippedThemeFailure
+      ) {
+        trippedThemeFailure = true;
+        throw new Error('transient resolver failure');
+      }
+      return baseResolver(what, importer);
+    };
+
+    const runOne = (entryFile: string) =>
+      transform(
+        {
+          cache,
+          eventEmitter: perf.eventEmitter,
+          options: {
+            filename: entryFile,
+            root,
+            pluginOptions: {
+              configFile: false,
+              features: { staticImportValues: true },
+              tagResolver: (source, tag) =>
+                source === 'test-css-processor' && tag === 'css'
+                  ? processorFile
+                  : null,
+            },
+          },
+        },
+        readFileSync(entryFile, 'utf8'),
+        resolver
+      );
+
+    try {
+      await runOne(firstEntry);
+      const eventsAfterFirst = perf.events.length;
+      const callsAfterFirst = calls;
+      const secondResult = await runOne(secondEntry);
+
+      // Second transform should inline cleanly — no cached null poisoning it.
+      const secondEvents = perf.events.slice(eventsAfterFirst);
+      const secondResolveEvents = secondEvents.filter(
+        (event): event is StaticResolveEvent => event.type === 'staticResolve'
+      );
+      const secondCascades = secondResolveEvents.filter(
+        (event) =>
+          event.status === 'rejected' &&
+          (event.reason === 'resolve-failed' ||
+            event.reason === 'candidate-import-unresolved')
+      );
+      expect({
+        cssText: secondResult.cssText,
+        cascades: secondCascades,
+      }).toEqual(
+        expect.objectContaining({
+          cascades: [],
+        })
+      );
+      expect(secondResult.cssText).toContain(
+        'background:var(--fibery-color-textColor)'
+      );
+
+      // Bounded: total resolver calls should NOT scale linearly with consumers.
+      // We measure by checking that the second transform's calls are bounded
+      // (a few extra for fresh imports + at most one bounded retry).
+      const secondTransformCalls = calls - callsAfterFirst;
+      expect(secondTransformCalls).toBeLessThan(20);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines logical / conditional / unary expressions', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+    const tokensFile = join(root, 'tokens.ts');
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const empty = null;
+        export const fallback = 'fallback';
+        export const flag = true;
+        export const yes = 'yes';
+        export const no = 'no';
+        export const offset = 12;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { empty, fallback, flag, yes, no, offset } from './tokens';
+
+        export const className = css\`
+          --logical: ${'${empty || fallback}'};
+          --nullish: ${'${empty ?? fallback}'};
+          --conditional: ${'${flag ? yes : no}'};
+          --neg: ${'${-offset}'}px;
+          --pos: ${'${+offset}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('--logical:fallback');
+      expect(result.cssText).toContain('--nullish:fallback');
+      expect(result.cssText).toContain('--conditional:yes');
+      expect(result.cssText).toContain('--neg:-12px');
+      expect(result.cssText).toContain('--pos:12px');
+      expect(result.code).not.toContain('./tokens');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/transform/src/__tests__/transform.partial-evaluated-cache.test.ts
+++ b/packages/transform/src/__tests__/transform.partial-evaluated-cache.test.ts
@@ -91,7 +91,7 @@ const runTransform = async (
   );
 
 describe('transform partial evaluated cache reuse', () => {
-  it('reuses cached evaluated dependency exports when the dependency has no __wywPreval export', async () => {
+  it('reprocesses partial cached evaluated dependency exports for static import loads', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-partial-cache-'));
     const entryFile = join(root, 'entry.js');
     const depFile = join(root, 'dep.js');
@@ -117,6 +117,50 @@ describe('transform partial evaluated cache reuse', () => {
     );
 
     seedEvaluatedCache(cache, depFile, { foo1: 'cached-foo1' });
+
+    try {
+      const result = await runTransform(root, entryFile, cache);
+      const cachedDep = cache.get('entrypoints', depFile) as
+        | IEvaluatedEntrypoint
+        | undefined;
+
+      expect(result.cssText).toContain('foo1');
+      expect(result.cssText).not.toContain('cached-foo1');
+      expect(cachedDep?.exports.foo1).toBe('foo1');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses complete cached evaluated dependency exports for static import loads', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-partial-cache-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'dep.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      depFile,
+      dedent`
+        export const foo1 = String('foo1');
+        export const foo2 = String('foo2');
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { foo1 } from './dep.js';
+
+        export const className = css\`
+          font-size: \${foo1};
+        \`;
+      `
+    );
+
+    seedEvaluatedCache(cache, depFile, {
+      foo1: 'cached-foo1',
+      foo2: 'cached-foo2',
+    });
 
     try {
       const result = await runTransform(root, entryFile, cache);

--- a/packages/transform/src/__tests__/transform.partial-evaluated-cache.test.ts
+++ b/packages/transform/src/__tests__/transform.partial-evaluated-cache.test.ts
@@ -11,11 +11,7 @@ import { transform } from '../transform';
 import { Entrypoint } from '../transform/Entrypoint';
 import type { IEvaluatedEntrypoint } from '../transform/EvaluatedEntrypoint';
 
-const processorFile = join(
-  __dirname,
-  '__fixtures__',
-  'test-css-processor.js'
-);
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
 
 const createResolver =
   (processorPath: string) => async (what: string, importer: string) => {

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -1973,6 +1973,66 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('inlines exported Object.assign alias members with opaque local bases without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const panelFile = join(root, 'panel.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      panelFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        const RuntimeHeading = () => null;
+
+        export const Heading = styled(RuntimeHeading)\`
+          color: blue;
+        \`;
+
+        const aliases = {
+          Heading,
+        };
+
+        const Panel = styled.div\`
+          color: red;
+        \`;
+
+        export default Object.assign(Panel, aliases);
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import Panel from './panel.js';
+
+        export const Extended = styled(Panel.Heading)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toContain(panelFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps non-metadata Object.assign values on the eval path', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -605,54 +605,7 @@ describe('transform static import value inlining', () => {
     }
   });
 
-  it('keeps static resolve debug events disabled by default', async () => {
-    const previousDebug = process.env.WYW_DEBUG_STATIC_RESOLVE;
-    delete process.env.WYW_DEBUG_STATIC_RESOLVE;
-
-    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
-    const entryFile = join(root, 'entry.js');
-    const depFile = join(root, 'unsafe.js');
-    const cache = new TransformCacheCollection();
-    const perf = createPerfEventRecorder();
-
-    writeFileSync(
-      depFile,
-      dedent`
-        const color = String('red');
-        export { color };
-      `
-    );
-    writeFileSync(
-      entryFile,
-      dedent`
-        import { css } from 'test-css-processor';
-        import { color } from './unsafe.js';
-
-        export const className = css\`
-          color: ${'${color}'};
-        \`;
-      `
-    );
-
-    try {
-      await runTransform(root, entryFile, cache, perf.eventEmitter);
-
-      expect(
-        perf.events.filter((event) => event.type === 'staticResolve')
-      ).toEqual([]);
-    } finally {
-      if (previousDebug === undefined) {
-        delete process.env.WYW_DEBUG_STATIC_RESOLVE;
-      } else {
-        process.env.WYW_DEBUG_STATIC_RESOLVE = previousDebug;
-      }
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it('emits static resolve debug rejection reasons when requested', async () => {
-    const previousDebug = process.env.WYW_DEBUG_STATIC_RESOLVE;
-    process.env.WYW_DEBUG_STATIC_RESOLVE = '1';
+  it('emits static resolve debug rejection reasons whenever the feature is enabled', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
@@ -696,20 +649,52 @@ describe('transform static import value inlining', () => {
           }),
         ])
       );
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[wyw-static-resolve]',
-        expect.objectContaining({
-          reason: 'unsupported-expression',
-          type: 'staticResolve',
-        })
-      );
+      expect(warnSpy).not.toHaveBeenCalled();
     } finally {
       warnSpy.mockRestore();
-      if (previousDebug === undefined) {
-        delete process.env.WYW_DEBUG_STATIC_RESOLVE;
-      } else {
-        process.env.WYW_DEBUG_STATIC_RESOLVE = previousDebug;
-      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not emit static resolve debug events when the feature is disabled', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'unsafe.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      depFile,
+      dedent`
+        const color = String('red');
+        export { color };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { color } from './unsafe.js';
+
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      await runTransformWithOptions(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter,
+        { features: { staticImportValues: false } }
+      );
+
+      expect(
+        perf.events.filter((event) => event.type === 'staticResolve')
+      ).toEqual([]);
+    } finally {
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -39,7 +39,7 @@ const createResolver =
     return null;
   };
 
-const runTransform = async (
+const runTransformWithOptions = async (
   root: string,
   entryFile: string,
   cache: TransformCacheCollection,
@@ -72,6 +72,29 @@ const runTransform = async (
       },
     },
     readFileSync(entryFile, 'utf8'),
+    asyncResolve
+  );
+
+const runTransform = async (
+  root: string,
+  entryFile: string,
+  cache: TransformCacheCollection,
+  eventEmitter?: EventEmitter,
+  pluginOptions: Partial<PluginOptions> = {},
+  asyncResolve = createResolver(processorFile)
+) =>
+  runTransformWithOptions(
+    root,
+    entryFile,
+    cache,
+    eventEmitter,
+    {
+      ...pluginOptions,
+      features: {
+        staticImportValues: true,
+        ...pluginOptions.features,
+      },
+    },
     asyncResolve
   );
 
@@ -132,6 +155,42 @@ describe('transform static import value inlining', () => {
       expect(result.dependencies).toContain(depFile);
       expect(perf.counts.get('transform:evaluator') ?? 0).toBe(1);
       expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps imported static values in eval by default', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'tokens.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(depFile, `export const color = 'red';`);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { color } from './tokens.js';
+
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransformWithOptions(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain('./tokens.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -200,7 +259,7 @@ describe('transform static import value inlining', () => {
     }
   });
 
-  it('can disable imported static value inlining with a feature flag', async () => {
+  it('keeps imported static values in eval when disabled explicitly', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');
     const depFile = join(root, 'tokens.js');
@@ -241,7 +300,7 @@ describe('transform static import value inlining', () => {
     }
   });
 
-  it('can disable local static value inlining with a feature flag', async () => {
+  it('keeps local static values in eval when disabled explicitly', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');
     const cache = new TransformCacheCollection();

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -137,6 +137,69 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('inlines compiled TypeScript enum exports without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const statusFile = join(root, 'status.js');
+    const levelFile = join(root, 'level.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      statusFile,
+      dedent`
+        var PowerStatus;
+        (function (PowerStatus) {
+          PowerStatus["UNKNOWN"] = "unknown";
+          PowerStatus["POWERED_ON"] = "powered_on";
+        })(PowerStatus || (PowerStatus = {}));
+        export { PowerStatus as PowerStatus };
+        export default PowerStatus;
+      `
+    );
+    writeFileSync(
+      levelFile,
+      dedent`
+        var Level;
+        (function (Level) {
+          Level[Level["Low"] = 0] = "Low";
+          Level[Level["High"] = 2] = "High";
+        })(Level || (Level = {}));
+        export default Level;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { PowerStatus } from './status.js';
+        import Level from './level.js';
+
+        export const className = css\`
+          content: "${'${PowerStatus.UNKNOWN}'}";
+          z-index: ${'${Level.High}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('content:"unknown"');
+      expect(result.cssText).toContain('z-index:2');
+      expect(result.dependencies).toContain(statusFile);
+      expect(result.dependencies).toContain(levelFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('can disable imported static value inlining with a feature flag', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -6,6 +6,7 @@ import dedent from 'dedent';
 
 import { TransformCacheCollection } from '../cache';
 import { transform } from '../transform';
+import { EventEmitter } from '../utils/EventEmitter';
 
 const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
 
@@ -25,11 +26,13 @@ const createResolver =
 const runTransform = async (
   root: string,
   entryFile: string,
-  cache: TransformCacheCollection
+  cache: TransformCacheCollection,
+  eventEmitter?: EventEmitter
 ) =>
   transform(
     {
       cache,
+      eventEmitter,
       options: {
         filename: entryFile,
         root,
@@ -49,12 +52,30 @@ const runTransform = async (
     createResolver(processorFile)
   );
 
+const createPerfEventRecorder = () => {
+  const counts = new Map<string, number>();
+  const eventEmitter = new EventEmitter(
+    (labels, type) => {
+      if (type !== 'start' || typeof labels.method !== 'string') {
+        return;
+      }
+
+      counts.set(labels.method, (counts.get(labels.method) ?? 0) + 1);
+    },
+    () => 0,
+    () => {}
+  );
+
+  return { counts, eventEmitter };
+};
+
 describe('transform static import value inlining', () => {
   it('inlines a direct imported literal without keeping the runtime import', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');
     const depFile = join(root, 'tokens.js');
     const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
 
     writeFileSync(depFile, `export const color = 'red';`);
     writeFileSync(
@@ -70,11 +91,17 @@ describe('transform static import value inlining', () => {
     );
 
     try {
-      const result = await runTransform(root, entryFile, cache);
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
 
       expect(result.cssText).toContain('color:red');
       expect(result.code).not.toContain('./tokens.js');
       expect(result.dependencies).toContain(depFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -157,6 +184,7 @@ describe('transform static import value inlining', () => {
     const entryFile = join(root, 'entry.js');
     const depFile = join(root, 'unsafe.js');
     const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
 
     writeFileSync(
       depFile,
@@ -178,10 +206,16 @@ describe('transform static import value inlining', () => {
     );
 
     try {
-      const result = await runTransform(root, entryFile, cache);
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
 
       expect(result.cssText).toContain('color:red');
       expect(result.dependencies).toContain('./unsafe.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join, resolve } from 'path';
 
@@ -38,7 +44,8 @@ const runTransform = async (
   entryFile: string,
   cache: TransformCacheCollection,
   eventEmitter?: EventEmitter,
-  pluginOptions: Partial<PluginOptions> = {}
+  pluginOptions: Partial<PluginOptions> = {},
+  asyncResolve = createResolver(processorFile)
 ) =>
   transform(
     {
@@ -65,13 +72,19 @@ const runTransform = async (
       },
     },
     readFileSync(entryFile, 'utf8'),
-    createResolver(processorFile)
+    asyncResolve
   );
 
 const createPerfEventRecorder = () => {
   const counts = new Map<string, number>();
+  const events: Record<string, unknown>[] = [];
   const eventEmitter = new EventEmitter(
     (labels, type) => {
+      if (type === 'single') {
+        events.push(labels);
+        return;
+      }
+
       if (type !== 'start' || typeof labels.method !== 'string') {
         return;
       }
@@ -82,7 +95,7 @@ const createPerfEventRecorder = () => {
     () => {}
   );
 
-  return { counts, eventEmitter };
+  return { counts, eventEmitter, events };
 };
 
 describe('transform static import value inlining', () => {
@@ -117,6 +130,7 @@ describe('transform static import value inlining', () => {
       expect(result.cssText).toContain('color:red');
       expect(result.code).not.toContain('./tokens.js');
       expect(result.dependencies).toContain(depFile);
+      expect(perf.counts.get('transform:evaluator') ?? 0).toBe(1);
       expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -323,6 +337,115 @@ describe('transform static import value inlining', () => {
       expect(result.dependencies).toContain('./unsafe.js');
       expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
     } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps static resolve debug events disabled by default', async () => {
+    const previousDebug = process.env.WYW_DEBUG_STATIC_RESOLVE;
+    delete process.env.WYW_DEBUG_STATIC_RESOLVE;
+
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'unsafe.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      depFile,
+      dedent`
+        const color = String('red');
+        export { color };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { color } from './unsafe.js';
+
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      await runTransform(root, entryFile, cache, perf.eventEmitter);
+
+      expect(
+        perf.events.filter((event) => event.type === 'staticResolve')
+      ).toEqual([]);
+    } finally {
+      if (previousDebug === undefined) {
+        delete process.env.WYW_DEBUG_STATIC_RESOLVE;
+      } else {
+        process.env.WYW_DEBUG_STATIC_RESOLVE = previousDebug;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('emits static resolve debug rejection reasons when requested', async () => {
+    const previousDebug = process.env.WYW_DEBUG_STATIC_RESOLVE;
+    process.env.WYW_DEBUG_STATIC_RESOLVE = '1';
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'unsafe.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      depFile,
+      dedent`
+        const color = String('red');
+        export { color };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { color } from './unsafe.js';
+
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      await runTransform(root, entryFile, cache, perf.eventEmitter);
+
+      expect(
+        perf.events.filter((event) => event.type === 'staticResolve')
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            exported: 'color',
+            filename: depFile,
+            phase: 'export',
+            reason: 'unsupported-expression',
+            status: 'rejected',
+          }),
+        ])
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[wyw-static-resolve]',
+        expect.objectContaining({
+          reason: 'unsupported-expression',
+          type: 'staticResolve',
+        })
+      );
+    } finally {
+      warnSpy.mockRestore();
+      if (previousDebug === undefined) {
+        delete process.env.WYW_DEBUG_STATIC_RESOLVE;
+      } else {
+        process.env.WYW_DEBUG_STATIC_RESOLVE = previousDebug;
+      }
       rmSync(root, { recursive: true, force: true });
     }
   });
@@ -677,6 +800,486 @@ describe('transform static import value inlining', () => {
       );
       expect(result.dependencies).toContain(baseFile);
       expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines local package styled metadata outside the app root without eval', async () => {
+    const temp = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const root = join(temp, 'app');
+    const sharedRoot = join(temp, 'shared');
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(sharedRoot, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    mkdirSync(root, { recursive: true });
+    mkdirSync(sharedRoot, { recursive: true });
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        export const Base = styled.div\`
+          color: red;
+        \`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Base } from '../shared/base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled metadata for a local runtime component without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        const Runtime = () => null;
+
+        export const Base = styled(Runtime)\`
+          color: red;
+        \`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Base } from './base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled metadata for a local React runtime wrapper without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      baseFile,
+      dedent`
+        import React from 'react';
+        import { styled } from 'test-styled-processor';
+
+        const Runtime = React.forwardRef(() => null);
+
+        export const Base = styled(Runtime)\`
+          color: red;
+        \`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Base } from './base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled metadata for a direct SVG runtime import without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import SvgIcon from './icon.svg?react';
+
+        export const Base = styled(SvgIcon)\`
+          color: red;
+        \`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Base } from './base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled metadata for an SVG runtime import re-exported through a barrel without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const iconsFile = join(root, 'icons.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      iconsFile,
+      dedent`
+        import SvgIcon from './icon.svg?react';
+
+        export { SvgIcon as Icon };
+      `
+    );
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Icon } from './icons.js';
+
+        export const Base = styled(Icon)\`
+          color: red;
+        \`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Base } from './base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toEqual(
+        expect.arrayContaining([baseFile, iconsFile])
+      );
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('prunes static SVG metadata helpers when the file still needs eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const runtimeFile = join(root, 'runtime.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(runtimeFile, `export const makeRuntime = () => null;`);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import SvgIcon from './icon.svg?react';
+        import { makeRuntime } from './runtime.js';
+
+        const RuntimeBase = makeRuntime();
+
+        export const Icon = styled(SvgIcon)\`
+          color: red;
+        \`;
+
+        export const Dynamic = styled(RuntimeBase)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    const resolver = createResolver(processorFile);
+    const failOnRuntimeSvgResolve = async (what: string, importer: string) => {
+      if (what.includes('.svg?react')) {
+        throw new Error(`SVG import reached eval: ${what}`);
+      }
+
+      return resolver(what, importer);
+    };
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter,
+        {},
+        failOnRuntimeSvgResolve
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.cssText).toContain('font-size:12px');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled metadata wrapped in local Object.assign without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        const Base = styled.div\`
+          color: red;
+        \`;
+        const aliases = {
+          Root: Base,
+        };
+
+        export default Object.assign(Base, aliases);
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import Base from './base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled metadata wrapped in Object.assign through a barrel without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const barrelFile = join(root, 'barrel.js');
+    const tableFile = join(root, 'table.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      tableFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        export const Table = styled.div\`
+          color: red;
+        \`;
+        export const Cell = styled.div\`
+          color: blue;
+        \`;
+      `
+    );
+    writeFileSync(
+      barrelFile,
+      dedent`
+        import { Table, Cell } from './table.js';
+
+        const aliases = {
+          Cell,
+        };
+
+        export default Object.assign(Table, aliases);
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import Table from './barrel.js';
+
+        export const Extended = styled(Table)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toEqual(
+        expect.arrayContaining([barrelFile, tableFile])
+      );
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps non-metadata Object.assign values on the eval path', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'theme.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      depFile,
+      dedent`
+        const aliases = {
+          background: 'blue',
+        };
+
+        export const theme = Object.assign({ color: 'red' }, aliases);
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { theme } from './theme.js';
+
+        export const className = css\`
+          color: ${'${theme.color}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain('./theme.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -1,0 +1,222 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
+
+import dedent from 'dedent';
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+
+const createResolver =
+  (processorPath: string) => async (what: string, importer: string) => {
+    if (what === 'test-css-processor') {
+      return processorPath;
+    }
+
+    if (what.startsWith('.')) {
+      return resolve(dirname(importer), what);
+    }
+
+    return null;
+  };
+
+const runTransform = async (
+  root: string,
+  entryFile: string,
+  cache: TransformCacheCollection
+) =>
+  transform(
+    {
+      cache,
+      options: {
+        filename: entryFile,
+        root,
+        pluginOptions: {
+          configFile: false,
+          tagResolver: (source, tag) => {
+            if (source === 'test-css-processor' && tag === 'css') {
+              return processorFile;
+            }
+
+            return null;
+          },
+        },
+      },
+    },
+    readFileSync(entryFile, 'utf8'),
+    createResolver(processorFile)
+  );
+
+describe('transform static import value inlining', () => {
+  it('inlines a direct imported literal without keeping the runtime import', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'tokens.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(depFile, `export const color = 'red';`);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { color } from './tokens.js';
+
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache);
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.code).not.toContain('./tokens.js');
+      expect(result.dependencies).toContain(depFile);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves literals through explicit re-export chains', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const barrelFile = join(root, 'barrel.js');
+    const depFile = join(root, 'tokens.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(depFile, `export const spacing = [4, 8];`);
+    writeFileSync(barrelFile, `export { spacing } from './tokens.js';`);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { spacing } from './barrel.js';
+
+        export const className = css\`
+          margin: ${'${spacing[1]}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache);
+
+      expect(result.cssText).toContain('margin:8px');
+      expect(result.code).not.toContain('./barrel.js');
+      expect(result.dependencies).toEqual(
+        expect.arrayContaining([barrelFile, depFile])
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines imported fixed objects for CSS object interpolation', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'theme.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      depFile,
+      dedent`
+        export const rules = {
+          color: 'red',
+          display: 'block',
+        };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { rules } from './theme.js';
+
+        export const className = css\`
+          ${'${rules}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache);
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.cssText).toContain('display:block');
+      expect(result.code).not.toContain('./theme.js');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to eval for unsafe dependency modules', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'unsafe.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      depFile,
+      dedent`
+        const color = String('red');
+        export { color };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { color } from './unsafe.js';
+
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache);
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain('./unsafe.js');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('invalidates cached output when a transitive static dependency changes', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const barrelFile = join(root, 'barrel.js');
+    const depFile = join(root, 'tokens.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(depFile, `export const color = 'red';`);
+    writeFileSync(barrelFile, `export { color } from './tokens.js';`);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { color } from './barrel.js';
+
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      const first = await runTransform(root, entryFile, cache);
+      writeFileSync(depFile, `export const color = 'blue';`);
+      const second = await runTransform(root, entryFile, cache);
+
+      expect(first.cssText).toContain('color:red');
+      expect(second.cssText).toContain('color:blue');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -2607,4 +2607,185 @@ describe('transform static import value inlining', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('does not produce link errors when a re-export barrel needs exports shaken from a prior eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const tokensFile = join(root, 'tokens.js');
+    const barrelFile = join(root, 'barrel.js');
+    const entryA = join(root, 'entry-a.js');
+    const entryB = join(root, 'entry-b.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const fontFamily = 'Inter, sans-serif';
+        export const textStyles = { fontSize: '14px', lineHeight: '1.5' };
+      `
+    );
+    writeFileSync(
+      barrelFile,
+      dedent`
+        export { fontFamily } from './tokens.js';
+      `
+    );
+    writeFileSync(
+      entryA,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { textStyles } from './tokens.js';
+
+        export const className = css\`
+          font-size: ${'${textStyles.fontSize}'};
+        \`;
+      `
+    );
+    writeFileSync(
+      entryB,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { fontFamily } from './barrel.js';
+
+        export const className = css\`
+          font-family: ${'${fontFamily}'};
+        \`;
+      `
+    );
+
+    try {
+      // entry-a caches tokens.js with only=['textStyles'] (fontFamily shaken out)
+      const resultA = await runTransform(root, entryA, cache);
+      expect(resultA.cssText).toContain('font-size:14px');
+
+      // entry-b needs fontFamily from tokens.js via barrel.js re-export.
+      // The broker/runner must not serve a shaken variant that omits fontFamily.
+      const resultB = await runTransform(root, entryB, cache);
+      expect(resultB.cssText).toContain('font-family:Inter,sans-serif');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('survives concurrent transforms that need different exports from the same module', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const tokensFile = join(root, 'tokens.js');
+    const barrelFile = join(root, 'barrel.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const fontFamily = 'Inter, sans-serif';
+        export const fontWeight = { light: 300, regular: 400, bold: 700 };
+        export const textStyles = { fontSize: '14px', lineHeight: '1.5' };
+      `
+    );
+    writeFileSync(
+      barrelFile,
+      dedent`
+        export { fontFamily, fontWeight } from './tokens.js';
+      `
+    );
+
+    // Create N entry files: half import textStyles directly, half import
+    // fontFamily via barrel.  Run all transforms concurrently (like webpack).
+    const N = 10;
+    const entries: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const entryFile = join(root, `entry-${i}.js`);
+      if (i % 2 === 0) {
+        writeFileSync(
+          entryFile,
+          dedent`
+            import { css } from 'test-css-processor';
+            import { textStyles } from './tokens.js';
+
+            export const className = css\`
+              font-size: ${'${textStyles.fontSize}'};
+            \`;
+          `
+        );
+      } else {
+        writeFileSync(
+          entryFile,
+          dedent`
+            import { css } from 'test-css-processor';
+            import { fontFamily } from './barrel.js';
+
+            export const className = css\`
+              font-family: ${'${fontFamily}'};
+            \`;
+          `
+        );
+      }
+      entries.push(entryFile);
+    }
+
+    try {
+      // Run all transforms concurrently, sharing the same cache.
+      const results = await Promise.all(
+        entries.map((entry) => runTransform(root, entry, cache))
+      );
+
+      for (let i = 0; i < N; i++) {
+        if (i % 2 === 0) {
+          expect(results[i].cssText).toContain('font-size:14px');
+        } else {
+          expect(results[i].cssText).toContain('font-family:Inter,sans-serif');
+        }
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not produce link errors when the same module is imported directly and via barrel with different exports', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const tokensFile = join(root, 'tokens.js');
+    const barrelFile = join(root, 'barrel.js');
+    const entryFile = join(root, 'entry.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const fontFamily = 'Inter, sans-serif';
+        export const fontWeight = { light: 300, regular: 400, bold: 700 };
+        export const textStyles = { fontSize: '14px', lineHeight: '1.5' };
+      `
+    );
+    writeFileSync(
+      barrelFile,
+      dedent`
+        export { fontFamily, fontWeight } from './tokens.js';
+      `
+    );
+    // Single entry that imports textStyles directly from tokens
+    // AND fontFamily via the barrel — within one eval, the runner loads
+    // tokens.js once for the direct import (only=['textStyles']) and once
+    // during barrel.js linking (needs fontFamily+fontWeight).
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { textStyles } from './tokens.js';
+        import { fontFamily, fontWeight } from './barrel.js';
+
+        export const className = css\`
+          font-size: ${'${textStyles.fontSize}'};
+          font-family: ${'${fontFamily}'};
+          font-weight: ${'${fontWeight.regular}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache);
+      expect(result.cssText).toContain('font-size:14px');
+      expect(result.cssText).toContain('font-family:Inter,sans-serif');
+      expect(result.cssText).toContain('font-weight:400');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -1851,6 +1851,128 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('inlines styled metadata from Object.assign alias members without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const barrelFile = join(root, 'barrel.js');
+    const tableFile = join(root, 'table.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      tableFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        export const Table = styled.div\`
+          color: red;
+        \`;
+        export const Row = styled.div\`
+          color: blue;
+        \`;
+      `
+    );
+    writeFileSync(
+      barrelFile,
+      dedent`
+        import { Row, Table } from './table.js';
+
+        const aliases = {
+          Row,
+        };
+
+        export default Object.assign(Table, aliases);
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import Table from './barrel.js';
+
+        export const Extended = styled(Table.Row)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toEqual(
+        expect.arrayContaining([barrelFile, tableFile])
+      );
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines same-module Object.assign alias members without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const panelFile = join(root, 'panel.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      panelFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        const aliases = {
+          Body: styled.div\`
+            color: blue;
+          \`,
+        };
+
+        const Panel = styled.div\`
+          color: red;
+        \`;
+
+        export default Object.assign(Panel, aliases);
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import Panel from './panel.js';
+
+        export const Extended = styled(Panel.Body)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toContain(panelFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps non-metadata Object.assign values on the eval path', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -2073,6 +2073,77 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('inlines static styled metadata helpers into local styled chains before eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const flexFile = join(root, 'flex.js');
+    const dynamicFile = join(root, 'dynamic.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'app' }));
+    writeFileSync(
+      flexFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        const runtimeOnly = (() => {
+          throw new Error('styled primitive module should not run during eval');
+        })();
+
+        export const Horizontal = styled.div\`
+          display: flex;
+        \`;
+
+        export const Spring = styled.div\`
+          flex: 1;
+        \`;
+
+        export { runtimeOnly };
+      `
+    );
+    writeFileSync(dynamicFile, `export const spacing = Date.now();`);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { styled } from 'test-styled-processor';
+        import { spacing } from './dynamic.js';
+        import { Horizontal, Spring } from './flex.js';
+
+        export const Runtime = () => Spring;
+
+        const Row = styled(Horizontal)\`
+          color: red;
+        \`;
+
+        export const Root = styled(Row)\`
+          font-size: 12px;
+        \`;
+
+        export const className = css\`
+          margin: ${'${spacing}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.dependencies).toContain(flexFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('reuses cached static styled metadata across entry transforms', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const firstEntryFile = join(root, 'entry-a.js');

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -1432,6 +1432,61 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('inlines post-declaration Object.assign alias members without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        const Infix = styled.span\`
+          color: blue;
+        \`;
+        const Base = styled.div\`
+          color: red;
+        \`;
+
+        Object.assign(Base, { Infix });
+
+        export default Base;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import Base from './base.js';
+
+        export const Extended = styled(Base.Infix)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('keeps unsafe post-declaration styled metadata calls on the eval path', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -6,6 +6,7 @@ import dedent from 'dedent';
 
 import { TransformCacheCollection } from '../cache';
 import { transform } from '../transform';
+import type { PluginOptions } from '../types';
 import { EventEmitter } from '../utils/EventEmitter';
 
 const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
@@ -36,7 +37,8 @@ const runTransform = async (
   root: string,
   entryFile: string,
   cache: TransformCacheCollection,
-  eventEmitter?: EventEmitter
+  eventEmitter?: EventEmitter,
+  pluginOptions: Partial<PluginOptions> = {}
 ) =>
   transform(
     {
@@ -47,6 +49,7 @@ const runTransform = async (
         root,
         pluginOptions: {
           configFile: false,
+          ...pluginOptions,
           tagResolver: (source, tag) => {
             if (source === 'test-css-processor' && tag === 'css') {
               return processorFile;
@@ -115,6 +118,47 @@ describe('transform static import value inlining', () => {
       expect(result.code).not.toContain('./tokens.js');
       expect(result.dependencies).toContain(depFile);
       expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('can disable imported static value inlining with a feature flag', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'tokens.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(depFile, `export const color = 'red';`);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { color } from './tokens.js';
+
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter,
+        {
+          features: {
+            staticImportValues: false,
+          },
+        }
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain('./tokens.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -283,7 +327,7 @@ describe('transform static import value inlining', () => {
     }
   });
 
-  it('falls back to eval when a function module also has unsafe top-level values', async () => {
+  it('inlines safe exports from modules with unrelated unsafe top-level values', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');
     const depFile = join(root, 'unsafe.js');
@@ -312,6 +356,58 @@ describe('transform static import value inlining', () => {
 
         export const className = css\`
           color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain(depFile);
+      expect(result.code).not.toContain('./unsafe.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to eval when a fixed object is mutated by top-level code', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'unsafe.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      depFile,
+      dedent`
+        const rules = {
+          color: 'red',
+        };
+
+        function mutate(value) {
+          value.color = 'blue';
+        }
+
+        mutate(rules);
+
+        export { rules };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { rules } from './unsafe.js';
+
+        export const className = css\`
+          ${'${rules}'};
         \`;
       `
     );

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -428,6 +428,211 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('removes statically resolved imports from modules that still need eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const staticFile = join(root, 'tokens.js');
+    const dynamicFile = join(root, 'dynamic.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      staticFile,
+      dedent`
+        const runtimeOnly = (() => {
+          throw new Error('static dependency should not be imported during eval');
+        })();
+
+        export const color = 'red';
+        export { runtimeOnly };
+      `
+    );
+    writeFileSync(
+      dynamicFile,
+      dedent`
+        export const spacing = Date.now();
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { color } from './tokens.js';
+        import { spacing } from './dynamic.js';
+
+        export const className = css\`
+          color: ${'${color}'};
+          margin: ${'${spacing}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain(staticFile);
+      expect(result.dependencies).toContain('./dynamic.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines imported selector-only processor class names without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const classesFile = join(root, 'classes.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      classesFile,
+      dedent`
+        import { css } from 'test-css-processor';
+
+        const runtimeOnly = (() => {
+          throw new Error('selector-only class should not be imported during eval');
+        })();
+
+        export const marker = css\`\`;
+        export { runtimeOnly };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { marker } from './classes.js';
+
+        export const className = css\`
+          .${'${marker}'} {
+            color: red;
+          }
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain(classesFile);
+      expect(result.code).not.toContain('./classes.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines namespace selector-only processor class names without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const classesFile = join(root, 'classes.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      classesFile,
+      dedent`
+        import { css } from 'test-css-processor';
+
+        const runtimeOnly = (() => {
+          throw new Error('namespace class should not be imported during eval');
+        })();
+
+        export const marker = css\`\`;
+        export { runtimeOnly };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import * as classes from './classes.js';
+
+        export const className = css\`
+          .${'${classes.marker}'} {
+            color: red;
+          }
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain(classesFile);
+      expect(result.code).not.toContain('./classes.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps processor class names with CSS rules on the eval path', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const classesFile = join(root, 'classes.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      classesFile,
+      dedent`
+        import { css } from 'test-css-processor';
+
+        export const marker = css\`
+          color: blue;
+        \`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { marker } from './classes.js';
+
+        export const className = css\`
+          .${'${marker}'} {
+            color: red;
+          }
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain('./classes.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('inlines imported styled primitive metadata without eval', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');
@@ -471,6 +676,124 @@ describe('transform static import value inlining', () => {
         /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
       );
       expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled primitive metadata from a mixed module without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'app' }));
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        const runtimeOnly = (() => {
+          throw new Error('runtime code should not run while resolving metadata');
+        })();
+
+        export const Base = styled.div\`
+          color: red;
+        \`;
+
+        export { runtimeOnly };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Base } from './base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines transitive styled metadata chains without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const middleFile = join(root, 'middle.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'app' }));
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        export const Base = styled.div\`
+          color: red;
+        \`;
+      `
+    );
+    writeFileSync(
+      middleFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Base } from './base.js';
+
+        export const Middle = styled(Base)\`
+          color: blue;
+        \`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Middle } from './middle.js';
+
+        export const Extended = styled(Middle)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toEqual(
+        expect.arrayContaining([baseFile, middleFile])
+      );
       expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -338,6 +338,109 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('inlines imported zero-arg helper calls with static return values', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const helperFile = join(root, 'helper.js');
+    const tokensFile = join(root, 'tokens.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const sizes = {
+          text: {
+            fontSize: '18px',
+          },
+        };
+        export const MOBILE = 'screen and (max-width: 768px)';
+      `
+    );
+    writeFileSync(
+      helperFile,
+      dedent`
+        import { MOBILE, sizes } from './tokens.js';
+
+        export const getLabelStyle = () => {
+          return \`
+            display: flex;
+            font-size: ${'${sizes.text.fontSize}'};
+
+            @media ${'${MOBILE}'} {
+              display: block;
+            }
+          \`;
+        };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { getLabelStyle } from './helper.js';
+
+        export const className = css\`
+          ${'${getLabelStyle()}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('display:flex');
+      expect(result.cssText).toContain('font-size:18px');
+      expect(result.cssText).toContain('@media screen and (max-width: 768px)');
+      expect(result.dependencies).toContain(helperFile);
+      expect(result.dependencies).toContain(tokensFile);
+      expect(result.code).not.toContain('./helper.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps imported zero-arg helpers in eval for bare function references', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const helperFile = join(root, 'helper.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      helperFile,
+      dedent`
+        export const getColor = () => 'red';
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { getColor } from './helper.js';
+
+        export const className = css\`
+          color: ${'${getColor}'};
+        \`;
+      `
+    );
+
+    try {
+      await expect(
+        runTransform(root, entryFile, cache, perf.eventEmitter)
+      ).rejects.toThrow("css tag cannot handle 'getColor'");
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('falls back to eval for unsafe dependency modules', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -178,6 +178,45 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('can disable local static value inlining with a feature flag', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+
+        const color = 'red';
+
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter,
+        {
+          features: {
+            staticImportValues: false,
+          },
+        }
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('resolves literals through explicit re-export chains', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -748,7 +748,7 @@ describe('transform static import value inlining', () => {
     }
   });
 
-  it('keeps processor class names with CSS rules on the eval path', async () => {
+  it('inlines imported processor class names with CSS rules while preserving a side-effect import', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');
     const classesFile = join(root, 'classes.js');
@@ -788,7 +788,71 @@ describe('transform static import value inlining', () => {
       );
 
       expect(result.cssText).toContain('color:red');
-      expect(result.dependencies).toContain('./classes.js');
+      expect(result.cssText).not.toContain('color:blue');
+      expect(result.dependencies).toContain(classesFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps preserved class side-effect imports out of eval runtime', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const classesFile = join(root, 'classes.js');
+    const dynamicFile = join(root, 'dynamic.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      classesFile,
+      dedent`
+        import { css } from 'test-css-processor';
+
+        const runtimeOnly = (() => {
+          throw new Error('side-effect class import should not be imported during eval');
+        })();
+
+        export const marker = css\`
+          color: blue;
+        \`;
+        export { runtimeOnly };
+      `
+    );
+    writeFileSync(
+      dynamicFile,
+      dedent`
+        export const spacing = \`\${Date.now()}px\`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { marker } from './classes.js';
+        import { spacing } from './dynamic.js';
+
+        export const className = css\`
+          .${'${marker}'} {
+            margin: ${'${spacing}'};
+          }
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('margin:');
+      expect(result.cssText).not.toContain('color:blue');
+      expect(result.code).toContain('./classes.js');
+      expect(result.dependencies).toContain(classesFile);
+      expect(result.dependencies).toContain('./dynamic.js');
       expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -992,6 +1056,411 @@ describe('transform static import value inlining', () => {
       );
       expect(result.dependencies).toContain(baseFile);
       expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled metadata for an imported React runtime wrapper export without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const runtimeFile = join(root, 'runtime.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      runtimeFile,
+      dedent`
+        import React from 'react';
+
+        const runtimeOnly = (() => {
+          throw new Error('runtime wrapper should not be imported during eval');
+        })();
+
+        export const Runtime = React.memo(() => null);
+        export { runtimeOnly };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Runtime } from './runtime.js';
+
+        export const Base = styled(Runtime)\`
+          color: red;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain(runtimeFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled metadata for an imported observer runtime wrapper export without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const runtimeFile = join(root, 'runtime.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      runtimeFile,
+      dedent`
+        import { observer } from 'mobx-react-lite';
+
+        const runtimeOnly = (() => {
+          throw new Error('observer wrapper should not be imported during eval');
+        })();
+
+        export const Runtime = observer(() => null);
+        export { runtimeOnly };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Runtime } from './runtime.js';
+
+        export const Base = styled(Runtime)\`
+          color: red;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain(runtimeFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled metadata for an imported runtime factory export without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const runtimeFile = join(root, 'runtime.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      runtimeFile,
+      dedent`
+        import React from 'react';
+
+        const runtimeOnly = (() => {
+          throw new Error('runtime factory should not be imported during eval');
+        })();
+
+        const createRuntime = (kind) => {
+          return React.forwardRef((props, ref) => null);
+        };
+
+        export const Runtime = createRuntime('warning');
+        export { runtimeOnly };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Runtime } from './runtime.js';
+
+        export const Base = styled(Runtime)\`
+          color: red;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain(runtimeFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines nested styled metadata object values with runtime bases without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const runtimeFile = join(root, 'runtime.js');
+    const stylesFile = join(root, 'styles.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      runtimeFile,
+      dedent`
+        const runtimeOnly = (() => {
+          throw new Error('nested runtime base should not be imported during eval');
+        })();
+
+        export const Button = () => null;
+        export { runtimeOnly };
+      `
+    );
+    writeFileSync(
+      stylesFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Button } from './runtime.js';
+
+        export const Styles = {
+          Primary: styled(Button)\`
+            color: red;
+          \`,
+          Secondary: styled(Button)\`
+            color: blue;
+          \`,
+        };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { Styles } from './styles.js';
+
+        export const className = css\`
+          .${'${Styles.Primary.__wyw_meta.className}'} {
+            border-color: red;
+          }
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('border-color:red');
+      expect(result.dependencies).toEqual(
+        expect.arrayContaining([runtimeFile, stylesFile])
+      );
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled metadata with safe post-declaration Object.assign aliases without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        const Runtime = () => null;
+        const Alias = styled.div\`
+          color: blue;
+        \`;
+        const Base = styled(Runtime)\`
+          color: red;
+        \`;
+
+        Object.assign(Base, { Alias });
+
+        export default Base;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import Base from './base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps unsafe post-declaration styled metadata calls on the eval path', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        const Runtime = () => null;
+        const Base = styled(Runtime)\`
+          color: red;
+        \`;
+
+        function touch(value) {
+          return value;
+        }
+
+        touch(Base);
+
+        export default Base;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import Base from './base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.dependencies).toContain('./base.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines styled metadata for an external runtime namespace primitive without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import * as Tabs from '@radix-ui/react-tabs';
+
+        export const Base = styled(Tabs.Root)\`
+          color: red;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps unresolved external runtime primitives outside the allowlist on the eval path', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const runtimeFile = join(root, 'runtime-ui.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const defaultResolve = createResolver(processorFile);
+    const asyncResolve = async (what: string, importer: string) => {
+      if (what === 'runtime-ui') {
+        return runtimeFile;
+      }
+
+      return defaultResolve(what, importer);
+    };
+
+    writeFileSync(
+      runtimeFile,
+      dedent`
+        export const Root = (() => () => null)();
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import * as UI from 'runtime-ui';
+
+        export const Base = styled(UI.Root)\`
+          color: red;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter,
+        {},
+        asyncResolve
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -1373,6 +1842,81 @@ describe('transform static import value inlining', () => {
         /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
       );
       expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses cached static styled metadata across entry transforms', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const firstEntryFile = join(root, 'entry-a.js');
+    const secondEntryFile = join(root, 'entry-b.js');
+    const baseFile = join(root, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const asyncResolve = createResolver(processorFile);
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'app' }));
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        export const Base = styled.div\`
+          color: red;
+        \`;
+      `
+    );
+    writeFileSync(
+      firstEntryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Base } from './base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+    writeFileSync(
+      secondEntryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Base } from './base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 14px;
+        \`;
+      `
+    );
+
+    try {
+      const first = await runTransform(
+        root,
+        firstEntryFile,
+        cache,
+        perf.eventEmitter,
+        {},
+        asyncResolve
+      );
+      const staticMetadataCount =
+        perf.counts.get('transform:preeval:staticMetadata') ?? 0;
+      expect(staticMetadataCount).toBeGreaterThan(0);
+      const second = await runTransform(
+        root,
+        secondEntryFile,
+        cache,
+        perf.eventEmitter,
+        {},
+        asyncResolve
+      );
+
+      expect(first.cssText).toContain('font-size:12px');
+      expect(second.cssText).toContain('font-size:14px');
+      expect(perf.counts.get('transform:preeval:staticMetadata') ?? 0).toBe(
+        staticMetadataCount
+      );
       expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -2397,6 +2397,62 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('reuses static metadata preeval for multiple exports from one file', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'app' }));
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        export const Base = styled.div\`
+          color: red;
+        \`;
+
+        export const Accent = styled.div\`
+          color: blue;
+        \`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Accent, Base } from './base.js';
+
+        export const ExtendedBase = styled(Base)\`
+          font-size: 12px;
+        \`;
+
+        export const ExtendedAccent = styled(Accent)\`
+          line-height: 16px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toContain('line-height:16px');
+      expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:preeval:staticMetadata') ?? 0).toBe(1);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('inlines transitive styled metadata chains without eval', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -9,11 +9,20 @@ import { transform } from '../transform';
 import { EventEmitter } from '../utils/EventEmitter';
 
 const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+const styledProcessorFile = join(
+  __dirname,
+  '__fixtures__',
+  'test-styled-processor.js'
+);
 
 const createResolver =
   (processorPath: string) => async (what: string, importer: string) => {
     if (what === 'test-css-processor') {
       return processorPath;
+    }
+
+    if (what === 'test-styled-processor') {
+      return styledProcessorFile;
     }
 
     if (what.startsWith('.')) {
@@ -41,6 +50,10 @@ const runTransform = async (
           tagResolver: (source, tag) => {
             if (source === 'test-css-processor' && tag === 'css') {
               return processorFile;
+            }
+
+            if (source === 'test-styled-processor' && tag === 'styled') {
+              return styledProcessorFile;
             }
 
             return null;
@@ -179,6 +192,55 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('inlines safe exports from modules with function declarations', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'theme.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      depFile,
+      dedent`
+        export function formatColor(value) {
+          return String(value);
+        }
+
+        export const rules = {
+          color: 'red',
+          display: 'block',
+        };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { rules } from './theme.js';
+
+        export const className = css\`
+          ${'${rules}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.cssText).toContain('display:block');
+      expect(result.code).not.toContain('./theme.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('falls back to eval for unsafe dependency modules', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');
@@ -216,6 +278,104 @@ describe('transform static import value inlining', () => {
       expect(result.cssText).toContain('color:red');
       expect(result.dependencies).toContain('./unsafe.js');
       expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to eval when a function module also has unsafe top-level values', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'unsafe.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      depFile,
+      dedent`
+        const unused = String('side-effect boundary');
+
+        export function formatColor(value) {
+          return String(value);
+        }
+
+        export const color = 'red';
+
+        void unused;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { color } from './unsafe.js';
+
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.dependencies).toContain('./unsafe.js');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines imported styled primitive metadata without eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'base.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'app' }));
+    writeFileSync(
+      baseFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        export const Base = styled.div\`
+          color: red;
+        \`;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { Base } from './base.js';
+
+        export const Extended = styled(Base)\`
+          font-size: 12px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.dependencies).toContain(baseFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/transform/src/__tests__/workflow.supersede-during-eval.test.ts
+++ b/packages/transform/src/__tests__/workflow.supersede-during-eval.test.ts
@@ -97,7 +97,9 @@ it('keeps root CSS extraction when the entrypoint is superseded during eval', as
       }
     }
 
-    throw new Error(`Unexpected resolve ${JSON.stringify(what)} from ${importer}`);
+    throw new Error(
+      `Unexpected resolve ${JSON.stringify(what)} from ${importer}`
+    );
   };
 
   const run = (filename: string, code: string) =>

--- a/packages/transform/src/cache.ts
+++ b/packages/transform/src/cache.ts
@@ -112,6 +112,10 @@ export class TransformCacheCollection<
     return `${key}::${this.keySalt}`;
   }
 
+  public getKeySalt() {
+    return this.keySalt;
+  }
+
   public add<
     TCache extends CacheNames,
     TValue extends MapValue<ICaches<TEntrypoint>[TCache]>,

--- a/packages/transform/src/debug/fileReporter.ts
+++ b/packages/transform/src/debug/fileReporter.ts
@@ -116,6 +116,10 @@ export const createFileReporter = (
     path.join(options.dir, 'entrypoints.jsonl')
   );
 
+  const staticResolveStream = createWriteStream(
+    path.join(options.dir, 'static-resolve.jsonl')
+  );
+
   const startedAt = performance.now();
   const timings: Timings = new Map();
   const addTiming = (label: string, key: string, value: number) => {
@@ -146,6 +150,11 @@ export const createFileReporter = (
   ) => {
     if (meta.type === 'dependency') {
       processDependencyEvent(meta as IProcessedEvent);
+      return;
+    }
+
+    if (meta.type === 'staticResolve') {
+      writeJSONl(staticResolveStream, meta);
     }
   };
 
@@ -224,6 +233,8 @@ export const createFileReporter = (
 
       actionStream.end();
       dependenciesStream.end();
+      entrypointStream.end();
+      staticResolveStream.end();
       timings.clear();
     },
   };

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -1800,7 +1800,7 @@ export class EvalBroker {
     const importerOnly = this.onlyByModule.get(importerId) ?? ['*'];
     const only = importerOnly.includes('__wywPreval')
       ? mergeOnly(importsOnly ?? ['*'], ['__wywPreval'])
-      : (importsOnly ?? ['*']);
+      : importsOnly ?? ['*'];
     if (process.env.WYW_DEBUG_EVAL_RESOLVE && !importsOnly) {
       // eslint-disable-next-line no-console
       console.warn('[wyw-eval:resolve:only-miss]', {
@@ -2822,7 +2822,7 @@ export class EvalBroker {
 
     let mergedOnly = storedOnly;
     for (const cachedEntrypoint of this.services.cache.entrypoints.values() as Iterable<CachedDependencyOwner>) {
-      const dependencies = cachedEntrypoint.dependencies;
+      const { dependencies } = cachedEntrypoint;
       if (!dependencies) {
         continue;
       }

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -2952,7 +2952,11 @@ export class EvalBroker {
 
   private rejectPending(
     id: string,
-    error: { message: string; stack?: string; cause?: { message: string; stack?: string } }
+    error: {
+      message: string;
+      stack?: string;
+      cause?: { message: string; stack?: string };
+    }
   ) {
     const pending = this.pending.get(id);
     if (!pending) return;

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -2803,11 +2803,11 @@ export class EvalBroker {
         }
       }
 
-      const prepared = prepareModuleOnDemand(
-        this.services,
-        id,
-        cached ? mergeOnly(cached.only, requiredOnly) : requiredOnly
-      );
+      const prepareOnly =
+        requiredOnly.includes('__wywPreval') || !cached
+          ? requiredOnly
+          : mergeOnly(cached.only, requiredOnly);
+      const prepared = prepareModuleOnDemand(this.services, id, prepareOnly);
 
       this.ensureImportsMapping(id, prepared.imports);
 

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -445,6 +445,25 @@ type PendingRequest = {
   timeout: ReturnType<typeof setTimeout>;
 };
 
+type EvaluateResult = {
+  values: Map<string, unknown> | null;
+  dependencies: string[];
+};
+
+type PendingEval = {
+  entrypoint: Entrypoint;
+  services: Services | undefined;
+  resolve: (value: EvaluateResult) => void;
+  reject: (reason?: unknown) => void;
+};
+
+// Mirrors runner.js `isFullModuleLoad`: wildcard `['*']` (or empty) is the
+// only shape stored in the runner's moduleCache; everything else lands in
+// moduleVariants. The shipped-code dedup must respect this shape because the
+// runner picks its lookup map based on the LoadResult's `only`.
+const isWildcardOnly = (only: string[] | undefined | null): boolean =>
+  !only || only.length === 0 || (only.length === 1 && only[0] === '*');
+
 const isEvalTimeoutError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') return false;
   if ('code' in error && (error as { code?: string }).code) {
@@ -646,7 +665,7 @@ const buildRunnerInitPayload = (
 
   return {
     evalOptions: {
-      globals: encodeGlobals(sanitizedGlobals) as Record<string, unknown>,
+      globals: encodeGlobalsCached(sanitizedGlobals),
       importOverrides,
       mode: evalOptions.mode ?? 'strict',
       require: evalOptions.require ?? 'warn-and-run',
@@ -1133,6 +1152,38 @@ const getInitPayloadKey = (payload: EvalRunnerInitPayload): string =>
     .update(JSON.stringify(canonicalizeForHash(payload)))
     .digest('hex');
 
+// Hash everything in the init payload that affects whether the runner needs
+// a fresh INIT — i.e. everything except `entrypoint` (which only affects
+// __filename/__dirname rebinding, not context reuse). The broker memoizes
+// this per-services so we replace per-evaluate SHA-256 of the full payload
+// with one SHA-256 of the stable bits + a cheap string concat per
+// entrypoint.
+const getStableInitPayloadHash = (
+  payload: EvalRunnerInitPayload
+): string => {
+  const { entrypoint: _entrypoint, ...stable } = payload;
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalizeForHash(stable)))
+    .digest('hex');
+};
+
+// Memoize encodeGlobals on input reference. The user's globals object is
+// stable across a build, so we can encode it once instead of per evaluate.
+// If the input ref changes, fall through to a fresh encode (and reset the
+// cache).
+const encodeGlobalsMemo = new WeakMap<object, Record<string, unknown>>();
+const encodeGlobalsCached = (input: unknown): Record<string, unknown> => {
+  if (input !== null && typeof input === 'object') {
+    const obj = input as object;
+    const cached = encodeGlobalsMemo.get(obj);
+    if (cached) return cached;
+    const encoded = encodeGlobals(input) as Record<string, unknown>;
+    encodeGlobalsMemo.set(obj, encoded);
+    return encoded;
+  }
+  return encodeGlobals(input) as Record<string, unknown>;
+};
+
 const formatLoaderResult = (code: string, loader?: string | null) => {
   if (loader === 'json') {
     return `export default ${JSON.stringify(JSON.parse(code))};`;
@@ -1194,6 +1245,39 @@ export class EvalBroker {
   private readonly runtimeDependenciesByModule = new Map<string, Set<string>>();
 
   private readonly emittedDependencies = new Set<string>();
+
+  // Mirrors the runner's view: for each module id, the (hash, mergedOnly) of
+  // the most recent LoadResult we shipped with non-empty `code`. Subsequent
+  // loads with a matching hash and a subset `only` skip the code transmission
+  // (and the eval dump) — the runner's hash-match branch returns its cached
+  // SourceTextModule. Cleared whenever the runner is killed/respawned so the
+  // mirror cannot drift from the runner's actual moduleCache.
+  private readonly lastSentLoadByModule = new Map<
+    string,
+    { hash: string; only: string[] }
+  >();
+
+  // Batch queue: concurrent evaluate() callers (e.g. parallel webpack-loader
+  // transform() invocations) pile up here within one event-loop turn, then a
+  // microtask flushes them as a single sequential runner pass. Each call
+  // still gets its own resolved Promise; this only collapses the per-call
+  // evalQueue chain + state-clear churn.
+  private pendingEvals: PendingEval[] = [];
+
+  private evalFlushScheduled = false;
+
+  // Cached stable init payload hash. Keyed on the refs that feed the stable
+  // bits (pluginOptions.eval and pluginOptions itself). Any reference change
+  // invalidates the cache. The full per-entrypoint init key is
+  // `${stableHash}::${entrypoint.name}` — cheap string concat instead of
+  // re-canonicalizing+stringifying+SHA-256ing the whole payload per call.
+  private stableInitHashCache: {
+    pluginOptionsRef: unknown;
+    evalOptionsRef: unknown;
+    featuresRef: FeatureFlags<'happyDOM'>;
+    rootRef: string | undefined;
+    hash: string;
+  } | null = null;
 
   private evalSeq = 0;
 
@@ -1308,43 +1392,75 @@ export class EvalBroker {
   public async evaluate(
     entrypoint: Entrypoint,
     services?: Services
-  ): Promise<{
-    values: Map<string, unknown> | null;
-    dependencies: string[];
-  }> {
+  ): Promise<EvaluateResult> {
+    return new Promise<EvaluateResult>((resolve, reject) => {
+      this.pendingEvals.push({ entrypoint, services, resolve, reject });
+      this.scheduleEvalFlush();
+    });
+  }
+
+  private scheduleEvalFlush() {
+    if (this.evalFlushScheduled) return;
+    this.evalFlushScheduled = true;
+    queueMicrotask(() => {
+      this.evalFlushScheduled = false;
+      if (this.pendingEvals.length === 0) return;
+      const batch = this.pendingEvals;
+      this.pendingEvals = [];
+      this.evalQueue = this.evalQueue.then(() => this.runEvalBatch(batch));
+    });
+  }
+
+  private async runEvalBatch(batch: PendingEval[]): Promise<void> {
+    try {
+      await this.ensureRunner();
+    } catch (error) {
+      for (const member of batch) member.reject(error);
+      return;
+    }
+    for (const member of batch) {
+      try {
+        const result = await this.runOneEntrypoint(
+          member.entrypoint,
+          member.services
+        );
+        member.resolve(result);
+      } catch (error) {
+        member.reject(error);
+      }
+    }
+  }
+
+  private async runOneEntrypoint(
+    entrypoint: Entrypoint,
+    services: Services | undefined
+  ): Promise<EvaluateResult> {
     const activeServices = services ?? this.currentServices;
     const resolveRootId = getEntrypointResolveRoot(entrypoint);
-    const task = this.evalQueue
-      .then(async () => {
-        this.currentServices = activeServices;
-        this.activeResolveRootId = resolveRootId;
-        this.runtimeDependenciesByModule.clear();
-        this.emittedDependencies.clear();
-        this.importsByModule.clear();
-        this.onlyByModule.clear();
-        this.resolveCache.clear();
-        this.resolveInFlight.clear();
-        this.onlyByModule.set(entrypoint.name, ['__wywPreval']);
-        this.evalSeq += 1;
+    this.currentServices = activeServices;
+    this.activeResolveRootId = resolveRootId;
+    this.resetPerEntrypointState(entrypoint);
+    this.evalSeq += 1;
 
-        debugAction({
-          type: 'eval:start',
-          evalSeq: this.evalSeq,
-          entrypoint: entrypoint.name,
-          ts: performance.now(),
-        });
+    if (debugEvalDir) {
+      debugAction({
+        type: 'eval:start',
+        evalSeq: this.evalSeq,
+        entrypoint: entrypoint.name,
+        ts: performance.now(),
+      });
+    }
 
-        await this.ensureRunner();
-        await this.initRunner(entrypoint);
+    try {
+      await this.initRunner(entrypoint);
 
-        const payload = await this.request<EvalResultPayload>(
-          'EVAL',
-          {
-            id: entrypoint.name,
-          },
-          EVAL_TIMEOUT_MS
-        );
+      const payload = await this.request<EvalResultPayload>(
+        'EVAL',
+        { id: entrypoint.name },
+        EVAL_TIMEOUT_MS
+      );
 
+      if (debugEvalDir) {
         debugAction({
           type: 'eval:finish',
           evalSeq: this.evalSeq,
@@ -1352,37 +1468,40 @@ export class EvalBroker {
           hasValues: Boolean(payload.values),
           ts: performance.now(),
         });
+      }
 
-        if (payload.modules) {
-          this.applyModuleExports(payload.modules);
-        }
+      if (payload.modules) {
+        this.applyModuleExports(payload.modules);
+      }
 
-        if (!payload.values) {
-          return { values: null, dependencies: [] };
-        }
+      if (!payload.values) {
+        return { values: null, dependencies: [] };
+      }
 
-        const values = new Map<string, unknown>();
-        Object.entries(payload.values).forEach(([key, serialized]) => {
-          values.set(key, deserializeValue(serialized));
-        });
-
-        return {
-          values,
-          dependencies: this.collectEntrypointDependencies(entrypoint.name),
-        };
-      })
-      .finally(() => {
-        if (this.activeResolveRootId === resolveRootId) {
-          this.activeResolveRootId = null;
-        }
+      const values = new Map<string, unknown>();
+      Object.entries(payload.values).forEach(([key, serialized]) => {
+        values.set(key, deserializeValue(serialized));
       });
 
-    this.evalQueue = task.then(
-      () => {},
-      () => {}
-    );
+      return {
+        values,
+        dependencies: this.collectEntrypointDependencies(entrypoint.name),
+      };
+    } finally {
+      if (this.activeResolveRootId === resolveRootId) {
+        this.activeResolveRootId = null;
+      }
+    }
+  }
 
-    return task;
+  private resetPerEntrypointState(entrypoint: Entrypoint) {
+    this.runtimeDependenciesByModule.clear();
+    this.emittedDependencies.clear();
+    this.importsByModule.clear();
+    this.onlyByModule.clear();
+    this.resolveCache.clear();
+    this.resolveInFlight.clear();
+    this.onlyByModule.set(entrypoint.name, ['__wywPreval']);
   }
 
   private applyModuleExports(
@@ -1440,6 +1559,8 @@ export class EvalBroker {
     }
     this.lastInitKey = null;
     this.lastHappyDomEnabled = false;
+    this.lastSentLoadByModule.clear();
+    this.stableInitHashCache = null;
     flushDebugStreams();
   }
 
@@ -1486,6 +1607,7 @@ export class EvalBroker {
       this.runnerReady = null;
       this.lastInitKey = null;
       this.lastHappyDomEnabled = false;
+      this.lastSentLoadByModule.clear();
     });
   }
 
@@ -1638,21 +1760,62 @@ export class EvalBroker {
     );
     this.attachRunnerListeners(nextRunner);
     this.runnerReady = Promise.resolve();
+    // New process ⇒ runner's moduleCache/moduleHashes are empty, so our mirror
+    // of "what we already shipped" is stale.
+    this.lastSentLoadByModule.clear();
+  }
+
+  private getStableInitHash(
+    services: Services,
+    features: FeatureFlags<'happyDOM'>
+  ): string {
+    const pluginOptionsRef = services.options.pluginOptions;
+    const evalOptionsRef = pluginOptionsRef.eval;
+    const rootRef = services.options.root;
+    if (
+      this.stableInitHashCache !== null &&
+      this.stableInitHashCache.pluginOptionsRef === pluginOptionsRef &&
+      this.stableInitHashCache.evalOptionsRef === evalOptionsRef &&
+      this.stableInitHashCache.featuresRef === features &&
+      this.stableInitHashCache.rootRef === rootRef
+    ) {
+      return this.stableInitHashCache.hash;
+    }
+    // Build a sample payload (entrypoint name doesn't affect stable hash; we
+    // pass any name and strip it inside getStableInitPayloadHash).
+    // encodeGlobals is memoized so this is the only place it actually runs
+    // per config change.
+    const samplePayload = buildRunnerInitPayload(
+      services,
+      { name: '\0stable-init-sample\0' } as Entrypoint,
+      features
+    );
+    samplePayload.reuseModules = true;
+    const hash = getStableInitPayloadHash(samplePayload);
+    this.stableInitHashCache = {
+      pluginOptionsRef,
+      evalOptionsRef,
+      featuresRef: features,
+      rootRef,
+      hash,
+    };
+    return hash;
   }
 
   private async initRunner(entrypoint: Entrypoint) {
     const features = this.getRunnerFeatures();
-    const payload = buildRunnerInitPayload(this.services, entrypoint, features);
-    payload.reuseModules = true;
-    const initKey = getInitPayloadKey(payload);
+    const stableHash = this.getStableInitHash(this.currentServices, features);
+    const initKey = `${stableHash}::${entrypoint.name}`;
+    if (this.lastInitKey === initKey) {
+      return;
+    }
     const nextHappyDomEnabled = isFeatureEnabled(
       features,
       'happyDOM',
       entrypoint.name
     );
-    if (this.lastInitKey === initKey) {
-      return;
-    }
+    const payload = buildRunnerInitPayload(this.services, entrypoint, features);
+    payload.reuseModules = true;
     const timeoutMs = this.getInitTimeoutMs(entrypoint, features);
 
     if (
@@ -1680,7 +1843,7 @@ export class EvalBroker {
           );
           fallbackPayload.reuseModules = true;
           await this.request('INIT', fallbackPayload, INIT_TIMEOUT_MS);
-          this.lastInitKey = getInitPayloadKey(fallbackPayload);
+          this.lastInitKey = `${this.getStableInitHash(this.currentServices, fallbackFeatures)}::${entrypoint.name}`;
           this.lastHappyDomEnabled = false;
           return;
         }
@@ -1790,6 +1953,12 @@ export class EvalBroker {
           this.runner?.kill();
           return;
         }
+        if (message.modulesReset) {
+          // Runner just cleared its moduleCache during this INIT (full
+          // context rebuild or reuseModules:false). Drop our shipped-code
+          // mirror so handleLoad ships fresh code on the next LOAD.
+          this.lastSentLoadByModule.clear();
+        }
         this.resolvePending(message.id, {});
         return;
       case 'EVAL_RESULT':
@@ -1857,16 +2026,18 @@ export class EvalBroker {
   private async handleResolve(id: string, payload: ResolveRequestPayload) {
     const result = await this.resolveImport(payload);
 
-    debugAction({
-      type: 'resolve',
-      evalSeq: this.evalSeq,
-      specifier: payload.specifier,
-      importer: payload.importerId,
-      kind: payload.kind,
-      resolvedId: result.resolvedId ?? null,
-      external: result.external ?? false,
-      ts: performance.now(),
-    });
+    if (debugEvalDir) {
+      debugAction({
+        type: 'resolve',
+        evalSeq: this.evalSeq,
+        specifier: payload.specifier,
+        importer: payload.importerId,
+        kind: payload.kind,
+        resolvedId: result.resolvedId ?? null,
+        external: result.external ?? false,
+        ts: performance.now(),
+      });
+    }
 
     await this.sendMessage({
       type: 'RESOLVE_RESULT',
@@ -2534,36 +2705,79 @@ export class EvalBroker {
   private async handleLoad(id: string, payload: LoadRequestPayload) {
     const prepared = await this.loadModule(payload);
 
-    if (debugEvalDir && prepared.code) {
-      dumpEvalCode(
-        payload.id,
-        prepared.code,
-        prepared.only,
-        prepared.hash ? `cache:${prepared.hash}` : 'fresh',
-        this.evalSeq
-      );
-    }
+    // Decide once whether the runner already has this exact prepared variant.
+    // The runner caches by id and short-circuits when the LoadResult hash
+    // matches `moduleHashes.get(id)` (runner.js:1834). So when our prior
+    // shipment under the same hash already covered the requested `only`,
+    // re-shipping the code is pure waste — both over IPC and to the dump dir.
+    const previouslySent = prepared.hash
+      ? this.lastSentLoadByModule.get(payload.id)
+      : undefined;
+    // Runner stores by hash but classifies storage by `only` shape: wildcard
+    // (`['*']`) ⇒ moduleCache, anything else ⇒ moduleVariants (runner.js
+    // isFullModuleLoad / runner.js:1832-1842). Reusing across shapes would
+    // hit the wrong map and miss. Require the same shape AND the prepared
+    // `only` to be a subset of what we already shipped — same hash already
+    // implies identical bytes.
+    const sameStorageShape = Boolean(
+      previouslySent &&
+        isWildcardOnly(previouslySent.only) === isWildcardOnly(prepared.only)
+    );
+    const runnerHasCachedVariant = Boolean(
+      prepared.hash &&
+        previouslySent &&
+        previouslySent.hash === prepared.hash &&
+        sameStorageShape &&
+        isSuperSet(previouslySent.only, prepared.only)
+    );
+    const shouldShipCode = Boolean(
+      prepared.code && !prepared.exports && !runnerHasCachedVariant
+    );
 
-    debugAction({
-      type: 'load',
-      evalSeq: this.evalSeq,
-      id: payload.id,
-      importer: payload.importerId ?? null,
-      only: prepared.only,
-      hasCode: Boolean(prepared.code),
-      hasExports: Boolean(prepared.exports),
-      hash: prepared.hash ?? null,
-      ts: performance.now(),
-    });
+    if (debugEvalDir) {
+      if (shouldShipCode) {
+        dumpEvalCode(
+          payload.id,
+          prepared.code!,
+          prepared.only,
+          prepared.hash ? `cache:${prepared.hash}` : 'fresh',
+          this.evalSeq
+        );
+      }
+
+      debugAction({
+        type: 'load',
+        evalSeq: this.evalSeq,
+        id: payload.id,
+        importer: payload.importerId ?? null,
+        only: prepared.only,
+        hasCode: Boolean(prepared.code),
+        hasExports: Boolean(prepared.exports),
+        hash: prepared.hash ?? null,
+        shipped: shouldShipCode,
+        ts: performance.now(),
+      });
+    }
 
     await this.sendLoadResult(id, {
       id: payload.id,
-      code: prepared.code,
+      code: shouldShipCode ? prepared.code : '',
       map: null,
       hash: prepared.hash,
       only: prepared.only,
       exports: prepared.exports,
     });
+
+    if (shouldShipCode && prepared.hash) {
+      const merged =
+        previouslySent?.hash === prepared.hash
+          ? mergeOnly(previouslySent.only, prepared.only)
+          : [...prepared.only];
+      this.lastSentLoadByModule.set(payload.id, {
+        hash: prepared.hash,
+        only: merged,
+      });
+    }
   }
 
   private async loadModule({
@@ -2621,9 +2835,6 @@ export class EvalBroker {
         }
       }
     }
-
-    const isSelfLoad = !importerId || importerId === id;
-
     const cachedEntrypoint = this.services.cache.get('entrypoints', id) as
       | {
           evaluated?: boolean;
@@ -2668,17 +2879,15 @@ export class EvalBroker {
         }
       }
     }
-    // Only skip the prepared-load cache for self-loads (the eval entrypoint),
-    // which must always be freshly prepared because __wywPreval evaluation has
-    // side effects. Dependencies propagate __wywPreval in their `only` chain
-    // but don't need fresh preparation — their code is deterministic.
-    const canReusePreparedLoad =
-      !isSelfLoad || !requiredOnly.includes('__wywPreval');
-    if (
-      canReusePreparedLoad &&
-      cached &&
-      isPreparedCacheHit(cached, requiredOnly)
-    ) {
+    // prepareModuleOnDemand is deterministic given (id, requiredOnly): the
+    // shaker output depends only on source bytes (invalidated via
+    // consumeInvalidation when the file changes) and the requested `only`.
+    // Side effects from __wywPreval happen at runtime in the runner, not at
+    // preparation time — so caching prepared bytes is safe even for self-loads
+    // with __wywPreval. This lets incremental rebuilds reuse the prepared
+    // entrypoint when its source is unchanged; my IPC dedup mirror then
+    // suppresses re-shipping to the runner.
+    if (cached && isPreparedCacheHit(cached, requiredOnly)) {
       this.ensureImportsMapping(id, cached.imports);
       return cached;
     }
@@ -2686,7 +2895,7 @@ export class EvalBroker {
     const inflight = this.loadInFlight.get(id);
     if (inflight) {
       const result = await inflight;
-      if (canReusePreparedLoad && isPreparedCacheHit(result, requiredOnly)) {
+      if (isPreparedCacheHit(result, requiredOnly)) {
         this.ensureImportsMapping(id, result.imports);
         return result;
       }

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -1220,7 +1220,31 @@ export class EvalBroker {
     id: string,
     imports: Map<string, string[]> | null | undefined
   ) {
-    this.importsByModule.set(id, imports ?? new Map());
+    if (!imports || imports.size === 0) {
+      if (!this.importsByModule.has(id)) {
+        this.importsByModule.set(id, new Map());
+      }
+      return;
+    }
+
+    const existing = this.importsByModule.get(id);
+    if (!existing || existing.size === 0) {
+      this.importsByModule.set(id, imports);
+      return;
+    }
+
+    // Merge: widen each specifier's import list rather than replacing.
+    // Different variants of the same module may import different subsets
+    // from the same dependency. The widest set must be preserved so that
+    // any still-linking variant can resolve all its bindings.
+    for (const [specifier, keys] of imports) {
+      const existingKeys = existing.get(specifier);
+      if (!existingKeys) {
+        existing.set(specifier, keys);
+      } else {
+        existing.set(specifier, mergeOnly(existingKeys, keys));
+      }
+    }
   }
 
   private getImportOnly(
@@ -2597,6 +2621,9 @@ export class EvalBroker {
         }
       }
     }
+
+    const isSelfLoad = !importerId || importerId === id;
+
     const cachedEntrypoint = this.services.cache.get('entrypoints', id) as
       | {
           evaluated?: boolean;
@@ -2641,7 +2668,12 @@ export class EvalBroker {
         }
       }
     }
-    const canReusePreparedLoad = !requiredOnly.includes('__wywPreval');
+    // Only skip the prepared-load cache for self-loads (the eval entrypoint),
+    // which must always be freshly prepared because __wywPreval evaluation has
+    // side effects. Dependencies propagate __wywPreval in their `only` chain
+    // but don't need fresh preparation — their code is deterministic.
+    const canReusePreparedLoad =
+      !isSelfLoad || !requiredOnly.includes('__wywPreval');
     if (
       canReusePreparedLoad &&
       cached &&
@@ -2822,6 +2854,11 @@ export class EvalBroker {
 
     try {
       const result = await task;
+      // Register imports for ALL code paths (barrel proxy, prepareModuleOnDemand,
+      // custom loaders). Without this, the barrel proxy path skips
+      // ensureImportsMapping, so getLoadRequestOnly can't determine what a barrel
+      // module imports from its sub-dependencies.
+      this.ensureImportsMapping(id, result.imports);
       this.loadCache.set(id, result);
       return result;
     } finally {

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -112,6 +112,51 @@ const isVirtualSpecifier = (specifier: string) =>
 const isEvalOnlyKey = (key: string) =>
   key === '__wywPreval' || key === 'side-effect';
 
+const isPreparedOnlySuperSet = (
+  currentOnly: string[],
+  requestedOnly: string[]
+): boolean => {
+  if (
+    requestedOnly.includes('__wywPreval') &&
+    !currentOnly.includes('__wywPreval')
+  ) {
+    return false;
+  }
+
+  return isSuperSet(currentOnly, requestedOnly);
+};
+
+const hasPreparedExportKeys = (
+  prepared: {
+    exports?: Record<string, SerializedValue>;
+  },
+  requestedOnly: string[]
+): boolean => {
+  if (!prepared.exports) {
+    return true;
+  }
+
+  if (requestedOnly.includes('*')) {
+    return false;
+  }
+
+  return requestedOnly
+    .filter((key) => !isEvalOnlyKey(key) && key !== '*')
+    .every((key) =>
+      Object.prototype.hasOwnProperty.call(prepared.exports, key)
+    );
+};
+
+const isPreparedCacheHit = (
+  prepared: {
+    exports?: Record<string, SerializedValue>;
+    only: string[];
+  },
+  requestedOnly: string[]
+): boolean =>
+  isPreparedOnlySuperSet(prepared.only, requestedOnly) &&
+  hasPreparedExportKeys(prepared, requestedOnly);
+
 const isExportContainer = (
   value: unknown
 ): value is Record<string | symbol, unknown> =>
@@ -2407,26 +2452,35 @@ export class EvalBroker {
       cachedEntrypoint.evaluated &&
       !cachedEntrypoint.ignored &&
       cachedEntrypoint.exports &&
+      !requiredOnly.includes('*') &&
       !requiredOnly.some(isEvalOnlyKey) &&
       isSuperSet(cachedEntrypoint.evaluatedOnly ?? [], requiredOnly)
     ) {
       const cacheOnly = cachedEntrypoint.evaluatedOnly ?? requiredOnly;
+      const serializeOnly = requiredOnly.includes('*')
+        ? cacheOnly
+        : requiredOnly;
       const serialized = serializeCachedExports(
         cachedEntrypoint.exports,
-        cacheOnly
+        serializeOnly
       );
       if (serialized) {
         const hash = hashContent(`exports:${JSON.stringify(serialized)}`);
         return {
           code: '',
           imports: null,
-          only: cacheOnly,
+          only: serializeOnly,
           hash,
           exports: serialized,
         };
       }
     }
-    if (cached && isSuperSet(cached.only, requiredOnly)) {
+    const canReusePreparedLoad = !requiredOnly.includes('__wywPreval');
+    if (
+      canReusePreparedLoad &&
+      cached &&
+      isPreparedCacheHit(cached, requiredOnly)
+    ) {
       this.ensureImportsMapping(id, cached.imports);
       return cached;
     }
@@ -2434,7 +2488,7 @@ export class EvalBroker {
     const inflight = this.loadInFlight.get(id);
     if (inflight) {
       const result = await inflight;
-      if (isSuperSet(result.only, requiredOnly)) {
+      if (canReusePreparedLoad && isPreparedCacheHit(result, requiredOnly)) {
         this.ensureImportsMapping(id, result.imports);
         return result;
       }

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -239,6 +239,78 @@ const serializeCachedExports = (
   return serialized;
 };
 
+type CachedExportEntrypointLike = {
+  evaluatedOnly?: string[];
+  exports?: Record<string | symbol, unknown>;
+  loadedAndParsed?: {
+    code?: string;
+    evalConfig?: { filename?: null | string };
+    evaluator?: unknown;
+  };
+};
+
+const collectKnownExportNames = (
+  services: Services,
+  id: string,
+  cachedEntrypoint?: CachedExportEntrypointLike
+): string[] | undefined => {
+  let knownExports = services.cache.get('exports', id) as string[] | undefined;
+  if (knownExports || !cachedEntrypoint) {
+    return knownExports;
+  }
+
+  const { loadedAndParsed } = cachedEntrypoint;
+  if (loadedAndParsed?.evaluator !== oxcShaker || !loadedAndParsed.code) {
+    return undefined;
+  }
+
+  const analyzed = collectOxcExportsAndImports(
+    loadedAndParsed.code,
+    loadedAndParsed.evalConfig?.filename ?? id
+  );
+  if (analyzed.reexports.some((reexport) => reexport.exported === '*')) {
+    return undefined;
+  }
+
+  knownExports = Array.from(
+    new Set([
+      ...Object.keys(analyzed.exports),
+      ...analyzed.reexports.map((reexport) => reexport.exported),
+    ])
+  );
+  services.cache.add('exports', id, knownExports);
+  return knownExports;
+};
+
+const getSerializableStaticImportKeys = (
+  services: Services,
+  id: string,
+  cachedEntrypoint: CachedExportEntrypointLike,
+  requiredOnly: string[],
+  request?: string | null,
+  importerId?: string | null
+): string[] | null => {
+  const isStaticImportLoad = Boolean(request && importerId);
+  const knownExports = collectKnownExportNames(
+    services,
+    id,
+    cachedEntrypoint
+  )?.filter((key) => !isEvalOnlyKey(key) && key !== '*');
+
+  if (knownExports?.length) {
+    return isSuperSet(cachedEntrypoint.evaluatedOnly ?? [], knownExports)
+      ? knownExports
+      : null;
+  }
+
+  if (isStaticImportLoad) {
+    return null;
+  }
+
+  const evaluatedOnly = cachedEntrypoint.evaluatedOnly ?? requiredOnly;
+  return requiredOnly.includes('*') ? evaluatedOnly : requiredOnly;
+};
+
 const DEFAULT_EVAL_OPTIONS: Required<
   Pick<EvalOptionsV2, 'mode' | 'require' | 'resolver'>
 > = {
@@ -1212,28 +1284,7 @@ export class EvalBroker {
         exportsProxy[key] = deserializeValue(serialized);
       });
 
-      let knownExports = this.services.cache.get('exports', id) as
-        | string[]
-        | undefined;
-      if (
-        !knownExports &&
-        target.loadedAndParsed &&
-        target.loadedAndParsed.evaluator === oxcShaker
-      ) {
-        const analyzed = collectOxcExportsAndImports(
-          target.loadedAndParsed.code,
-          target.loadedAndParsed.evalConfig.filename ?? id
-        );
-        if (analyzed.reexports.every((reexport) => reexport.exported !== '*')) {
-          knownExports = Array.from(
-            new Set([
-              ...Object.keys(analyzed.exports),
-              ...analyzed.reexports.map((reexport) => reexport.exported),
-            ])
-          );
-          this.services.cache.add('exports', id, knownExports);
-        }
-      }
+      const knownExports = collectKnownExportNames(this.services, id, target);
       const serializedKeys = Object.keys(serializedExports);
       const coversAllKnownExports =
         Array.isArray(knownExports) &&
@@ -2456,23 +2507,29 @@ export class EvalBroker {
       !requiredOnly.some(isEvalOnlyKey) &&
       isSuperSet(cachedEntrypoint.evaluatedOnly ?? [], requiredOnly)
     ) {
-      const cacheOnly = cachedEntrypoint.evaluatedOnly ?? requiredOnly;
-      const serializeOnly = requiredOnly.includes('*')
-        ? cacheOnly
-        : requiredOnly;
-      const serialized = serializeCachedExports(
-        cachedEntrypoint.exports,
-        serializeOnly
+      const serializeOnly = getSerializableStaticImportKeys(
+        this.services,
+        id,
+        cachedEntrypoint,
+        requiredOnly,
+        request,
+        importerId
       );
-      if (serialized) {
-        const hash = hashContent(`exports:${JSON.stringify(serialized)}`);
-        return {
-          code: '',
-          imports: null,
-          only: serializeOnly,
-          hash,
-          exports: serialized,
-        };
+      if (serializeOnly) {
+        const serialized = serializeCachedExports(
+          cachedEntrypoint.exports,
+          serializeOnly
+        );
+        if (serialized) {
+          const hash = hashContent(`exports:${JSON.stringify(serialized)}`);
+          return {
+            code: '',
+            imports: null,
+            only: serializeOnly,
+            hash,
+            exports: serialized,
+          };
+        }
       }
     }
     const canReusePreparedLoad = !requiredOnly.includes('__wywPreval');

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -128,23 +128,49 @@ const isPreparedOnlySuperSet = (
 
 const hasPreparedExportKeys = (
   prepared: {
+    code?: string;
     exports?: Record<string, SerializedValue>;
   },
   requestedOnly: string[]
 ): boolean => {
-  if (!prepared.exports) {
+  const requestedKeys = requestedOnly.filter(
+    (key) => !isEvalOnlyKey(key) && key !== '*'
+  );
+
+  if (requestedKeys.length === 0) {
     return true;
   }
 
-  if (requestedOnly.includes('*')) {
-    return false;
+  if (!prepared.exports) {
+    if (!prepared.code) {
+      return false;
+    }
+
+    try {
+      const collected = collectOxcExportsAndImports(
+        prepared.code,
+        'prepared-module.js'
+      );
+      if (collected.reexports.some((reexport) => reexport.exported === '*')) {
+        return true;
+      }
+
+      const exportNames = new Set([
+        ...Object.keys(collected.exports),
+        ...collected.reexports
+          .filter((reexport) => reexport.exported !== '*')
+          .map((reexport) => reexport.exported),
+      ]);
+
+      return requestedKeys.every((key) => exportNames.has(key));
+    } catch {
+      return false;
+    }
   }
 
-  return requestedOnly
-    .filter((key) => !isEvalOnlyKey(key) && key !== '*')
-    .every((key) =>
-      Object.prototype.hasOwnProperty.call(prepared.exports, key)
-    );
+  return requestedKeys.every((key) =>
+    Object.prototype.hasOwnProperty.call(prepared.exports, key)
+  );
 };
 
 const isPreparedCacheHit = (
@@ -291,20 +317,37 @@ const getSerializableStaticImportKeys = (
   importerId?: string | null
 ): string[] | null => {
   const isStaticImportLoad = Boolean(request && importerId);
+  const requestedExports = requiredOnly.includes('*')
+    ? null
+    : requiredOnly.filter((key) => !isEvalOnlyKey(key) && key !== '*');
   const knownExports = collectKnownExportNames(
     services,
     id,
     cachedEntrypoint
   )?.filter((key) => !isEvalOnlyKey(key) && key !== '*');
 
+  if (isStaticImportLoad) {
+    if (
+      !requestedExports?.length ||
+      !knownExports?.length ||
+      !isSuperSet(cachedEntrypoint.evaluatedOnly ?? [], knownExports)
+    ) {
+      return null;
+    }
+
+    if (!requestedExports.every((key) => knownExports.includes(key))) {
+      return null;
+    }
+
+    return isSuperSet(cachedEntrypoint.evaluatedOnly ?? [], requestedExports)
+      ? requestedExports
+      : null;
+  }
+
   if (knownExports?.length) {
     return isSuperSet(cachedEntrypoint.evaluatedOnly ?? [], knownExports)
       ? knownExports
       : null;
-  }
-
-  if (isStaticImportLoad) {
-    return null;
   }
 
   const evaluatedOnly = cachedEntrypoint.evaluatedOnly ?? requiredOnly;
@@ -1180,6 +1223,64 @@ export class EvalBroker {
     this.importsByModule.set(id, imports ?? new Map());
   }
 
+  private getImportOnly(
+    importerId: string | null | undefined,
+    specifier: string
+  ): string[] {
+    const importsOnly = importerId
+      ? this.importsByModule.get(importerId)?.get(specifier)
+      : undefined;
+    const importerOnly = importerId
+      ? this.onlyByModule.get(importerId) ?? ['*']
+      : ['*'];
+    return importerOnly.includes('__wywPreval')
+      ? mergeOnly(importsOnly ?? ['*'], ['__wywPreval'])
+      : importsOnly ?? ['*'];
+  }
+
+  private getLoadRequestOnly(
+    id: string,
+    importerId: string | null | undefined,
+    request: string | null | undefined
+  ): string[] | null {
+    if (!request || !importerId || importerId === id) {
+      return null;
+    }
+
+    const imports = this.importsByModule.get(importerId);
+    if (!imports?.has(request)) {
+      return null;
+    }
+
+    const { root } = this.services.options;
+    const keyInfo = toImportKey({
+      source: request,
+      resolved: id,
+      root,
+    });
+    const override = getImportOverride(
+      this.services.options.pluginOptions.importOverrides,
+      keyInfo.key
+    );
+    let nextOnly = applyImportOverrideToOnly(
+      this.getImportOnly(importerId, request),
+      override
+    );
+    const cached = this.services.cache.get('entrypoints', id) as
+      | CachedEntrypointLike
+      | undefined;
+    if (
+      nextOnly.includes('__wywPreval') &&
+      cached?.evaluated &&
+      !cached.ignored &&
+      !hasCachedWywPrevalExport(this.services, id, cached)
+    ) {
+      nextOnly = nextOnly.filter((item) => item !== '__wywPreval');
+    }
+
+    return nextOnly;
+  }
+
   public async evaluate(
     entrypoint: Entrypoint,
     services?: Services
@@ -1848,10 +1949,7 @@ export class EvalBroker {
     const evalOptions = getEvalOptions(this.services);
     const stack = this.getResolveStack(importerId);
     const importsOnly = this.importsByModule.get(importerId)?.get(specifier);
-    const importerOnly = this.onlyByModule.get(importerId) ?? ['*'];
-    const only = importerOnly.includes('__wywPreval')
-      ? mergeOnly(importsOnly ?? ['*'], ['__wywPreval'])
-      : importsOnly ?? ['*'];
+    const only = this.getImportOnly(importerId, specifier);
     if (process.env.WYW_DEBUG_EVAL_RESOLVE && !importsOnly) {
       // eslint-disable-next-line no-console
       console.warn('[wyw-eval:resolve:only-miss]', {
@@ -2467,6 +2565,17 @@ export class EvalBroker {
     if (this.services.cache.consumeInvalidation(id)) {
       this.loadCache.delete(id);
       cached = undefined;
+    }
+
+    const loadRequestOnly = this.getLoadRequestOnly(id, importerId, request);
+    if (loadRequestOnly) {
+      const storedOnly = this.onlyByModule.get(id);
+      this.onlyByModule.set(
+        id,
+        storedOnly ? mergeOnly(storedOnly, loadRequestOnly) : loadRequestOnly
+      );
+      this.trackImporterDependency(importerId!, request!, id, loadRequestOnly);
+      this.emitDependency(importerId!, request!, id, loadRequestOnly);
     }
 
     let requiredOnly = this.mergeKnownDependencyOnly(id);

--- a/packages/transform/src/eval/prepareModuleOnDemand.ts
+++ b/packages/transform/src/eval/prepareModuleOnDemand.ts
@@ -14,7 +14,9 @@ export function prepareModuleOnDemand(
   id: string,
   only: string[]
 ): PreparedModule {
-  const entrypoint = Entrypoint.createRoot(services, id, only, undefined);
+  const entrypoint = Entrypoint.createRoot(services, id, only, undefined, {
+    mergeCachedOnly: !only.includes('__wywPreval'),
+  });
 
   if (entrypoint.ignored) {
     return {

--- a/packages/transform/src/eval/protocol.ts
+++ b/packages/transform/src/eval/protocol.ts
@@ -71,6 +71,11 @@ export type InitAckMessage = {
   type: 'INIT_ACK';
   id: string;
   error?: SerializedError;
+  // Set by the runner when it just reset its moduleCache during INIT (full
+  // reset on context rebuild, or `reuseModules: false`). The broker uses
+  // this to invalidate its "what runner has" mirror without doing any
+  // payload hashing or stringification on its own hot path.
+  modulesReset?: boolean;
 };
 
 export type EvalMessage = {

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -988,7 +988,14 @@ const resetModuleState = () => {
   externalInFlight.clear();
   resolveInFlight.clear();
   resolveCache.clear();
+  sentNamespaceIdentifiers.clear();
 };
+
+// Tracks the SourceTextModule identifier (versioned with hash) that was last
+// included in an EVAL_RESULT for each id. Reused module variants don't need
+// re-serialization across eval sessions — same variant = same namespace =
+// same exports the broker already has cached.
+const sentNamespaceIdentifiers = new Map();
 
 const resetSingleModuleState = (id, cachedModule = moduleCache.get(id)) => {
   if (cachedModule) {
@@ -1841,6 +1848,19 @@ loadModule = async (id, importer, requestSpec) => {
       }
     }
 
+    // The broker only ships empty `code` when it expects the runner to reuse
+    // a cached module via the hash-match short-circuit above. Reaching this
+    // point with no code means the broker's "what runner has" mirror is out
+    // of sync with our actual moduleCache/moduleVariants — fail loudly rather
+    // than feeding empty source into vm.SourceTextModule.
+    if (loaded.code == null || loaded.code === '') {
+      throw new Error(
+        `[wyw-in-js] LoadResult for ${id} has empty code but no cached module ` +
+          `matched hash ${loaded.hash ?? '(none)'}. ` +
+          `This indicates a broker/runner cache desync.`
+      );
+    }
+
     if (usePrimaryCache) {
       resetSingleModuleState(id, cached);
     }
@@ -1979,6 +1999,16 @@ const collectModuleExports = () => {
     const data = moduleData.get(id);
     if (!module || !data) return;
 
+    // The broker already has the serialized exports for this exact variant
+    // from a prior eval session. Re-serializing here just wastes CPU on the
+    // runner side and bloats the EVAL_RESULT payload. Same variant identifier
+    // ⇒ same namespace ⇒ no change to send.
+    const moduleIdentifier =
+      typeof module.identifier === 'string' ? module.identifier : id;
+    if (sentNamespaceIdentifiers.get(id) === moduleIdentifier) {
+      return;
+    }
+
     // .namespace is only safe on fully evaluated modules. Modules that
     // errored or were never evaluated (stale from a prior failed session
     // with reuseModules) have TDZ bindings that crash Object.keys().
@@ -2025,6 +2055,7 @@ const collectModuleExports = () => {
 
     if (Object.keys(serialized).length) {
       exportsByModule[id] = serialized;
+      sentNamespaceIdentifiers.set(id, moduleIdentifier);
     }
   });
 
@@ -2120,7 +2151,8 @@ const handleMessage = async (message) => {
         const reuseModules = Boolean(message.payload.reuseModules);
 
         if (canReuseContext) {
-          if (!reuseModules) {
+          const modulesReset = !reuseModules;
+          if (modulesReset) {
             resetModuleState();
           } else {
             // Clear resolution caches between sessions even when reusing modules.
@@ -2146,7 +2178,7 @@ const handleMessage = async (message) => {
           });
           state.globalsSignature = nextGlobalsSignature;
           debug('init:reuse', Date.now() - initStart);
-          sendMessage({ type: 'INIT_ACK', id: message.id });
+          sendMessage({ type: 'INIT_ACK', id: message.id, modulesReset });
           break;
         }
 
@@ -2171,7 +2203,8 @@ const handleMessage = async (message) => {
         state.happyDomEnabled = nextHappyDomEnabled;
         state.globalsSignature = nextGlobalsSignature;
 
-        sendMessage({ type: 'INIT_ACK', id: message.id });
+        // Full context rebuild ⇒ moduleCache was cleared by resetEvaluationState.
+        sendMessage({ type: 'INIT_ACK', id: message.id, modulesReset: true });
         debug('init:done', Date.now() - initStart);
       } catch (error) {
         sendMessage({

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1413,7 +1413,7 @@ const createRequireFn = (importer) => {
   };
 };
 
-function createSyntheticModule(id, exportsValue) {
+function createSyntheticModule(id, exportsValue, cache = true) {
   const exportNames = new Set(Object.keys(exportsValue));
   if (!exportNames.has('default')) {
     exportNames.add('default');
@@ -1431,7 +1431,9 @@ function createSyntheticModule(id, exportsValue) {
     { context: state.context, identifier: id }
   );
 
-  moduleCache.set(id, module);
+  if (cache) {
+    moduleCache.set(id, module);
+  }
   return module;
 }
 
@@ -1725,7 +1727,6 @@ loadModule = async (id, importer, requestSpec) => {
       importer,
       durationMs: Date.now() - loadStart,
     });
-
     if (loaded.error) {
       throw new Error(loaded.error.message);
     }
@@ -1740,16 +1741,13 @@ loadModule = async (id, importer, requestSpec) => {
         return cached;
       }
 
-      resetSingleModuleState(id, cached);
-
       const exportsValue = {};
       Object.entries(loaded.exports).forEach(([key, serialized]) => {
         exportsValue[key] = deserializeValue(serialized);
       });
-      const module = createSyntheticModule(id, exportsValue);
-      if (loaded.hash) {
-        moduleHashes.set(id, loaded.hash);
-      }
+      // Serialized exports can be a narrow slice of a module. Do not let them
+      // replace a cached SourceTextModule that may be needed by another import.
+      const module = createSyntheticModule(id, exportsValue, false);
       return module;
     }
 

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1007,7 +1007,8 @@ const resetSingleModuleState = (id, cachedModule = moduleCache.get(id)) => {
   moduleLastVariant.delete(id);
 };
 
-const isFullModuleLoad = (loaded) => !loaded.only || loaded.only.includes('*');
+const isFullModuleLoad = (loaded) =>
+  !loaded.only || (loaded.only.length === 1 && loaded.only[0] === '*');
 
 const getModuleVariant = (id, hash) => moduleVariants.get(id)?.get(hash);
 

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -111,6 +111,7 @@ const builtins = {
 
 const RESOLVE_CACHE_SIZE = 5000;
 const LOAD_CACHE_SIZE = 1000;
+const MODULE_VARIANT_LIMIT = 8;
 
 const isBuiltinSpecifier = (specifier) => {
   const normalized = specifier.startsWith('node:')
@@ -958,6 +959,8 @@ const moduleCache = new LruCache(LOAD_CACHE_SIZE);
 const moduleHashes = new Map();
 const moduleData = new Map();
 const moduleOnly = new Map();
+const moduleVariants = new Map();
+const moduleLastVariant = new Map();
 const linkPromises = new Map();
 const loadInFlight = new Map();
 const externalInFlight = new Map();
@@ -978,6 +981,8 @@ const resetModuleState = () => {
   moduleHashes.clear();
   moduleData.clear();
   moduleOnly.clear();
+  moduleVariants.clear();
+  moduleLastVariant.clear();
   linkPromises.clear();
   loadInFlight.clear();
   externalInFlight.clear();
@@ -990,9 +995,41 @@ const resetSingleModuleState = (id, cachedModule = moduleCache.get(id)) => {
     linkPromises.delete(cachedModule);
   }
 
+  const variants = moduleVariants.get(id);
+  if (variants) {
+    variants.forEach((variant) => linkPromises.delete(variant));
+  }
+
   moduleCache.delete(id);
   moduleHashes.delete(id);
   moduleData.delete(id);
+  moduleVariants.delete(id);
+  moduleLastVariant.delete(id);
+};
+
+const isFullModuleLoad = (loaded) => !loaded.only || loaded.only.includes('*');
+
+const getModuleVariant = (id, hash) => moduleVariants.get(id)?.get(hash);
+
+const setModuleVariant = (id, hash, module) => {
+  let variants = moduleVariants.get(id);
+  if (!variants) {
+    variants = new Map();
+    moduleVariants.set(id, variants);
+  }
+  variants.set(hash, module);
+  moduleLastVariant.set(id, module);
+
+  if (variants.size > MODULE_VARIANT_LIMIT) {
+    const oldestHash = variants.keys().next().value;
+    if (oldestHash !== undefined) {
+      const oldest = variants.get(oldestHash);
+      if (oldest) {
+        linkPromises.delete(oldest);
+      }
+      variants.delete(oldestHash);
+    }
+  }
 };
 
 const toSourceModuleId = (id) => stripQueryAndHash(String(id));
@@ -1751,11 +1788,21 @@ loadModule = async (id, importer, requestSpec) => {
       return module;
     }
 
-    if (cached && loaded.hash && moduleHashes.get(id) === loaded.hash) {
-      return cached;
+    const usePrimaryCache = isFullModuleLoad(loaded);
+    if (usePrimaryCache) {
+      if (cached && loaded.hash && moduleHashes.get(id) === loaded.hash) {
+        return cached;
+      }
+    } else if (loaded.hash) {
+      const variant = getModuleVariant(id, loaded.hash);
+      if (variant) {
+        return variant;
+      }
     }
 
-    resetSingleModuleState(id, cached);
+    if (usePrimaryCache) {
+      resetSingleModuleState(id, cached);
+    }
 
     const module = new vm.SourceTextModule(
       `${buildPreamble(id)}${loaded.code ?? ''}`,
@@ -1783,9 +1830,13 @@ loadModule = async (id, importer, requestSpec) => {
       }
     );
 
-    moduleCache.set(id, module);
-    if (loaded.hash) {
-      moduleHashes.set(id, loaded.hash);
+    if (usePrimaryCache) {
+      moduleCache.set(id, module);
+      if (loaded.hash) {
+        moduleHashes.set(id, loaded.hash);
+      }
+    } else if (loaded.hash) {
+      setModuleVariant(id, loaded.hash, module);
     }
     return module;
   })();
@@ -1883,7 +1934,7 @@ const collectModuleExports = () => {
   moduleOnly.forEach((only, id) => {
     if (!only || only.length === 0) return;
 
-    const module = moduleCache.get(id);
+    const module = moduleCache.get(id) ?? moduleLastVariant.get(id);
     const data = moduleData.get(id);
     if (!module || !data) return;
 

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1775,17 +1775,57 @@ loadModule = async (id, importer, requestSpec) => {
     }
 
     if (loaded.exports) {
-      if (cached && loaded.hash && moduleHashes.get(id) === loaded.hash) {
-        return cached;
+      // Serialized exports are a narrow slice — only the keys the importer
+      // requested. If we have a fully evaluated module (in moduleCache or as
+      // a variant), prefer it: its namespace has ALL exports, so any consumer
+      // can link against it without "does not provide export" errors.
+      //
+      // An evaluated variant is only safe to reuse when its namespace covers
+      // the serialized key set. A narrow variant that was evaluated first may
+      // lack exports that a wider consumer needs (the 4df6e915 race).
+      const requiredKeys = Object.keys(loaded.exports);
+      const coversKeys = (mod) => {
+        const ns = mod.namespace;
+        return requiredKeys.every((k) => k in ns);
+      };
+
+      let evaluated =
+        cached && cached.status === 'evaluated' && coversKeys(cached)
+          ? cached
+          : undefined;
+
+      if (!evaluated) {
+        const variants = moduleVariants.get(id);
+        if (variants) {
+          for (const variant of variants.values()) {
+            if (variant.status === 'evaluated' && coversKeys(variant)) {
+              evaluated = variant;
+              break;
+            }
+          }
+        }
+      }
+
+      if (evaluated) {
+        return evaluated;
+      }
+
+      // Reuse a previously created SyntheticModule for this exact serialized set
+      if (loaded.hash) {
+        const existing = getModuleVariant(id, loaded.hash);
+        if (existing) {
+          return existing;
+        }
       }
 
       const exportsValue = {};
       Object.entries(loaded.exports).forEach(([key, serialized]) => {
         exportsValue[key] = deserializeValue(serialized);
       });
-      // Serialized exports can be a narrow slice of a module. Do not let them
-      // replace a cached SourceTextModule that may be needed by another import.
       const module = createSyntheticModule(id, exportsValue, false);
+      if (loaded.hash) {
+        setModuleVariant(id, loaded.hash, module);
+      }
       return module;
     }
 

--- a/packages/transform/src/transform/Entrypoint.ts
+++ b/packages/transform/src/transform/Entrypoint.ts
@@ -282,6 +282,13 @@ export class Entrypoint extends BaseEntrypoint {
         cached.transformResultCode,
         cached.hasWywMetadata
       );
+      if (
+        'preevalResult' in cached &&
+        cached.preevalResult !== null &&
+        cached.preevalResult !== undefined
+      ) {
+        reusedEntrypoint.setPreevalResult(cached.preevalResult);
+      }
 
       return [isLoop ? 'loop' : 'cached', reusedEntrypoint];
     }

--- a/packages/transform/src/transform/Entrypoint.ts
+++ b/packages/transform/src/transform/Entrypoint.ts
@@ -22,6 +22,10 @@ import { stripQueryAndHash } from '../utils/parseRequest';
 const EMPTY_FILE = '=== empty file ===';
 const DEFAULT_ACTION_CONTEXT = Symbol('defaultActionContext');
 
+type CreateEntrypointOptions = {
+  mergeCachedOnly?: boolean;
+};
+
 function hasLoop(
   name: string,
   parent: ParentEntrypoint,
@@ -176,9 +180,17 @@ export class Entrypoint extends BaseEntrypoint {
     services: Services,
     name: string,
     only: string[],
-    loadedCode: string | undefined
+    loadedCode: string | undefined,
+    options: CreateEntrypointOptions = {}
   ): Entrypoint {
-    const created = Entrypoint.create(services, null, name, only, loadedCode);
+    const created = Entrypoint.create(
+      services,
+      null,
+      name,
+      only,
+      loadedCode,
+      options
+    );
     invariant(created !== 'loop', 'loop detected');
 
     return created;
@@ -189,7 +201,8 @@ export class Entrypoint extends BaseEntrypoint {
     parent: ParentEntrypoint | null,
     name: string,
     only: string[],
-    loadedCode: string | undefined
+    loadedCode: string | undefined,
+    options: CreateEntrypointOptions = {}
   ): Entrypoint | 'loop' {
     const { cache, eventEmitter } = services;
     return eventEmitter.perf('createEntrypoint', () => {
@@ -206,7 +219,8 @@ export class Entrypoint extends BaseEntrypoint {
           : null,
         name,
         only,
-        loadedCode
+        loadedCode,
+        options
       );
 
       if (status !== 'cached') {
@@ -222,7 +236,8 @@ export class Entrypoint extends BaseEntrypoint {
     parent: ParentEntrypoint | null,
     name: string,
     only: string[],
-    loadedCode: string | undefined
+    loadedCode: string | undefined,
+    options: CreateEntrypointOptions
   ): ['loop' | 'created' | 'cached', Entrypoint] {
     const { cache } = services;
 
@@ -254,7 +269,10 @@ export class Entrypoint extends BaseEntrypoint {
 
     const exports = cached?.exports;
     const evaluatedOnly = changed ? [] : cached?.evaluatedOnly ?? [];
-    const mergedOnly = cached?.only ? mergeOnly(cached.only, only) : [...only];
+    const mergedOnly =
+      options.mergeCachedOnly !== false && cached?.only
+        ? mergeOnly(cached.only, only)
+        : [...only];
     const reusableEvaluatedState =
       !changed && cached?.evaluated && cached.loadedAndParsed !== undefined;
     const canReuseEvaluatedTransformResult =

--- a/packages/transform/src/transform/Entrypoint.ts
+++ b/packages/transform/src/transform/Entrypoint.ts
@@ -54,6 +54,14 @@ export class Entrypoint extends BaseEntrypoint {
     Map<unknown, Map<unknown, BaseAction<ActionQueueItem>>>
   > = new Map();
 
+  // Tracks how many times resolveImports has settled with `resolved: null`
+  // for a given source. Bundler resolvers can return null transiently early
+  // in a build (loader context for that file isn't registered yet); after a
+  // bounded number of retries we accept the null as authoritative.
+  #resolveTaskNullAttempts = new Map<string, number>();
+
+  private static readonly RESOLVE_TASK_MAX_NULL_ATTEMPTS = 2;
+
   #hasWywMetadata: boolean = false;
 
   #hasTransformResult = false;
@@ -266,7 +274,7 @@ export class Entrypoint extends BaseEntrypoint {
         parent ? [parent] : [],
         loadedCode,
         name,
-        cached.only,
+        mergedOnly,
         exports,
         evaluatedOnly,
         cached.loadedAndParsed,
@@ -387,7 +395,28 @@ export class Entrypoint extends BaseEntrypoint {
     name: string,
     dependency: Promise<IEntrypointDependency>
   ): void {
-    this.resolveTasks.set(name, dependency);
+    // Bounded retry of transient null resolutions. The first time a
+    // resolveTask settles to null, evict it from the cache so the next
+    // consumer re-attempts the resolver. After RESOLVE_TASK_MAX_NULL_ATTEMPTS
+    // failures the entry stays cached so we don't thrash. Successful (non-null)
+    // resolutions remain cached normally; this branch only ever fires for null.
+    const tracked = dependency.then((resolved) => {
+      if (resolved.resolved !== null) {
+        return resolved;
+      }
+
+      const attempts = (this.#resolveTaskNullAttempts.get(name) ?? 0) + 1;
+      this.#resolveTaskNullAttempts.set(name, attempts);
+      if (
+        attempts < Entrypoint.RESOLVE_TASK_MAX_NULL_ATTEMPTS &&
+        this.resolveTasks.get(name) === tracked
+      ) {
+        this.resolveTasks.delete(name);
+      }
+
+      return resolved;
+    });
+    this.resolveTasks.set(name, tracked);
   }
 
   public applyDeferredSupersede() {

--- a/packages/transform/src/transform/Entrypoint.types.ts
+++ b/packages/transform/src/transform/Entrypoint.types.ts
@@ -40,6 +40,7 @@ export interface IPreevalResult {
   staticValueCandidates?: Array<{
     imports: Array<{
       imported: 'default' | string;
+      importLocal?: string;
       local: string;
       source: string;
     }>;

--- a/packages/transform/src/transform/Entrypoint.types.ts
+++ b/packages/transform/src/transform/Entrypoint.types.ts
@@ -34,7 +34,9 @@ export interface IPreevalResult {
   baseCode?: string;
   code: string;
   dependencyNames?: string[];
+  evalCode?: string;
   metadata: WYWTransformMetadata | null;
+  staticSideEffectImportLocals?: string[];
   staticDependencies?: string[];
   staticNullWYWMetaExtendsHelpers?: string[];
   staticValueCache?: Map<string, unknown>;

--- a/packages/transform/src/transform/Entrypoint.types.ts
+++ b/packages/transform/src/transform/Entrypoint.types.ts
@@ -31,8 +31,21 @@ export interface IEntrypointDependency {
 
 export interface IPreevalResult {
   ast: ParsedAst | null;
+  baseCode?: string;
   code: string;
+  dependencyNames?: string[];
   metadata: WYWTransformMetadata | null;
+  staticDependencies?: string[];
+  staticValueCache?: Map<string, unknown>;
+  staticValueCandidates?: Array<{
+    imports: Array<{
+      imported: 'default' | string;
+      local: string;
+      source: string;
+    }>;
+    name: string;
+    source: string;
+  }>;
 }
 
 export type LoadAndParseFn = (

--- a/packages/transform/src/transform/Entrypoint.types.ts
+++ b/packages/transform/src/transform/Entrypoint.types.ts
@@ -36,6 +36,7 @@ export interface IPreevalResult {
   dependencyNames?: string[];
   metadata: WYWTransformMetadata | null;
   staticDependencies?: string[];
+  staticNullWYWMetaExtendsHelpers?: string[];
   staticValueCache?: Map<string, unknown>;
   staticValueCandidates?: Array<{
     imports: Array<{

--- a/packages/transform/src/transform/__tests__/createEntrypoint.test.ts
+++ b/packages/transform/src/transform/__tests__/createEntrypoint.test.ts
@@ -183,6 +183,14 @@ describe('createEntrypoint', () => {
       ['value'],
       code
     );
+    const preevalResult = {
+      ast: null,
+      code,
+      dependencyNames: [],
+      metadata: null,
+      staticValueCache: new Map([['_exp', 'red']]),
+    };
+    entrypoint1.setPreevalResult(preevalResult);
     entrypoint1.setTransformResult({ code, metadata: null });
     const evaluated = entrypoint1.createEvaluated();
     services.cache.add('entrypoints', '/foo/bar.js', evaluated);
@@ -199,6 +207,7 @@ describe('createEntrypoint', () => {
     expect(entrypoint2.transformedCode).toBe(code);
     expect(entrypoint2.loadedAndParsed.code).toBe(code);
     expect(entrypoint2.loadedAndParsed).toBe(evaluated.loadedAndParsed);
+    expect(entrypoint2.getPreevalResult()).toBe(preevalResult);
   });
 
   it('reuses evaluated parsed state when only changes', () => {

--- a/packages/transform/src/transform/__tests__/createEntrypoint.test.ts
+++ b/packages/transform/src/transform/__tests__/createEntrypoint.test.ts
@@ -250,8 +250,16 @@ describe('createEntrypoint', () => {
 
     const code = 'export const a = 1; export const b = 2; export const c = 3;';
     const narrowPreparedCode = 'export const a = 1; export const b = 2;';
-    const entrypoint1 = createEntrypoint(services, '/foo/bar.js', ['a', 'b'], code);
-    entrypoint1.setTransformResult({ code: narrowPreparedCode, metadata: null });
+    const entrypoint1 = createEntrypoint(
+      services,
+      '/foo/bar.js',
+      ['a', 'b'],
+      code
+    );
+    entrypoint1.setTransformResult({
+      code: narrowPreparedCode,
+      metadata: null,
+    });
     const evaluated = entrypoint1.createEvaluated();
 
     (evaluated as unknown as { only: string[] }).only = ['a', 'b', 'c'];

--- a/packages/transform/src/transform/generators/collect.ts
+++ b/packages/transform/src/transform/generators/collect.ts
@@ -14,6 +14,7 @@ export function* collect(
   const { valueCache } = this.data;
   const { entrypoint } = this;
   const { loadedAndParsed, name } = entrypoint;
+  const preevalResult = entrypoint.getPreevalResult();
 
   if (loadedAndParsed.evaluator === 'ignored') {
     throw new Error('entrypoint was ignored');
@@ -29,7 +30,12 @@ export function* collect(
     loadedAndParsed.code,
     name,
     options.root ?? process.cwd(),
-    options.pluginOptions,
+    {
+      ...options.pluginOptions,
+      preserveSideEffectImportLocals: new Set(
+        preevalResult?.staticSideEffectImportLocals ?? []
+      ),
+    },
     valueCache,
     options.inputSourceMap
   );

--- a/packages/transform/src/transform/generators/evalFile.ts
+++ b/packages/transform/src/transform/generators/evalFile.ts
@@ -14,6 +14,19 @@ export async function* evalFile(
 ): AsyncScenarioForAction<IEvalAction> {
   const { entrypoint } = this;
   const { log } = entrypoint;
+  const preevalResult = entrypoint.getPreevalResult();
+
+  if (preevalResult && (preevalResult.dependencyNames?.length ?? 0) === 0) {
+    const valueCache: ValueCache = new Map();
+    preevalResult.staticValueCache?.forEach((value, key) => {
+      valueCache.set(key, value);
+    });
+
+    const dependencies = [...new Set(preevalResult.staticDependencies ?? [])];
+    log(`<< skipped evaluate __wywPreval %O`, valueCache);
+
+    return [valueCache, dependencies];
+  }
 
   log(`>> evaluate __wywPreval`);
 
@@ -22,7 +35,10 @@ export async function* evalFile(
   while (evaluated === undefined) {
     try {
       // eslint-disable-next-line no-await-in-loop
-      evaluated = await evaluate(this.services, entrypoint);
+      evaluated = await this.services.eventEmitter.perf(
+        'transform:evalFile',
+        () => evaluate(this.services, entrypoint)
+      );
     } catch (e) {
       if (isUnprocessedEntrypointError(e)) {
         entrypoint.log(
@@ -40,7 +56,6 @@ export async function* evalFile(
   }
 
   const valueCache: ValueCache = evaluated.values;
-  const preevalResult = entrypoint.getPreevalResult();
   preevalResult?.staticValueCache?.forEach((value, key) => {
     valueCache.set(key, value);
   });

--- a/packages/transform/src/transform/generators/evalFile.ts
+++ b/packages/transform/src/transform/generators/evalFile.ts
@@ -40,8 +40,18 @@ export async function* evalFile(
   }
 
   const valueCache: ValueCache = evaluated.values;
+  const preevalResult = entrypoint.getPreevalResult();
+  preevalResult?.staticValueCache?.forEach((value, key) => {
+    valueCache.set(key, value);
+  });
+  const dependencies = [
+    ...new Set([
+      ...evaluated.dependencies,
+      ...(preevalResult?.staticDependencies ?? []),
+    ]),
+  ];
 
   log(`<< evaluated __wywPreval %O`, valueCache);
 
-  return [valueCache, evaluated.dependencies];
+  return [valueCache, dependencies];
 }

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-restricted-syntax,no-continue,@typescript-eslint/no-use-before-define */
 
+import { isAbsolute, relative } from 'path';
+
 import type {
   ExportNamedDeclaration,
   ExportSpecifier,
@@ -13,14 +15,19 @@ import type {
 } from 'oxc-parser';
 
 import { oxcShaker } from '../../shaker';
+import { collectOxcProcessorImportsFromProgram } from '../../utils/collectOxcExportsAndImports';
 import {
   evaluateOxcStaticExpression,
   evaluateOxcStaticExpressionAt,
   isOxcStaticSerializableValue,
   type OxcStaticValueCandidate,
 } from '../../utils/collectOxcTemplateDependencies';
-import { appendOxcWywPreval } from '../../utils/oxcPreevalStage';
+import {
+  appendOxcWywPreval,
+  runOxcPreevalStage,
+} from '../../utils/oxcPreevalStage';
 import { parseOxcProgramCached } from '../../utils/parseOxc';
+import { getProcessorForImport } from '../../utils/processorLookup';
 import { Entrypoint } from '../Entrypoint';
 import type { IEntrypointDependency } from '../Entrypoint.types';
 import type { ITransformAction, SyncScenarioFor } from '../types';
@@ -47,6 +54,16 @@ type ExportTarget =
 type StaticExportResult = {
   dependencies: string[];
   value: unknown;
+};
+
+const isInsideRoot = (filename: string, root: string): boolean => {
+  const relativePath = relative(root, filename);
+  return (
+    relativePath === '' ||
+    (!!relativePath &&
+      !relativePath.startsWith('..') &&
+      !isAbsolute(relativePath))
+  );
 };
 
 const parseProgram = (code: string, filename: string): Program =>
@@ -255,6 +272,10 @@ const isSafeStaticStatement = (statement: Node): boolean => {
     return true;
   }
 
+  if (statement.type === 'FunctionDeclaration') {
+    return true;
+  }
+
   if (statement.type === 'ImportDeclaration') {
     return (
       isTypeOnlyImport(statement) ||
@@ -285,13 +306,17 @@ const isSafeStaticStatement = (statement: Node): boolean => {
     }
 
     return (
-      statement.declaration.type === 'VariableDeclaration' &&
-      isSafeVariableDeclaration(statement.declaration)
+      statement.declaration.type === 'FunctionDeclaration' ||
+      (statement.declaration.type === 'VariableDeclaration' &&
+        isSafeVariableDeclaration(statement.declaration))
     );
   }
 
   if (statement.type === 'ExportDefaultDeclaration') {
-    return isSafeStaticExpression(statement.declaration);
+    return (
+      statement.declaration.type === 'FunctionDeclaration' ||
+      isSafeStaticExpression(statement.declaration)
+    );
   }
 
   if (statement.type === 'ExpressionStatement') {
@@ -303,6 +328,236 @@ const isSafeStaticStatement = (statement: Node): boolean => {
 
 const isSafeStaticProgram = (program: Program): boolean =>
   program.body.every((statement) => isSafeStaticStatement(statement));
+
+const collectProcessorImportLocals = (
+  action: ITransformAction,
+  program: Program,
+  code: string,
+  filename: string
+): Set<string> => {
+  const result = new Set<string>();
+
+  collectOxcProcessorImportsFromProgram(program, code).forEach((item) => {
+    if (
+      item.type !== 'esm' ||
+      item.imported === '*' ||
+      item.imported === 'side-effect'
+    ) {
+      return;
+    }
+
+    const localName = item.local.name ?? item.local.code;
+    if (!localName) {
+      return;
+    }
+
+    const [processor] = getProcessorForImport(
+      {
+        imported: item.imported,
+        source: item.source,
+      },
+      filename,
+      action.services.options.pluginOptions
+    );
+
+    if (!processor) {
+      return;
+    }
+
+    result.add(localName);
+    const rootLocalName = localName.split('.')[0];
+    if (rootLocalName) {
+      result.add(rootLocalName);
+    }
+  });
+
+  return result;
+};
+
+const isSafeProcessorImport = (
+  statement: ImportDeclaration,
+  processorImportLocals: Set<string>
+): boolean => {
+  if (isTypeOnlyImport(statement)) {
+    return true;
+  }
+
+  return (
+    statement.specifiers.length > 0 &&
+    statement.specifiers.every((specifier) => {
+      if (
+        specifier.type === 'ImportSpecifier' &&
+        (specifier as ImportSpecifier).importKind === 'type'
+      ) {
+        return true;
+      }
+
+      return (
+        specifier.type !== 'ImportNamespaceSpecifier' &&
+        !!specifier.local?.name &&
+        processorImportLocals.has(specifier.local.name)
+      );
+    })
+  );
+};
+
+const expressionRootIdentifierName = (expr: Node): string | null => {
+  const unwrapped = unwrapExpression(expr);
+
+  if (unwrapped.type === 'Identifier') {
+    return unwrapped.name;
+  }
+
+  if (unwrapped.type === 'MemberExpression') {
+    return expressionRootIdentifierName(unwrapped.object);
+  }
+
+  if (unwrapped.type === 'CallExpression') {
+    return expressionRootIdentifierName(unwrapped.callee);
+  }
+
+  if (unwrapped.type === 'TaggedTemplateExpression') {
+    return expressionRootIdentifierName(unwrapped.tag);
+  }
+
+  return null;
+};
+
+const isProcessorUsageExpression = (
+  expr: Node,
+  processorImportLocals: Set<string>
+): boolean => {
+  const unwrapped = unwrapExpression(expr);
+
+  if (
+    unwrapped.type !== 'CallExpression' &&
+    unwrapped.type !== 'TaggedTemplateExpression'
+  ) {
+    return false;
+  }
+
+  const rootName = expressionRootIdentifierName(unwrapped);
+  return !!rootName && processorImportLocals.has(rootName);
+};
+
+const isSafeProcessorMetadataVariableDeclaration = (
+  statement: VariableDeclaration,
+  processorImportLocals: Set<string>
+): boolean =>
+  statement.kind === 'const' &&
+  statement.declarations.every(
+    (declarator) =>
+      declarator.init &&
+      (isSafeStaticExpression(declarator.init) ||
+        isProcessorUsageExpression(declarator.init, processorImportLocals))
+  );
+
+const isSafeProcessorMetadataStatement = (
+  statement: Node,
+  processorImportLocals: Set<string>
+): boolean => {
+  if (statement.type.startsWith('TS') || statement.type.startsWith('JSDoc')) {
+    return statement.type !== 'TSEnumDeclaration';
+  }
+
+  if (statement.type === 'EmptyStatement') {
+    return true;
+  }
+
+  if (statement.type === 'FunctionDeclaration') {
+    return true;
+  }
+
+  if (statement.type === 'ImportDeclaration') {
+    return isSafeProcessorImport(statement, processorImportLocals);
+  }
+
+  if (statement.type === 'VariableDeclaration') {
+    return isSafeProcessorMetadataVariableDeclaration(
+      statement,
+      processorImportLocals
+    );
+  }
+
+  if (statement.type === 'ExportNamedDeclaration') {
+    if (isTypeOnlyExport(statement)) {
+      return true;
+    }
+
+    if (statement.source) {
+      return statement.specifiers.every(
+        (specifier) => specifier.type === 'ExportSpecifier'
+      );
+    }
+
+    if (!statement.declaration) {
+      return true;
+    }
+
+    return (
+      statement.declaration.type === 'FunctionDeclaration' ||
+      (statement.declaration.type === 'VariableDeclaration' &&
+        isSafeProcessorMetadataVariableDeclaration(
+          statement.declaration,
+          processorImportLocals
+        ))
+    );
+  }
+
+  if (statement.type === 'ExportDefaultDeclaration') {
+    return (
+      statement.declaration.type === 'FunctionDeclaration' ||
+      isSafeStaticExpression(statement.declaration) ||
+      isProcessorUsageExpression(statement.declaration, processorImportLocals)
+    );
+  }
+
+  if (statement.type === 'ExpressionStatement') {
+    return isSafeLiteral(statement.expression);
+  }
+
+  return false;
+};
+
+const isSafeProcessorMetadataProgram = (
+  action: ITransformAction,
+  program: Program,
+  code: string,
+  filename: string
+): boolean => {
+  const processorImportLocals = collectProcessorImportLocals(
+    action,
+    program,
+    code,
+    filename
+  );
+
+  if (processorImportLocals.size === 0) {
+    return false;
+  }
+
+  return program.body.every((statement) =>
+    isSafeProcessorMetadataStatement(statement, processorImportLocals)
+  );
+};
+
+const isStaticWYWMetaValue = (value: unknown): boolean => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const meta = (value as { __wyw_meta?: unknown }).__wyw_meta;
+  if (typeof meta !== 'object' || meta === null) {
+    return false;
+  }
+
+  const { className, extends: extended } = meta as {
+    className?: unknown;
+    extends?: unknown;
+  };
+
+  return typeof className === 'string' && extended === null;
+};
 
 const collectLocalConstExpressions = (
   program: Program
@@ -511,6 +766,77 @@ function* resolveImportValue(
   };
 }
 
+const resolveProcessorMetadataExport = (
+  action: ITransformAction,
+  filename: string,
+  code: string,
+  program: Program,
+  exportedName: string
+): StaticExportResult | null => {
+  const root = action.services.options.root ?? process.cwd();
+  if (!isInsideRoot(filename, root)) {
+    return null;
+  }
+
+  if (!isSafeProcessorMetadataProgram(action, program, code, filename)) {
+    return null;
+  }
+
+  let preevalResult: ReturnType<typeof runOxcPreevalStage>;
+  try {
+    preevalResult = action.services.eventEmitter.perf(
+      'transform:preeval:staticMetadata',
+      () =>
+        runOxcPreevalStage(
+          code,
+          {
+            filename,
+            root,
+          },
+          {
+            ...action.services.options.pluginOptions,
+            eventEmitter: action.services.eventEmitter,
+          }
+        )
+    );
+  } catch {
+    return null;
+  }
+
+  if (!preevalResult.metadata) {
+    return null;
+  }
+
+  const preevalCode = preevalResult.baseCode;
+  const preevalProgram = parseProgram(preevalCode, filename);
+  const target = findExportTarget(preevalProgram, exportedName);
+  if (!target || target.kind === 'import') {
+    return null;
+  }
+
+  if (!isSafeStaticExpression(target.expression)) {
+    return null;
+  }
+
+  const value = evaluateOxcStaticExpressionAt(
+    preevalCode,
+    filename,
+    {
+      end: target.expression.end,
+      start: target.expression.start,
+    },
+    new Map()
+  );
+  if (!isStaticWYWMetaValue(value) || !isOxcStaticSerializableValue(value)) {
+    return null;
+  }
+
+  return {
+    dependencies: [filename],
+    value,
+  };
+};
+
 function* resolveStaticExport(
   action: ITransformAction,
   filename: string,
@@ -548,9 +874,16 @@ function* resolveStaticExport(
   const { code } = loadedAndParsed;
   const program = parseProgram(code, filename);
   if (!isSafeStaticProgram(program)) {
-    memo.set(memoKey, null);
+    const metadataResult = resolveProcessorMetadataExport(
+      action,
+      filename,
+      code,
+      program,
+      exportedName
+    );
+    memo.set(memoKey, metadataResult);
     stack.delete(memoKey);
-    return null;
+    return metadataResult;
   }
 
   const target = findExportTarget(program, exportedName);

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax,no-continue,@typescript-eslint/no-use-before-define */
 
-import { isAbsolute, relative } from 'path';
+import { dirname, isAbsolute, relative, resolve as resolvePath } from 'path';
 
 import { isFeatureEnabled, type FeatureFlag } from '@wyw-in-js/shared';
 import type {
@@ -28,6 +28,7 @@ import {
   runOxcPreevalStage,
 } from '../../utils/oxcPreevalStage';
 import { parseOxcProgramCached } from '../../utils/parseOxc';
+import { stripQueryAndHash } from '../../utils/parseRequest';
 import { getProcessorForImport } from '../../utils/processorLookup';
 import { Entrypoint } from '../Entrypoint';
 import type { IEntrypointDependency } from '../Entrypoint.types';
@@ -66,6 +67,28 @@ type StaticExpressionOptions = {
   allowMetadataCalls?: boolean;
 };
 
+type StaticResolveDebugPhase =
+  | 'candidate'
+  | 'entrypoint'
+  | 'export'
+  | 'import'
+  | 'processor-metadata';
+
+type StaticResolveDebugStatus = 'rejected' | 'resolved' | 'skipped';
+
+type StaticResolveDebugEvent = {
+  candidate?: string;
+  dependency?: string;
+  exported?: string;
+  filename: string;
+  imported?: string;
+  importer?: string;
+  phase: StaticResolveDebugPhase;
+  reason?: string;
+  source?: string;
+  status: StaticResolveDebugStatus;
+};
+
 const isInsideRoot = (filename: string, root: string): boolean => {
   const relativePath = relative(root, filename);
   return (
@@ -73,6 +96,19 @@ const isInsideRoot = (filename: string, root: string): boolean => {
     (!!relativePath &&
       !relativePath.startsWith('..') &&
       !isAbsolute(relativePath))
+  );
+};
+
+const nodeModulesPattern = /[\\/]node_modules[\\/]/;
+
+const isLocalStaticMetadataFile = (filename: string, root: string): boolean => {
+  const strippedFilename = stripQueryAndHash(filename);
+  if (isInsideRoot(strippedFilename, root)) {
+    return true;
+  }
+
+  return (
+    isAbsolute(strippedFilename) && !nodeModulesPattern.test(strippedFilename)
   );
 };
 
@@ -93,6 +129,31 @@ const isStaticImportValuesEnabled = (
     'staticImportValues',
     filename
   );
+};
+
+const isStaticResolveDebugEnabled = (): boolean => {
+  const envValue = process.env.WYW_DEBUG_STATIC_RESOLVE?.trim().toLowerCase();
+  return !!envValue && !isEnvDisabled(envValue);
+};
+
+const debugStaticResolve = (
+  action: ITransformAction,
+  event: StaticResolveDebugEvent
+): void => {
+  if (!isStaticResolveDebugEnabled()) {
+    return;
+  }
+
+  const labels = Object.fromEntries(
+    Object.entries({
+      ...event,
+      type: 'staticResolve',
+    }).filter(([, value]) => value !== undefined)
+  );
+
+  action.services.eventEmitter.single(labels);
+  // eslint-disable-next-line no-console
+  console.warn('[wyw-static-resolve]', labels);
 };
 
 const parseProgram = (code: string, filename: string): Program =>
@@ -346,12 +407,32 @@ type Range = {
   start: number;
 };
 
+type Replacement = Range & {
+  text: string;
+};
+
 const removeRanges = (code: string, ranges: Range[]): string => {
   let result = code;
   ranges
     .sort((a, b) => b.start - a.start)
     .forEach((range) => {
       result = result.slice(0, range.start) + result.slice(range.end);
+    });
+  return result;
+};
+
+const applyReplacements = (
+  code: string,
+  replacements: Replacement[]
+): string => {
+  let result = code;
+  replacements
+    .sort((a, b) => b.start - a.start)
+    .forEach((replacement) => {
+      result =
+        result.slice(0, replacement.start) +
+        replacement.text +
+        result.slice(replacement.end);
     });
   return result;
 };
@@ -453,18 +534,43 @@ const removableStaticHelperNames = (
   return result;
 };
 
+const collectImportLocalReferences = (
+  node: Node,
+  importLocals: Set<string>,
+  result: Set<string>
+): void => {
+  const walk = (item: Node, parent: Node | null): void => {
+    if (
+      item.type === 'Identifier' &&
+      importLocals.has(item.name) &&
+      !isIdentifierBindingPosition(item, parent) &&
+      !isPropertyKeyOnlyIdentifier(item, parent)
+    ) {
+      result.add(item.name);
+    }
+
+    getChildren(item).forEach((child) => walk(child, item));
+  };
+
+  walk(node, null);
+};
+
 const removeStaticHelperDeclarations = (
   code: string,
   filename: string,
   staticValueNames: Set<string>
-): { code: string; removed: Set<string> } => {
+): { code: string; removed: Set<string>; removedImportLocals: Set<string> } => {
   if (staticValueNames.size === 0) {
-    return { code, removed: new Set() };
+    return { code, removed: new Set(), removedImportLocals: new Set() };
   }
 
   const program = parseProgram(code, filename);
   const removableNames = removableStaticHelperNames(program, staticValueNames);
+  const importLocals = new Set<string>();
+  collectImportBindings(program).forEach((_, local) => importLocals.add(local));
+  const removedImportLocals = new Set<string>();
   const ranges: Range[] = [];
+  const replacements: Replacement[] = [];
 
   program.body.forEach((statement) => {
     if (
@@ -474,23 +580,50 @@ const removeStaticHelperDeclarations = (
       return;
     }
 
-    if (
-      statement.declarations.every(
-        (declarator) =>
-          declarator.id.type === 'Identifier' &&
-          removableNames.has(declarator.id.name)
-      )
-    ) {
+    const removableIndexes = statement.declarations.flatMap(
+      (declarator, index) =>
+        declarator.id.type === 'Identifier' &&
+        removableNames.has(declarator.id.name)
+          ? [index]
+          : []
+    );
+    if (removableIndexes.length === 0) {
+      return;
+    }
+
+    removableIndexes.forEach((index) => {
+      collectImportLocalReferences(
+        statement.declarations[index],
+        importLocals,
+        removedImportLocals
+      );
+    });
+
+    if (removableIndexes.length === statement.declarations.length) {
       ranges.push({
         end: statement.end,
         start: statement.start,
       });
+      return;
     }
+
+    const keptDeclarations = statement.declarations
+      .filter((_, index) => !removableIndexes.includes(index))
+      .map((declarator) => code.slice(declarator.start, declarator.end));
+    replacements.push({
+      end: statement.end,
+      start: statement.start,
+      text: `${statement.kind} ${keptDeclarations.join(', ')};`,
+    });
   });
 
   return {
-    code: removeRanges(code, ranges),
+    code: applyReplacements(code, [
+      ...ranges.map((range) => ({ ...range, text: '' })),
+      ...replacements,
+    ]),
     removed: removableNames,
+    removedImportLocals,
   };
 };
 
@@ -545,25 +678,75 @@ const removeUnusedStaticImports = (
   return removeRanges(code, ranges);
 };
 
+const replaceStaticWYWMetaExtendsHelpers = (
+  code: string,
+  filename: string,
+  helperNames: Set<string>
+): string => {
+  if (helperNames.size === 0) {
+    return code;
+  }
+
+  const program = parseProgram(code, filename);
+  const replacements: Replacement[] = [];
+
+  const visit = (node: Node): void => {
+    if (node.type === 'ObjectExpression') {
+      const extendsExpression = findWYWMetaExtendsExpression(node);
+      if (extendsExpression) {
+        const unwrapped = unwrapExpression(extendsExpression);
+        if (
+          unwrapped.type === 'CallExpression' &&
+          unwrapped.callee.type === 'Identifier' &&
+          unwrapped.arguments.length === 0 &&
+          helperNames.has(unwrapped.callee.name)
+        ) {
+          replacements.push({
+            end: extendsExpression.end,
+            start: extendsExpression.start,
+            text: 'null',
+          });
+        }
+      }
+    }
+
+    getChildren(node).forEach(visit);
+  };
+
+  visit(program);
+  return applyReplacements(code, replacements);
+};
+
 const pruneStaticPreevalCode = (
   code: string,
   filename: string,
   staticValueNames: Set<string>,
-  staticImportLocals: Set<string>
+  staticImportLocals: Set<string>,
+  staticNullWYWMetaExtendsHelpers: Set<string>
 ): string => {
-  const helpersRemoved = removeStaticHelperDeclarations(
+  const codeWithMetadataPruned = replaceStaticWYWMetaExtendsHelpers(
     code,
+    filename,
+    staticNullWYWMetaExtendsHelpers
+  );
+  const helpersRemoved = removeStaticHelperDeclarations(
+    codeWithMetadataPruned,
     filename,
     staticValueNames
   );
   if (helpersRemoved.removed.size === 0) {
-    return code;
+    return codeWithMetadataPruned;
   }
+
+  const importLocalsToPrune = new Set([
+    ...staticImportLocals,
+    ...helpersRemoved.removedImportLocals,
+  ]);
 
   return removeUnusedStaticImports(
     helpersRemoved.code,
     filename,
-    staticImportLocals
+    importLocalsToPrune
   );
 };
 
@@ -782,6 +965,13 @@ const collectLocalConstExpressions = (
 
 type StaticExpressionDependencies = {
   imports: ImportBinding[];
+};
+
+type PreparedProcessorTarget = {
+  dependencies: StaticExpressionDependencies;
+  expression: Expression;
+  expressionCode?: string;
+  opaqueRuntimeBase: boolean;
 };
 
 const mutatingMethodNames = new Set([
@@ -1343,6 +1533,525 @@ const collectTopLevelMutationHints = (
   return { callArgumentNames, mutatedNames };
 };
 
+const objectPropertyKeyName = (node: Node): string | null => {
+  const unwrapped = unwrapExpression(node);
+
+  if (unwrapped.type === 'Identifier') {
+    return unwrapped.name;
+  }
+
+  if (isSafeLiteral(unwrapped) && typeof unwrapped.value === 'string') {
+    return unwrapped.value;
+  }
+
+  return null;
+};
+
+const findObjectPropertyValue = (
+  expr: Node,
+  name: string
+): Expression | null => {
+  const unwrapped = unwrapExpression(expr);
+  if (unwrapped.type !== 'ObjectExpression') {
+    return null;
+  }
+
+  for (const property of unwrapped.properties) {
+    if (property.type === 'SpreadElement') {
+      continue;
+    }
+
+    const propertyNode = property as AnyNode;
+    if (propertyNode.computed) {
+      continue;
+    }
+
+    const key = propertyNode.key as Node | undefined;
+    const value = propertyNode.value as Expression | undefined;
+    if (key && value && objectPropertyKeyName(key) === name) {
+      return value;
+    }
+  }
+
+  return null;
+};
+
+const findWYWMetaExtendsExpression = (expr: Expression): Expression | null => {
+  const meta = findObjectPropertyValue(expr, '__wyw_meta');
+  if (!meta) {
+    return null;
+  }
+
+  return findObjectPropertyValue(meta, 'extends');
+};
+
+const topLevelStatements = (program: Program): Node[] => {
+  const result: Node[] = [];
+
+  program.body.forEach((statement) => {
+    if (
+      statement.type === 'ExportNamedDeclaration' ||
+      statement.type === 'ExportDefaultDeclaration'
+    ) {
+      result.push(statement.declaration ?? statement);
+      return;
+    }
+
+    result.push(statement);
+  });
+
+  return result;
+};
+
+const findTopLevelConstExpression = (
+  program: Program,
+  name: string
+): Expression | null => {
+  for (const statement of topLevelStatements(program)) {
+    if (
+      statement.type !== 'VariableDeclaration' ||
+      statement.kind !== 'const'
+    ) {
+      continue;
+    }
+
+    for (const declarator of statement.declarations) {
+      if (
+        declarator.id.type === 'Identifier' &&
+        declarator.id.name === name &&
+        declarator.init
+      ) {
+        return declarator.init;
+      }
+    }
+  }
+
+  return null;
+};
+
+const hasTopLevelBinding = (program: Program, name: string): boolean => {
+  if (collectImportBindings(program).has(name)) {
+    return true;
+  }
+
+  return topLevelStatements(program).some((statement) => {
+    if (statement.type === 'VariableDeclaration') {
+      return statement.declarations.some(
+        (declarator) =>
+          declarator.id.type === 'Identifier' && declarator.id.name === name
+      );
+    }
+
+    if (statement.type === 'FunctionDeclaration') {
+      return statement.id?.name === name;
+    }
+
+    if (statement.type === 'ClassDeclaration') {
+      return statement.id?.name === name;
+    }
+
+    return false;
+  });
+};
+
+const isTopLevelFunctionOrClass = (program: Program, name: string): boolean =>
+  topLevelStatements(program).some((statement) => {
+    if (statement.type === 'FunctionDeclaration') {
+      return statement.id?.name === name;
+    }
+
+    if (statement.type === 'ClassDeclaration') {
+      return statement.id?.name === name;
+    }
+
+    return false;
+  });
+
+const functionReturnExpression = (expr: Node): Expression | null => {
+  const unwrapped = unwrapExpression(expr);
+  if (
+    unwrapped.type !== 'ArrowFunctionExpression' &&
+    unwrapped.type !== 'FunctionExpression'
+  ) {
+    return null;
+  }
+
+  if (unwrapped.async || unwrapped.params.length > 0 || !unwrapped.body) {
+    return null;
+  }
+
+  if (unwrapped.body.type !== 'BlockStatement') {
+    return unwrapped.body as Expression;
+  }
+
+  if (unwrapped.body.body.length !== 1) {
+    return null;
+  }
+
+  const [statement] = unwrapped.body.body;
+  return statement.type === 'ReturnStatement' && statement.argument
+    ? statement.argument
+    : null;
+};
+
+const isReactImport = (
+  imports: Map<string, ImportBinding>,
+  localName: string
+): boolean => imports.get(localName)?.source === 'react';
+
+const isReactFactoryName = (name: string): boolean =>
+  name === 'forwardRef' || name === 'memo';
+
+const isKnownReactFactoryCall = (
+  expr: Node,
+  imports: Map<string, ImportBinding>
+): boolean => {
+  const unwrapped = unwrapExpression(expr);
+  if (unwrapped.type !== 'CallExpression') {
+    return false;
+  }
+
+  const callee = unwrapExpression(unwrapped.callee);
+  if (callee.type === 'Identifier') {
+    return (
+      isReactFactoryName(callee.name) && isReactImport(imports, callee.name)
+    );
+  }
+
+  if (callee.type !== 'MemberExpression' || callee.computed) {
+    return false;
+  }
+
+  const methodName = staticMemberName(callee.property);
+  return (
+    !!methodName &&
+    isReactFactoryName(methodName) &&
+    callee.object.type === 'Identifier' &&
+    isReactImport(imports, callee.object.name)
+  );
+};
+
+const isKnownOpaqueRuntimeImportSource = (source: string): boolean =>
+  /\.svg(?:$|[?#])/.test(source);
+
+type OpaqueRuntimeImportProof = {
+  dependencies: string[];
+  names: Set<string>;
+};
+
+const isStaticMetaObjectExpression = (expr: Node): boolean => {
+  const meta = findObjectPropertyValue(expr, '__wyw_meta');
+  return !!meta && findObjectPropertyValue(meta, 'className') !== null;
+};
+
+const isObjectAssignCallee = (program: Program, expr: Node): boolean => {
+  const unwrapped = unwrapExpression(expr);
+  if (unwrapped.type !== 'MemberExpression' || unwrapped.computed) {
+    return false;
+  }
+
+  const methodName = staticMemberName(unwrapped.property);
+  return (
+    methodName === 'assign' &&
+    unwrapped.object.type === 'Identifier' &&
+    unwrapped.object.name === 'Object' &&
+    !hasTopLevelBinding(program, 'Object')
+  );
+};
+
+const isSafeObjectAssignAliasExpression = (
+  program: Program,
+  expr: Node,
+  seen: Set<string> = new Set()
+): boolean => {
+  const unwrapped = unwrapExpression(expr);
+
+  if (unwrapped.type === 'Identifier') {
+    if (seen.has(unwrapped.name)) {
+      return false;
+    }
+
+    const local = findTopLevelConstExpression(program, unwrapped.name);
+    if (!local) {
+      return false;
+    }
+
+    seen.add(unwrapped.name);
+    const result = isSafeObjectAssignAliasExpression(program, local, seen);
+    seen.delete(unwrapped.name);
+    return result;
+  }
+
+  if (unwrapped.type !== 'ObjectExpression') {
+    return false;
+  }
+
+  return unwrapped.properties.every((property) => {
+    if (property.type === 'SpreadElement') {
+      return false;
+    }
+
+    const propertyNode = property as AnyNode;
+    if (
+      propertyNode.computed ||
+      propertyNode.method ||
+      !propertyNode.value ||
+      typeof propertyNode.value !== 'object'
+    ) {
+      return false;
+    }
+
+    return isSafeStaticExpression(propertyNode.value as Node);
+  });
+};
+
+const objectAssignTargetExpression = (
+  program: Program,
+  expr: Node
+): Expression | null => {
+  const unwrapped = unwrapExpression(expr);
+  if (
+    unwrapped.type !== 'CallExpression' ||
+    !isObjectAssignCallee(program, unwrapped.callee) ||
+    unwrapped.arguments.length < 2
+  ) {
+    return null;
+  }
+
+  const [target, ...aliases] = unwrapped.arguments;
+  if (!target || target.type === 'SpreadElement') {
+    return null;
+  }
+
+  if (
+    aliases.some(
+      (alias) =>
+        alias.type === 'SpreadElement' ||
+        !isSafeObjectAssignAliasExpression(program, alias)
+    )
+  ) {
+    return null;
+  }
+
+  return target;
+};
+
+const resolveObjectAssignProcessorExpression = (
+  program: Program,
+  expr: Expression
+): Expression => {
+  const objectAssignTarget = objectAssignTargetExpression(program, expr);
+  const target = objectAssignTarget ?? expr;
+
+  if (target.type !== 'Identifier') {
+    return target;
+  }
+
+  return findTopLevelConstExpression(program, target.name) ?? target;
+};
+
+const isOpaqueRuntimeComponentExpression = (
+  program: Program,
+  expr: Node,
+  opaqueImportNames: Set<string> = new Set(),
+  seen: Set<string> = new Set()
+): boolean => {
+  const imports = collectImportBindings(program);
+  const unwrapped = unwrapExpression(expr);
+
+  if (isStaticMetaObjectExpression(unwrapped)) {
+    return false;
+  }
+
+  if (
+    unwrapped.type === 'ArrowFunctionExpression' ||
+    unwrapped.type === 'FunctionExpression' ||
+    unwrapped.type === 'ClassExpression'
+  ) {
+    return true;
+  }
+
+  if (isKnownReactFactoryCall(unwrapped, imports)) {
+    return true;
+  }
+
+  if (
+    unwrapped.type === 'CallExpression' &&
+    unwrapped.callee.type === 'Identifier' &&
+    unwrapped.arguments.length === 0
+  ) {
+    const local = findTopLevelConstExpression(program, unwrapped.callee.name);
+    const returned = local ? functionReturnExpression(local) : null;
+    return returned
+      ? isOpaqueRuntimeComponentExpression(
+          program,
+          returned,
+          opaqueImportNames,
+          seen
+        )
+      : false;
+  }
+
+  if (unwrapped.type !== 'Identifier') {
+    return false;
+  }
+
+  const { name } = unwrapped;
+  if (seen.has(name)) {
+    return false;
+  }
+  seen.add(name);
+
+  const imported = imports.get(name);
+  if (imported) {
+    return (
+      opaqueImportNames.has(name) ||
+      isKnownOpaqueRuntimeImportSource(imported.source)
+    );
+  }
+
+  if (isTopLevelFunctionOrClass(program, name)) {
+    return true;
+  }
+
+  const local = findTopLevelConstExpression(program, name);
+  return local
+    ? isOpaqueRuntimeComponentExpression(
+        program,
+        local,
+        opaqueImportNames,
+        seen
+      )
+    : false;
+};
+
+const collectOpaqueRuntimeReferenceNames = (
+  program: Program,
+  expr: Node,
+  names: Set<string>,
+  seenHelpers: Set<string> = new Set()
+): void => {
+  const unwrapped = unwrapExpression(expr);
+
+  if (
+    unwrapped.type === 'CallExpression' &&
+    unwrapped.callee.type === 'Identifier' &&
+    unwrapped.arguments.length === 0
+  ) {
+    if (seenHelpers.has(unwrapped.callee.name)) {
+      return;
+    }
+
+    const local = findTopLevelConstExpression(program, unwrapped.callee.name);
+    const returned = local ? functionReturnExpression(local) : null;
+    if (returned) {
+      seenHelpers.add(unwrapped.callee.name);
+      collectOpaqueRuntimeReferenceNames(program, returned, names, seenHelpers);
+      seenHelpers.delete(unwrapped.callee.name);
+      return;
+    }
+  }
+
+  if (unwrapped.type === 'Identifier') {
+    names.add(unwrapped.name);
+    return;
+  }
+
+  getChildren(unwrapped).forEach((child) =>
+    collectOpaqueRuntimeReferenceNames(program, child, names, seenHelpers)
+  );
+};
+
+const collectWYWMetaExtendsHelperNames = (program: Program): Set<string> => {
+  const result = new Set<string>();
+
+  const visit = (node: Node): void => {
+    if (node.type === 'ObjectExpression') {
+      const extendsExpression = findWYWMetaExtendsExpression(node);
+      const unwrapped = extendsExpression
+        ? unwrapExpression(extendsExpression)
+        : null;
+      if (
+        unwrapped?.type === 'CallExpression' &&
+        unwrapped.callee.type === 'Identifier' &&
+        unwrapped.arguments.length === 0
+      ) {
+        result.add(unwrapped.callee.name);
+      }
+    }
+
+    getChildren(node).forEach(visit);
+  };
+
+  visit(program);
+  return result;
+};
+
+const replaceExpressionChild = (
+  code: string,
+  expression: Expression,
+  child: Expression,
+  replacement: string
+): string => {
+  const expressionCode = code.slice(expression.start, expression.end);
+  return (
+    expressionCode.slice(0, child.start - expression.start) +
+    replacement +
+    expressionCode.slice(child.end - expression.start)
+  );
+};
+
+const prepareProcessorTarget = (
+  code: string,
+  program: Program,
+  target: Extract<ExportTarget, { kind: 'expression' }>,
+  opaqueImportNames: Set<string> = new Set()
+): PreparedProcessorTarget | null => {
+  const expression = resolveObjectAssignProcessorExpression(
+    program,
+    target.expression
+  );
+  const extendsExpression = findWYWMetaExtendsExpression(expression);
+  if (
+    extendsExpression &&
+    isOpaqueRuntimeComponentExpression(
+      program,
+      extendsExpression,
+      opaqueImportNames
+    )
+  ) {
+    return {
+      dependencies: { imports: [] },
+      expression,
+      expressionCode: replaceExpressionChild(
+        code,
+        expression,
+        extendsExpression,
+        'null'
+      ),
+      opaqueRuntimeBase: true,
+    };
+  }
+
+  const dependencies = collectStaticExpressionDependencies(
+    program,
+    {
+      ...target,
+      expression,
+    },
+    {
+      allowMetadataCalls: true,
+    }
+  );
+  return dependencies
+    ? {
+        dependencies,
+        expression,
+        opaqueRuntimeBase: false,
+      }
+    : null;
+};
+
 const collectStaticExpressionDependencies = (
   program: Program,
   target: Extract<ExportTarget, { kind: 'expression' }>,
@@ -1597,6 +2306,14 @@ function* resolveImportValue(
     binding.imported
   );
   if (!dependency?.resolved) {
+    debugStaticResolve(action, {
+      filename: importer,
+      imported: binding.imported,
+      phase: 'import',
+      reason: 'dependency-unresolved',
+      source: binding.source,
+      status: 'rejected',
+    });
     return null;
   }
 
@@ -1608,8 +2325,26 @@ function* resolveImportValue(
     memo
   );
   if (!resolved) {
+    debugStaticResolve(action, {
+      dependency: dependency.resolved,
+      filename: importer,
+      imported: binding.imported,
+      phase: 'import',
+      reason: 'resolve-failed',
+      source: binding.source,
+      status: 'rejected',
+    });
     return null;
   }
+
+  debugStaticResolve(action, {
+    dependency: dependency.resolved,
+    filename: importer,
+    imported: binding.imported,
+    phase: 'import',
+    source: binding.source,
+    status: 'resolved',
+  });
 
   return {
     dependencies: [
@@ -1620,125 +2355,13 @@ function* resolveImportValue(
   };
 }
 
-function* resolveProcessorStaticExport(
-  action: ITransformAction,
-  filename: string,
-  code: string,
-  program: Program,
-  exportedName: string,
-  stack: Set<string>,
-  memo: Map<string, StaticExportResult | null>
-): SyncScenarioFor<StaticExportResult | null> {
-  const root = action.services.options.root ?? process.cwd();
-  if (!isInsideRoot(filename, root)) {
-    return null;
-  }
-
-  if (
-    collectProcessorImportLocals(action, program, code, filename).size === 0
-  ) {
-    return null;
-  }
-
-  let preevalResult: ReturnType<typeof runOxcPreevalStage>;
-  try {
-    preevalResult = action.services.eventEmitter.perf(
-      'transform:preeval:staticMetadata',
-      () =>
-        runOxcPreevalStage(
-          code,
-          {
-            filename,
-            root,
-          },
-          {
-            ...action.services.options.pluginOptions,
-            eventEmitter: action.services.eventEmitter,
-          }
-        )
-    );
-  } catch {
-    return null;
-  }
-
-  if (!preevalResult.metadata) {
-    return null;
-  }
-
-  const preevalCode = preevalResult.baseCode;
-  const preevalProgram = parseProgram(preevalCode, filename);
-  const target = findExportTarget(preevalProgram, exportedName);
-  if (!target || target.kind === 'import') {
-    return null;
-  }
-
-  const staticDependencies = collectStaticExpressionDependencies(
-    preevalProgram,
-    target,
-    {
-      allowMetadataCalls: true,
-    }
-  );
-  if (!staticDependencies) {
-    return null;
-  }
-
-  const env = new Map<string, unknown>();
-  const dependencies = new Set<string>([filename]);
-
-  for (const binding of staticDependencies.imports) {
-    const resolved = yield* resolveImportValue(
-      action,
-      filename,
-      binding,
-      stack,
-      memo
-    );
-    if (!resolved) {
-      return null;
-    }
-
-    env.set(binding.local, createOxcStaticCallableValue(resolved.value));
-    resolved.dependencies.forEach((dependency) => dependencies.add(dependency));
-  }
-
-  const value = evaluateOxcStaticExpressionAt(
-    preevalCode,
-    filename,
-    {
-      end: target.expression.end,
-      start: target.expression.start,
-    },
-    env
-  );
-  if (!isOxcStaticSerializableValue(value)) {
-    return null;
-  }
-
-  if (
-    !isStaticWYWMetaValue(value) &&
-    !isSelectorOnlyProcessorValue(
-      value,
-      preevalResult.metadata.processors as unknown as StaticProcessorInstance[],
-      new Map()
-    )
-  ) {
-    return null;
-  }
-
-  return {
-    dependencies: [...dependencies],
-    value,
-  };
-}
-
-function* resolveStaticExport(
+function* resolveExportAsOpaqueRuntimeImport(
   action: ITransformAction,
   filename: string,
   exportedName: string,
   stack: Set<string>,
-  memo: Map<string, StaticExportResult | null>
-): SyncScenarioFor<StaticExportResult | null> {
+  memo: Map<string, OpaqueRuntimeImportProof | null>
+): SyncScenarioFor<OpaqueRuntimeImportProof | null> {
   const memoKey = `${filename}\0${exportedName}`;
   if (memo.has(memoKey)) {
     return memo.get(memoKey) ?? null;
@@ -1766,12 +2389,508 @@ function* resolveStaticExport(
     return null;
   }
 
+  const program = parseProgram(loadedAndParsed.code, filename);
+  const target = findExportTarget(program, exportedName);
+  if (!target || target.kind !== 'import') {
+    memo.set(memoKey, null);
+    stack.delete(memoKey);
+    return null;
+  }
+
+  const resolved = yield* resolveImportAsOpaqueRuntime(
+    action,
+    filename,
+    target,
+    stack,
+    memo
+  );
+  memo.set(memoKey, resolved);
+  stack.delete(memoKey);
+  return resolved;
+}
+
+const knownOpaqueRuntimeSourceDependency = (
+  importer: string,
+  source: string
+): string | null => {
+  if (!isKnownOpaqueRuntimeImportSource(source)) {
+    return null;
+  }
+
+  const request = stripQueryAndHash(source);
+  if (isAbsolute(request)) {
+    return request;
+  }
+
+  return request.startsWith('.')
+    ? resolvePath(dirname(importer), request)
+    : null;
+};
+
+function* resolveImportAsOpaqueRuntime(
+  action: ITransformAction,
+  importer: string,
+  binding: Pick<ImportBinding, 'imported' | 'source'>,
+  stack: Set<string>,
+  memo: Map<string, OpaqueRuntimeImportProof | null>
+): SyncScenarioFor<OpaqueRuntimeImportProof | null> {
+  const knownSourceDependency = knownOpaqueRuntimeSourceDependency(
+    importer,
+    binding.source
+  );
+  if (knownSourceDependency) {
+    return {
+      dependencies: [knownSourceDependency],
+      names: new Set(),
+    };
+  }
+
+  const dependency = yield* resolveDependency(
+    action,
+    importer,
+    binding.source,
+    binding.imported
+  );
+  if (!dependency?.resolved) {
+    return null;
+  }
+
+  if (
+    isKnownOpaqueRuntimeImportSource(binding.source) ||
+    isKnownOpaqueRuntimeImportSource(dependency.resolved)
+  ) {
+    return {
+      dependencies: [dependency.resolved],
+      names: new Set(),
+    };
+  }
+
+  const resolved = yield* resolveExportAsOpaqueRuntimeImport(
+    action,
+    dependency.resolved,
+    binding.imported,
+    stack,
+    memo
+  );
+  return resolved
+    ? {
+        dependencies: [
+          dependency.resolved,
+          ...resolved.dependencies.filter(
+            (item) => item !== dependency.resolved
+          ),
+        ],
+        names: resolved.names,
+      }
+    : null;
+}
+
+function* collectOpaqueRuntimeImportProof(
+  action: ITransformAction,
+  filename: string,
+  program: Program,
+  expression: Expression
+): SyncScenarioFor<OpaqueRuntimeImportProof> {
+  const extendsExpression = findWYWMetaExtendsExpression(expression);
+  if (!extendsExpression) {
+    return {
+      dependencies: [],
+      names: new Set(),
+    };
+  }
+
+  const imports = collectImportBindings(program);
+  const referencedNames = new Set<string>();
+  collectOpaqueRuntimeReferenceNames(
+    program,
+    extendsExpression,
+    referencedNames
+  );
+
+  const dependencies = new Set<string>();
+  const names = new Set<string>();
+  const memo = new Map<string, OpaqueRuntimeImportProof | null>();
+
+  for (const name of referencedNames) {
+    const binding = imports.get(name);
+    if (!binding || binding.source === 'react') {
+      continue;
+    }
+
+    const proof = yield* resolveImportAsOpaqueRuntime(
+      action,
+      filename,
+      binding,
+      new Set(),
+      memo
+    );
+    if (!proof) {
+      continue;
+    }
+
+    names.add(name);
+    proof.dependencies.forEach((dependency) => dependencies.add(dependency));
+  }
+
+  return {
+    dependencies: [...dependencies],
+    names,
+  };
+}
+
+function* resolveProcessorStaticExport(
+  action: ITransformAction,
+  filename: string,
+  code: string,
+  program: Program,
+  exportedName: string,
+  stack: Set<string>,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<StaticExportResult | null> {
+  const root = action.services.options.root ?? process.cwd();
+  if (!isLocalStaticMetadataFile(filename, root)) {
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'processor-metadata',
+      reason: 'outside-root',
+      status: 'rejected',
+    });
+    return null;
+  }
+
+  if (
+    collectProcessorImportLocals(action, program, code, filename).size === 0
+  ) {
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'processor-metadata',
+      reason: 'no-processor-imports',
+      status: 'rejected',
+    });
+    return null;
+  }
+
+  let preevalResult: ReturnType<typeof runOxcPreevalStage>;
+  try {
+    preevalResult = action.services.eventEmitter.perf(
+      'transform:preeval:staticMetadata',
+      () =>
+        runOxcPreevalStage(
+          code,
+          {
+            filename,
+            root,
+          },
+          {
+            ...action.services.options.pluginOptions,
+            eventEmitter: action.services.eventEmitter,
+          }
+        )
+    );
+  } catch {
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'processor-metadata',
+      reason: 'metadata-preeval-failed',
+      status: 'rejected',
+    });
+    return null;
+  }
+
+  if (!preevalResult.metadata) {
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'processor-metadata',
+      reason: 'metadata-missing',
+      status: 'rejected',
+    });
+    return null;
+  }
+
+  const preevalCode = preevalResult.baseCode;
+  const preevalProgram = parseProgram(preevalCode, filename);
+  const target = findExportTarget(preevalProgram, exportedName);
+  if (!target || target.kind === 'import') {
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'processor-metadata',
+      reason: 'processor-target-missing',
+      status: 'rejected',
+    });
+    return null;
+  }
+
+  const processorExpression = resolveObjectAssignProcessorExpression(
+    preevalProgram,
+    target.expression
+  );
+  const opaqueRuntimeImportProof = yield* collectOpaqueRuntimeImportProof(
+    action,
+    filename,
+    preevalProgram,
+    processorExpression
+  );
+  const preparedTarget = prepareProcessorTarget(
+    preevalCode,
+    preevalProgram,
+    target,
+    opaqueRuntimeImportProof.names
+  );
+  if (!preparedTarget) {
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'processor-metadata',
+      reason: 'unsupported-processor-expression',
+      status: 'rejected',
+    });
+    return null;
+  }
+
+  const env = new Map<string, unknown>();
+  const dependencies = new Set<string>([filename]);
+  opaqueRuntimeImportProof.dependencies.forEach((dependency) =>
+    dependencies.add(dependency)
+  );
+
+  for (const binding of preparedTarget.dependencies.imports) {
+    const resolved = yield* resolveImportValue(
+      action,
+      filename,
+      binding,
+      stack,
+      memo
+    );
+    if (!resolved) {
+      debugStaticResolve(action, {
+        exported: exportedName,
+        filename,
+        imported: binding.imported,
+        phase: 'processor-metadata',
+        reason: 'resolve-failed',
+        source: binding.source,
+        status: 'rejected',
+      });
+      return null;
+    }
+
+    env.set(binding.local, createOxcStaticCallableValue(resolved.value));
+    resolved.dependencies.forEach((dependency) => dependencies.add(dependency));
+  }
+
+  const value = preparedTarget.expressionCode
+    ? evaluateOxcStaticExpression(preparedTarget.expressionCode, filename, env)
+    : evaluateOxcStaticExpressionAt(
+        preevalCode,
+        filename,
+        {
+          end: preparedTarget.expression.end,
+          start: preparedTarget.expression.start,
+        },
+        env
+      );
+  if (!isOxcStaticSerializableValue(value)) {
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'processor-metadata',
+      reason: 'non-serializable',
+      status: 'rejected',
+    });
+    return null;
+  }
+
+  if (
+    !isStaticWYWMetaValue(value) &&
+    !isSelectorOnlyProcessorValue(
+      value,
+      preevalResult.metadata.processors as unknown as StaticProcessorInstance[],
+      new Map()
+    )
+  ) {
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'processor-metadata',
+      reason: 'non-empty-css-artifact',
+      status: 'rejected',
+    });
+    return null;
+  }
+
+  debugStaticResolve(action, {
+    exported: exportedName,
+    filename,
+    phase: 'processor-metadata',
+    reason: preparedTarget.opaqueRuntimeBase
+      ? 'opaque-runtime-component'
+      : undefined,
+    status: 'resolved',
+  });
+
+  return {
+    dependencies: [...dependencies],
+    value,
+  };
+}
+
+function* resolveObjectAssignStaticExport(
+  action: ITransformAction,
+  filename: string,
+  code: string,
+  program: Program,
+  target: Extract<ExportTarget, { kind: 'expression' }>,
+  stack: Set<string>,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<StaticExportResult | null> {
+  const objectAssignTarget = objectAssignTargetExpression(
+    program,
+    target.expression
+  );
+  if (!objectAssignTarget) {
+    return null;
+  }
+
+  const imports = collectImportBindings(program);
+  if (objectAssignTarget.type === 'Identifier') {
+    const importBinding = imports.get(objectAssignTarget.name);
+    if (importBinding) {
+      const resolved = yield* resolveImportValue(
+        action,
+        filename,
+        importBinding,
+        stack,
+        memo
+      );
+      if (!resolved || !isStaticWYWMetaValue(resolved.value)) {
+        return null;
+      }
+
+      return {
+        dependencies: [
+          filename,
+          ...resolved.dependencies.filter((item) => item !== filename),
+        ],
+        value: resolved.value,
+      };
+    }
+  }
+
+  const expression =
+    objectAssignTarget.type === 'Identifier'
+      ? findTopLevelConstExpression(program, objectAssignTarget.name) ??
+        objectAssignTarget
+      : objectAssignTarget;
+  const staticDependencies = collectStaticExpressionDependencies(program, {
+    ...target,
+    expression,
+  });
+  if (!staticDependencies) {
+    return null;
+  }
+
+  const env = new Map<string, unknown>();
+  const dependencies = new Set<string>([filename]);
+
+  for (const binding of staticDependencies.imports) {
+    const resolved = yield* resolveImportValue(
+      action,
+      filename,
+      binding,
+      stack,
+      memo
+    );
+    if (!resolved) {
+      return null;
+    }
+
+    env.set(binding.local, resolved.value);
+    resolved.dependencies.forEach((item) => dependencies.add(item));
+  }
+
+  const value = evaluateOxcStaticExpressionAt(
+    code,
+    filename,
+    {
+      end: expression.end,
+      start: expression.start,
+    },
+    env
+  );
+  return isStaticWYWMetaValue(value)
+    ? {
+        dependencies: [...dependencies],
+        value,
+      }
+    : null;
+}
+
+function* resolveStaticExport(
+  action: ITransformAction,
+  filename: string,
+  exportedName: string,
+  stack: Set<string>,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<StaticExportResult | null> {
+  const memoKey = `${filename}\0${exportedName}`;
+  if (memo.has(memoKey)) {
+    return memo.get(memoKey) ?? null;
+  }
+
+  if (stack.has(memoKey)) {
+    memo.set(memoKey, null);
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'export',
+      reason: 'cyclic-export',
+      status: 'rejected',
+    });
+    return null;
+  }
+
+  stack.add(memoKey);
+
+  const loadedAndParsed = action.services.loadAndParseFn(
+    action.services,
+    filename,
+    undefined,
+    action.services.log
+  );
+  if (
+    loadedAndParsed.evaluator === 'ignored' ||
+    loadedAndParsed.evaluator !== oxcShaker
+  ) {
+    memo.set(memoKey, null);
+    stack.delete(memoKey);
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'export',
+      reason: 'ignored-or-non-oxc',
+      status: 'rejected',
+    });
+    return null;
+  }
+
   const { code } = loadedAndParsed;
   const program = parseProgram(code, filename);
   const target = findExportTarget(program, exportedName);
   if (!target) {
     memo.set(memoKey, null);
     stack.delete(memoKey);
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'export',
+      reason: 'no-export-target',
+      status: 'rejected',
+    });
     return null;
   }
 
@@ -1785,7 +2904,38 @@ function* resolveStaticExport(
     );
     memo.set(memoKey, resolved);
     stack.delete(memoKey);
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      imported: target.imported,
+      phase: 'export',
+      reason: resolved ? undefined : 'resolve-failed',
+      source: target.source,
+      status: resolved ? 'resolved' : 'rejected',
+    });
     return resolved;
+  }
+
+  const objectAssignResult = yield* resolveObjectAssignStaticExport(
+    action,
+    filename,
+    code,
+    program,
+    target,
+    stack,
+    memo
+  );
+  if (objectAssignResult) {
+    memo.set(memoKey, objectAssignResult);
+    stack.delete(memoKey);
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'export',
+      reason: 'object-assign',
+      status: 'resolved',
+    });
+    return objectAssignResult;
   }
 
   const staticDependencies = collectStaticExpressionDependencies(
@@ -1793,6 +2943,13 @@ function* resolveStaticExport(
     target
   );
   if (!staticDependencies) {
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'export',
+      reason: 'unsupported-expression',
+      status: 'rejected',
+    });
     const metadataResult = yield* resolveProcessorStaticExport(
       action,
       filename,
@@ -1804,6 +2961,13 @@ function* resolveStaticExport(
     );
     memo.set(memoKey, metadataResult);
     stack.delete(memoKey);
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'export',
+      reason: metadataResult ? undefined : 'resolve-failed',
+      status: metadataResult ? 'resolved' : 'rejected',
+    });
     return metadataResult;
   }
 
@@ -1821,6 +2985,15 @@ function* resolveStaticExport(
     if (!resolved) {
       memo.set(memoKey, null);
       stack.delete(memoKey);
+      debugStaticResolve(action, {
+        exported: exportedName,
+        filename,
+        imported: binding.imported,
+        phase: 'export',
+        reason: 'resolve-failed',
+        source: binding.source,
+        status: 'rejected',
+      });
       return null;
     }
 
@@ -1840,6 +3013,13 @@ function* resolveStaticExport(
   if (!isOxcStaticSerializableValue(value)) {
     memo.set(memoKey, null);
     stack.delete(memoKey);
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'export',
+      reason: 'non-serializable',
+      status: 'rejected',
+    });
     return null;
   }
 
@@ -1849,6 +3029,12 @@ function* resolveStaticExport(
   };
   memo.set(memoKey, result);
   stack.delete(memoKey);
+  debugStaticResolve(action, {
+    exported: exportedName,
+    filename,
+    phase: 'export',
+    status: 'resolved',
+  });
   return result;
 }
 
@@ -1870,6 +3056,15 @@ function* resolveCandidateValue(
       memo
     );
     if (!resolved) {
+      debugStaticResolve(action, {
+        candidate: candidate.name,
+        filename,
+        imported: item.imported,
+        phase: 'candidate',
+        reason: 'candidate-import-unresolved',
+        source: item.source,
+        status: 'rejected',
+      });
       return null;
     }
 
@@ -1879,12 +3074,59 @@ function* resolveCandidateValue(
 
   const value = evaluateOxcStaticExpression(candidate.source, filename, env);
   if (!isOxcStaticSerializableValue(value)) {
+    debugStaticResolve(action, {
+      candidate: candidate.name,
+      filename,
+      phase: 'candidate',
+      reason: 'candidate-expression-non-serializable',
+      status: 'rejected',
+    });
     return null;
   }
+
+  debugStaticResolve(action, {
+    candidate: candidate.name,
+    filename,
+    phase: 'candidate',
+    status: 'resolved',
+  });
 
   return {
     dependencies: [...dependencies],
     value,
+  };
+}
+
+function* resolveOpaqueRuntimeCandidateValue(
+  action: ITransformAction,
+  candidate: OxcStaticValueCandidate,
+  filename: string
+): SyncScenarioFor<StaticExportResult | null> {
+  if (candidate.imports.length === 0) {
+    return null;
+  }
+
+  const dependencies = new Set<string>();
+  const memo = new Map<string, OpaqueRuntimeImportProof | null>();
+
+  for (const item of candidate.imports) {
+    const proof = yield* resolveImportAsOpaqueRuntime(
+      action,
+      filename,
+      item,
+      new Set(),
+      memo
+    );
+    if (!proof) {
+      return null;
+    }
+
+    proof.dependencies.forEach((dependency) => dependencies.add(dependency));
+  }
+
+  return {
+    dependencies: [...dependencies],
+    value: null,
   };
 }
 
@@ -1903,6 +3145,12 @@ export function* resolveStaticOxcPreevalValues(
       : this.entrypoint.loadedAndParsed.evalConfig.filename ??
         this.entrypoint.name;
   if (!isStaticImportValuesEnabled(this, filename)) {
+    debugStaticResolve(this, {
+      filename,
+      phase: 'entrypoint',
+      reason: 'feature-disabled',
+      status: 'skipped',
+    });
     return false;
   }
 
@@ -1910,25 +3158,78 @@ export function* resolveStaticOxcPreevalValues(
     preevalResult.staticValueCache ?? new Map<string, unknown>();
   const staticDependencies = new Set(preevalResult.staticDependencies ?? []);
   const staticImportLocals = new Set<string>();
+  const staticNullWYWMetaExtendsHelpers = new Set(
+    preevalResult.staticNullWYWMetaExtendsHelpers ?? []
+  );
   const memo = new Map<string, StaticExportResult | null>();
+  const opaqueRuntimeBaseHelpers = collectWYWMetaExtendsHelperNames(
+    parseProgram(preevalResult.baseCode ?? preevalResult.code, filename)
+  );
   let changed = false;
+  let hasKnownStaticCandidate = false;
 
   for (const candidate of candidates) {
+    const isOpaqueRuntimeBaseHelper = opaqueRuntimeBaseHelpers.has(
+      candidate.name
+    );
     if (staticValueCache.has(candidate.name)) {
+      hasKnownStaticCandidate = true;
+      candidate.imports.forEach((item) =>
+        staticImportLocals.add(item.importLocal ?? item.local)
+      );
+      if (
+        isOpaqueRuntimeBaseHelper &&
+        staticValueCache.get(candidate.name) === null
+      ) {
+        staticNullWYWMetaExtendsHelpers.add(candidate.name);
+      }
+      debugStaticResolve(this, {
+        candidate: candidate.name,
+        filename,
+        phase: 'candidate',
+        reason: 'already-static',
+        status: 'skipped',
+      });
       continue;
     }
 
-    const resolved = yield* resolveCandidateValue(
-      this,
-      candidate,
-      filename,
-      memo
-    );
+    let resolved: StaticExportResult | null;
+    let resolvedOpaqueRuntimeBase = false;
+    if (isOpaqueRuntimeBaseHelper) {
+      resolved = yield* resolveOpaqueRuntimeCandidateValue(
+        this,
+        candidate,
+        filename
+      );
+      resolvedOpaqueRuntimeBase = !!resolved;
+      if (!resolved) {
+        resolved = yield* resolveCandidateValue(
+          this,
+          candidate,
+          filename,
+          memo
+        );
+      }
+    } else {
+      resolved = yield* resolveCandidateValue(this, candidate, filename, memo);
+    }
     if (!resolved) {
       continue;
     }
 
+    if (resolvedOpaqueRuntimeBase) {
+      debugStaticResolve(this, {
+        candidate: candidate.name,
+        filename,
+        phase: 'candidate',
+        reason: 'opaque-runtime-component',
+        status: 'resolved',
+      });
+      staticNullWYWMetaExtendsHelpers.add(candidate.name);
+    }
+
     staticValueCache.set(candidate.name, resolved.value);
+    hasKnownStaticCandidate = true;
     candidate.imports.forEach((item) =>
       staticImportLocals.add(item.importLocal ?? item.local)
     );
@@ -1938,7 +3239,7 @@ export function* resolveStaticOxcPreevalValues(
     changed = true;
   }
 
-  if (!changed) {
+  if (!changed && !hasKnownStaticCandidate) {
     return false;
   }
 
@@ -1948,11 +3249,15 @@ export function* resolveStaticOxcPreevalValues(
   preevalResult.dependencyNames = dependencyNames;
   preevalResult.staticValueCache = staticValueCache;
   preevalResult.staticDependencies = [...staticDependencies];
+  preevalResult.staticNullWYWMetaExtendsHelpers = [
+    ...staticNullWYWMetaExtendsHelpers,
+  ];
   const baseCode = pruneStaticPreevalCode(
     preevalResult.baseCode ?? preevalResult.code,
     filename,
     new Set(staticValueCache.keys()),
-    staticImportLocals
+    staticImportLocals,
+    staticNullWYWMetaExtendsHelpers
   );
   preevalResult.baseCode = baseCode;
   preevalResult.code = appendOxcWywPreval(baseCode, filename, dependencyNames);

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -1297,6 +1297,17 @@ type StaticProcessorInstance = {
   className: string;
 };
 
+const isPlainObjectRecord = (
+  value: unknown
+): value is Record<string, unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  Object.getPrototypeOf(value) === Object.prototype;
+
+const isStaticObjectAssignAliasValue = (value: unknown): boolean =>
+  isStaticWYWMetaValue(value) || isStaticWYWMetaTreeValue(value);
+
 const artifactCssText = (artifact: unknown): string | null => {
   if (!Array.isArray(artifact) || artifact[0] !== 'css') {
     return null;
@@ -2426,6 +2437,33 @@ const objectAssignTargetExpression = (
   return target;
 };
 
+const objectAssignAliasExpressions = (
+  program: Program,
+  expr: Node
+): Expression[] | null => {
+  const unwrapped = unwrapExpression(expr);
+  if (
+    unwrapped.type !== 'CallExpression' ||
+    !isObjectAssignCallee(program, unwrapped.callee) ||
+    unwrapped.arguments.length < 2
+  ) {
+    return null;
+  }
+
+  const [, ...aliases] = unwrapped.arguments;
+  if (
+    aliases.some(
+      (alias) =>
+        alias.type === 'SpreadElement' ||
+        !isSafeObjectAssignAliasExpression(program, alias)
+    )
+  ) {
+    return null;
+  }
+
+  return aliases as Expression[];
+};
+
 const isFunctionBoundaryNode = (node: Node): boolean =>
   node.type === 'ArrowFunctionExpression' ||
   node.type === 'FunctionDeclaration' ||
@@ -2525,6 +2563,112 @@ const resolveObjectAssignProcessorExpression = (
 
   return findTopLevelConstExpression(program, target.name) ?? target;
 };
+
+type ObjectAssignAliasResolution = {
+  dependencies: string[];
+  sideEffectDependencies: string[];
+  values: Record<string, unknown>[];
+};
+
+const mergeStaticObjectAssignAliases = (
+  targetValue: unknown,
+  aliasValues: Record<string, unknown>[]
+): unknown | null => {
+  if (!isPlainObjectRecord(targetValue) || !isStaticWYWMetaValue(targetValue)) {
+    return null;
+  }
+
+  const result: Record<string, unknown> = { ...targetValue };
+  aliasValues.forEach((aliasValue) => {
+    Object.assign(result, aliasValue);
+  });
+
+  return result;
+};
+
+function* resolveObjectAssignAliasValues(
+  action: ITransformAction,
+  filename: string,
+  code: string,
+  program: Program,
+  aliases: Expression[],
+  stack: Set<string>,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<ObjectAssignAliasResolution | null> {
+  const env = new Map<string, unknown>();
+  const dependencies = new Set<string>();
+  const sideEffectDependencies = new Set<string>();
+  const values: Record<string, unknown>[] = [];
+  const ignoredMutableCallArgumentNames = new Set<string>();
+  aliases.forEach((alias) => {
+    const name = rootIdentifierName(alias);
+    if (name) {
+      ignoredMutableCallArgumentNames.add(name);
+    }
+  });
+
+  for (const alias of aliases) {
+    const staticDependencies = collectStaticExpressionDependencies(
+      program,
+      {
+        expression: alias,
+        kind: 'expression',
+      },
+      {
+        allowMetadataCalls: true,
+        ignoredMutableCallArgumentNames,
+      }
+    );
+    if (!staticDependencies) {
+      return null;
+    }
+
+    for (const binding of staticDependencies.imports) {
+      const resolved = yield* resolveImportValue(
+        action,
+        filename,
+        binding,
+        stack,
+        memo
+      );
+      if (
+        !resolved ||
+        !bindStaticResolvedValue(env, alias, binding.local, resolved)
+      ) {
+        return null;
+      }
+
+      resolved.dependencies.forEach((item) => dependencies.add(item));
+      resolved.sideEffectDependencies?.forEach((item) =>
+        sideEffectDependencies.add(item)
+      );
+    }
+
+    const value = evaluateOxcStaticExpressionAt(
+      code,
+      filename,
+      {
+        end: alias.end,
+        start: alias.start,
+      },
+      env
+    );
+    if (
+      !isPlainObjectRecord(value) ||
+      !Object.values(value).every(isStaticObjectAssignAliasValue)
+    ) {
+      return null;
+    }
+
+    values.push(value);
+  }
+
+  return {
+    dependencies: [...dependencies],
+    sideEffectDependencies: [...sideEffectDependencies],
+    values,
+  };
+}
 
 const isOpaqueRuntimeComponentExpression = (
   program: Program,
@@ -3483,6 +3627,10 @@ function* resolveProcessorStaticExport(
     return null;
   }
 
+  const processorObjectAssignAliases = objectAssignAliasExpressions(
+    preevalProgram,
+    target.expression
+  );
   const processorExpression = resolveObjectAssignProcessorExpression(
     preevalProgram,
     target.expression
@@ -3596,19 +3744,46 @@ function* resolveProcessorStaticExport(
     return null;
   }
 
-  const isStaticMeta = isStaticWYWMetaValue(value);
-  const isStaticMetaTree = !isStaticMeta && isStaticWYWMetaTreeValue(value);
+  let resolvedValue = value;
+  if (processorObjectAssignAliases && isStaticWYWMetaValue(value)) {
+    const aliasValues = yield* resolveObjectAssignAliasValues(
+      action,
+      filename,
+      preevalCode,
+      preevalProgram,
+      processorObjectAssignAliases,
+      stack,
+      memo
+    );
+    const mergedValue = aliasValues
+      ? mergeStaticObjectAssignAliases(value, aliasValues.values)
+      : null;
+
+    if (mergedValue) {
+      resolvedValue = mergedValue;
+      aliasValues?.dependencies.forEach((dependency) =>
+        dependencies.add(dependency)
+      );
+      aliasValues?.sideEffectDependencies.forEach((dependency) =>
+        sideEffectDependencies.add(dependency)
+      );
+    }
+  }
+
+  const isStaticMeta = isStaticWYWMetaValue(resolvedValue);
+  const isStaticMetaTree =
+    !isStaticMeta && isStaticWYWMetaTreeValue(resolvedValue);
   const processors = preevalResult.metadata
     .processors as unknown as StaticProcessorInstance[];
   const isSelectorOnly =
     !isStaticMeta &&
     !isStaticMetaTree &&
-    isSelectorOnlyProcessorValue(value, processors, new Map());
+    isSelectorOnlyProcessorValue(resolvedValue, processors, new Map());
   const isSideEffectClassValue =
     !isStaticMeta &&
     !isStaticMetaTree &&
     !isSelectorOnly &&
-    isProcessorClassValue(value, processors, new Map());
+    isProcessorClassValue(resolvedValue, processors, new Map());
   if (
     !isStaticMeta &&
     !isStaticMetaTree &&
@@ -3645,7 +3820,7 @@ function* resolveProcessorStaticExport(
     sideEffectDependencies: isSideEffectClassValue
       ? [filename, ...sideEffectDependencies]
       : [...sideEffectDependencies],
-    value,
+    value: resolvedValue,
   };
 }
 
@@ -3658,6 +3833,10 @@ function* resolveObjectAssignStaticExport(
   stack: Set<string>,
   memo: Map<string, StaticExportResult | null>
 ): SyncScenarioFor<StaticExportResult | null> {
+  const objectAssignAliases = objectAssignAliasExpressions(
+    program,
+    target.expression
+  );
   const objectAssignTarget = objectAssignTargetExpression(
     program,
     target.expression
@@ -3681,13 +3860,36 @@ function* resolveObjectAssignStaticExport(
         return null;
       }
 
+      const dependencies = new Set([
+        filename,
+        ...resolved.dependencies.filter((item) => item !== filename),
+      ]);
+      const sideEffectDependencies = new Set(
+        resolved.sideEffectDependencies ?? []
+      );
+      const aliasValues = objectAssignAliases
+        ? yield* resolveObjectAssignAliasValues(
+            action,
+            filename,
+            code,
+            program,
+            objectAssignAliases,
+            stack,
+            memo
+          )
+        : null;
+      const mergedValue = aliasValues
+        ? mergeStaticObjectAssignAliases(resolved.value, aliasValues.values)
+        : null;
+      aliasValues?.dependencies.forEach((item) => dependencies.add(item));
+      aliasValues?.sideEffectDependencies.forEach((item) =>
+        sideEffectDependencies.add(item)
+      );
+
       return {
-        dependencies: [
-          filename,
-          ...resolved.dependencies.filter((item) => item !== filename),
-        ],
-        sideEffectDependencies: resolved.sideEffectDependencies,
-        value: resolved.value,
+        dependencies: [...dependencies],
+        sideEffectDependencies: [...sideEffectDependencies],
+        value: mergedValue ?? resolved.value,
       };
     }
   }
@@ -3740,13 +3942,34 @@ function* resolveObjectAssignStaticExport(
     },
     env
   );
-  return isStaticWYWMetaValue(value)
-    ? {
-        dependencies: [...dependencies],
-        sideEffectDependencies: [...sideEffectDependencies],
-        value,
-      }
+  if (!isStaticWYWMetaValue(value)) {
+    return null;
+  }
+
+  const aliasValues = objectAssignAliases
+    ? yield* resolveObjectAssignAliasValues(
+        action,
+        filename,
+        code,
+        program,
+        objectAssignAliases,
+        stack,
+        memo
+      )
     : null;
+  const mergedValue = aliasValues
+    ? mergeStaticObjectAssignAliases(value, aliasValues.values)
+    : null;
+  aliasValues?.dependencies.forEach((item) => dependencies.add(item));
+  aliasValues?.sideEffectDependencies.forEach((item) =>
+    sideEffectDependencies.add(item)
+  );
+
+  return {
+    dependencies: [...dependencies],
+    sideEffectDependencies: [...sideEffectDependencies],
+    value: mergedValue ?? value,
+  };
 }
 
 const zeroArgFunctionReturnExpression = (

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -1064,9 +1064,9 @@ const removeUnusedStaticImports = (
 const replaceStaticWYWMetaExtendsHelpers = (
   code: string,
   filename: string,
-  helperNames: Set<string>
+  helperValues: Map<string, unknown>
 ): string => {
-  if (helperNames.size === 0) {
+  if (helperValues.size === 0) {
     return code;
   }
 
@@ -1082,13 +1082,18 @@ const replaceStaticWYWMetaExtendsHelpers = (
           unwrapped.type === 'CallExpression' &&
           unwrapped.callee.type === 'Identifier' &&
           unwrapped.arguments.length === 0 &&
-          helperNames.has(unwrapped.callee.name)
+          helperValues.has(unwrapped.callee.name)
         ) {
-          replacements.push({
-            end: extendsExpression.end,
-            start: extendsExpression.start,
-            text: 'null',
-          });
+          const replacement = staticWYWMetaExtendsReplacementCode(
+            helperValues.get(unwrapped.callee.name)
+          );
+          if (replacement) {
+            replacements.push({
+              end: extendsExpression.end,
+              start: extendsExpression.start,
+              text: replacement,
+            });
+          }
         }
       }
     }
@@ -1105,13 +1110,13 @@ const pruneStaticPreevalCode = (
   filename: string,
   staticValueNames: Set<string>,
   staticImportLocals: Set<string>,
-  staticNullWYWMetaExtendsHelpers: Set<string>,
+  staticExtendsHelperValues: Map<string, unknown>,
   sideEffectImportLocals: Set<string>
 ): string => {
   const codeWithMetadataPruned = replaceStaticWYWMetaExtendsHelpers(
     code,
     filename,
-    staticNullWYWMetaExtendsHelpers
+    staticExtendsHelperValues
   );
   const helpersRemoved = removeStaticHelperDeclarations(
     codeWithMetadataPruned,
@@ -1207,6 +1212,59 @@ const isStaticWYWMetaValue = (
     typeof className === 'string' &&
     (extended === null || isStaticWYWMetaValue(extended, seen))
   );
+};
+
+type StaticWYWSelectorMetaValue = {
+  __wyw_meta: {
+    className: string;
+    extends: StaticWYWSelectorMetaValue | null;
+  };
+};
+
+const toStaticWYWSelectorMetaValue = (
+  value: unknown,
+  seen: Set<unknown> = new Set()
+): StaticWYWSelectorMetaValue | null => {
+  if (typeof value !== 'object' || value === null || seen.has(value)) {
+    return null;
+  }
+
+  seen.add(value);
+
+  const meta = (value as { __wyw_meta?: unknown }).__wyw_meta;
+  if (typeof meta !== 'object' || meta === null) {
+    return null;
+  }
+
+  const { className, extends: extended } = meta as {
+    className?: unknown;
+    extends?: unknown;
+  };
+  if (typeof className !== 'string') {
+    return null;
+  }
+
+  const staticExtends =
+    extended === null ? null : toStaticWYWSelectorMetaValue(extended, seen);
+  if (extended !== null && staticExtends === null) {
+    return null;
+  }
+
+  return {
+    __wyw_meta: {
+      className,
+      extends: staticExtends,
+    },
+  };
+};
+
+const staticWYWMetaExtendsReplacementCode = (value: unknown): string | null => {
+  if (value === null) {
+    return 'null';
+  }
+
+  const selectorMeta = toStaticWYWSelectorMetaValue(value);
+  return selectorMeta ? `(${JSON.stringify(selectorMeta)})` : null;
 };
 
 const staticWYWMetaTreeValueStatus = (
@@ -4603,12 +4661,18 @@ export function* resolveStaticOxcPreevalValues(
     ...staticNullWYWMetaExtendsHelpers,
   ];
   const originalBaseCode = preevalResult.baseCode ?? preevalResult.code;
+  const staticExtendsHelperValues = new Map(staticValueCache);
+  staticNullWYWMetaExtendsHelpers.forEach((name) => {
+    if (!staticExtendsHelperValues.has(name)) {
+      staticExtendsHelperValues.set(name, null);
+    }
+  });
   const baseCode = pruneStaticPreevalCode(
     originalBaseCode,
     filename,
     new Set(staticValueCache.keys()),
     staticImportLocals,
-    staticNullWYWMetaExtendsHelpers,
+    staticExtendsHelperValues,
     sideEffectImportLocals
   );
   const evalBaseCode =
@@ -4618,7 +4682,7 @@ export function* resolveStaticOxcPreevalValues(
           filename,
           new Set(staticValueCache.keys()),
           staticImportLocals,
-          staticNullWYWMetaExtendsHelpers,
+          staticExtendsHelperValues,
           new Set()
         )
       : baseCode;

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -177,19 +177,10 @@ const isStaticImportValuesEnabled = (
   );
 };
 
-const isStaticResolveDebugEnabled = (): boolean => {
-  const envValue = process.env.WYW_DEBUG_STATIC_RESOLVE?.trim().toLowerCase();
-  return !!envValue && !isEnvDisabled(envValue);
-};
-
 const debugStaticResolve = (
   action: ITransformAction,
   event: StaticResolveDebugEvent
 ): void => {
-  if (!isStaticResolveDebugEnabled()) {
-    return;
-  }
-
   const labels = Object.fromEntries(
     Object.entries({
       ...event,
@@ -198,8 +189,6 @@ const debugStaticResolve = (
   );
 
   action.services.eventEmitter.single(labels);
-  // eslint-disable-next-line no-console
-  console.warn('[wyw-static-resolve]', labels);
 };
 
 const parseProgram = (code: string, filename: string): Program =>
@@ -247,7 +236,7 @@ const isStaticResolveCacheEnabled = (): boolean => {
     return !isEnvDisabled(envValue);
   }
 
-  return !isStaticResolveDebugEnabled();
+  return true;
 };
 
 const staticCachePrefix = (action: ITransformAction): string =>

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-restricted-syntax,no-continue,@typescript-eslint/no-use-before-define */
 
+import { createHash } from 'crypto';
+import { readFileSync, statSync } from 'fs';
 import { dirname, isAbsolute, relative, resolve as resolvePath } from 'path';
 
 import { isFeatureEnabled, type FeatureFlag } from '@wyw-in-js/shared';
@@ -37,9 +39,13 @@ import type { ITransformAction, SyncScenarioFor } from '../types';
 type AnyNode = Node & Record<string, unknown>;
 
 type ImportBinding = {
-  imported: 'default' | string;
+  imported: '*' | 'default' | string;
   local: string;
   source: string;
+};
+
+type CollectImportBindingsOptions = {
+  includeNamespace?: boolean;
 };
 
 type ExportTarget =
@@ -56,8 +62,31 @@ type ExportTarget =
 
 type StaticExportResult = {
   dependencies: string[];
+  sideEffectDependencies?: string[];
+  sideEffectImportLocals?: string[];
   value: unknown;
 };
+
+type StaticFileAnalysis = {
+  code: string;
+  codeHash: string;
+  program: Program;
+};
+
+type StaticFileHashCacheEntry = {
+  hash: string;
+  mtimeMs: number;
+  size: number;
+};
+
+type StaticExportCacheEntry =
+  | {
+      result: null;
+    }
+  | {
+      dependencyHashes: Map<string, string>;
+      result: StaticExportResult;
+    };
 
 type StaticImportValueFeatures = {
   staticImportValues?: FeatureFlag;
@@ -65,6 +94,7 @@ type StaticImportValueFeatures = {
 
 type StaticExpressionOptions = {
   allowMetadataCalls?: boolean;
+  ignoredMutableCallArgumentNames?: Set<string>;
 };
 
 type StaticResolveDebugPhase =
@@ -158,6 +188,256 @@ const debugStaticResolve = (
 
 const parseProgram = (code: string, filename: string): Program =>
   parseOxcProgramCached(filename, code, 'unambiguous');
+
+const staticFileAnalysisCaches = new WeakMap<
+  object,
+  Map<string, StaticFileAnalysis>
+>();
+
+const staticFileHashCaches = new WeakMap<
+  object,
+  Map<string, StaticFileHashCacheEntry>
+>();
+
+const staticExportResultCaches = new WeakMap<
+  object,
+  Map<string, StaticExportCacheEntry>
+>();
+
+const hashStaticContent = (content: string | Buffer): string =>
+  createHash('sha256').update(content).digest('hex');
+
+const getWeakCacheMap = <TValue>(
+  caches: WeakMap<object, Map<string, TValue>>,
+  key: object
+): Map<string, TValue> => {
+  let cache = caches.get(key);
+  if (!cache) {
+    cache = new Map();
+    caches.set(key, cache);
+  }
+
+  return cache;
+};
+
+const isStaticResolveCacheEnabled = (): boolean => {
+  const envValue = process.env.WYW_STATIC_RESOLVE_CACHE?.trim().toLowerCase();
+  if (envValue) {
+    return !isEnvDisabled(envValue);
+  }
+
+  return !isStaticResolveDebugEnabled();
+};
+
+const staticCachePrefix = (action: ITransformAction): string =>
+  `${action.services.cache.getKeySalt() ?? ''}\0${
+    action.services.options.root ?? ''
+  }`;
+
+const staticFileAnalysisCache = (
+  action: ITransformAction
+): Map<string, StaticFileAnalysis> =>
+  getWeakCacheMap(staticFileAnalysisCaches, action.services.cache);
+
+const staticFileHashCache = (
+  action: ITransformAction
+): Map<string, StaticFileHashCacheEntry> =>
+  getWeakCacheMap(staticFileHashCaches, action.services.cache);
+
+const staticExportResultCache = (
+  action: ITransformAction
+): Map<string, StaticExportCacheEntry> =>
+  getWeakCacheMap(staticExportResultCaches, action.services.cache);
+
+const staticFileAnalysisCacheKey = (
+  action: ITransformAction,
+  filename: string,
+  codeHash: string
+): string => `${staticCachePrefix(action)}\0${filename}\0${codeHash}`;
+
+const staticExportCacheKey = (
+  action: ITransformAction,
+  filename: string,
+  exportedName: string,
+  codeHash: string
+): string =>
+  `${staticCachePrefix(action)}\0${filename}\0${exportedName}\0${codeHash}`;
+
+const getStaticFileContentHash = (
+  action: ITransformAction,
+  dependency: string
+): string | null => {
+  const filename = stripQueryAndHash(dependency);
+  if (!isAbsolute(filename)) {
+    return null;
+  }
+
+  let stat;
+  try {
+    stat = statSync(filename);
+  } catch {
+    return null;
+  }
+
+  if (!stat.isFile()) {
+    return null;
+  }
+
+  const cache = staticFileHashCache(action);
+  const cached = cache.get(filename);
+  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return cached.hash;
+  }
+
+  let hash: string;
+  try {
+    hash = hashStaticContent(readFileSync(filename));
+  } catch {
+    return null;
+  }
+
+  cache.set(filename, {
+    hash,
+    mtimeMs: stat.mtimeMs,
+    size: stat.size,
+  });
+  return hash;
+};
+
+const collectStaticDependencyHashes = (
+  action: ITransformAction,
+  dependencies: string[]
+): Map<string, string> | null => {
+  const hashes = new Map<string, string>();
+  for (const dependency of dependencies) {
+    const hash = getStaticFileContentHash(action, dependency);
+    if (!hash) {
+      return null;
+    }
+
+    hashes.set(stripQueryAndHash(dependency), hash);
+  }
+
+  return hashes;
+};
+
+const areStaticDependencyHashesCurrent = (
+  action: ITransformAction,
+  dependencyHashes: Map<string, string>
+): boolean => {
+  for (const [dependency, expectedHash] of dependencyHashes) {
+    if (getStaticFileContentHash(action, dependency) !== expectedHash) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const getStaticExportCachedResult = (
+  action: ITransformAction,
+  filename: string,
+  exportedName: string,
+  codeHash: string
+): StaticExportResult | null | undefined => {
+  if (!isStaticResolveCacheEnabled()) {
+    return undefined;
+  }
+
+  const cache = staticExportResultCache(action);
+  const cacheKey = staticExportCacheKey(
+    action,
+    filename,
+    exportedName,
+    codeHash
+  );
+  const cached = cache.get(cacheKey);
+  if (!cached) {
+    return undefined;
+  }
+
+  if (cached.result === null) {
+    return null;
+  }
+
+  if (areStaticDependencyHashesCurrent(action, cached.dependencyHashes)) {
+    return cached.result;
+  }
+
+  cache.delete(cacheKey);
+  return undefined;
+};
+
+const setStaticExportCachedResult = (
+  action: ITransformAction,
+  filename: string,
+  exportedName: string,
+  codeHash: string,
+  result: StaticExportResult | null
+): void => {
+  if (!isStaticResolveCacheEnabled()) {
+    return;
+  }
+
+  const cacheKey = staticExportCacheKey(
+    action,
+    filename,
+    exportedName,
+    codeHash
+  );
+  if (!result) {
+    staticExportResultCache(action).set(cacheKey, { result: null });
+    return;
+  }
+
+  const dependencyHashes = collectStaticDependencyHashes(
+    action,
+    result.dependencies
+  );
+  if (!dependencyHashes) {
+    return;
+  }
+
+  staticExportResultCache(action).set(cacheKey, {
+    dependencyHashes,
+    result,
+  });
+};
+
+const getStaticFileAnalysis = (
+  action: ITransformAction,
+  filename: string
+): StaticFileAnalysis | null => {
+  const loadedAndParsed = action.services.loadAndParseFn(
+    action.services,
+    filename,
+    undefined,
+    action.services.log
+  );
+  if (
+    loadedAndParsed.evaluator === 'ignored' ||
+    loadedAndParsed.evaluator !== oxcShaker
+  ) {
+    return null;
+  }
+
+  const { code } = loadedAndParsed;
+  const codeHash = hashStaticContent(code);
+  const cache = staticFileAnalysisCache(action);
+  const cacheKey = staticFileAnalysisCacheKey(action, filename, codeHash);
+  const cached = cache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const analysis = {
+    code,
+    codeHash,
+    program: parseProgram(code, filename),
+  };
+  cache.set(cacheKey, analysis);
+  return analysis;
+};
 
 const getChildren = (node: Node): Node[] => {
   const children: Node[] = [];
@@ -348,11 +628,22 @@ const isTypeOnlyImport = (statement: ImportDeclaration): boolean => {
 
 const getImportBinding = (
   statement: ImportDeclaration,
-  specifier: ImportDeclaration['specifiers'][number]
+  specifier: ImportDeclaration['specifiers'][number],
+  options: CollectImportBindingsOptions = {}
 ): ImportBinding | null => {
   const local = specifier.local?.name;
   if (!local) {
     return null;
+  }
+
+  if (specifier.type === 'ImportNamespaceSpecifier') {
+    return options.includeNamespace
+      ? {
+          imported: '*',
+          local,
+          source: statement.source.value,
+        }
+      : null;
   }
 
   if (specifier.type === 'ImportDefaultSpecifier') {
@@ -382,7 +673,8 @@ const getImportBinding = (
 };
 
 const collectImportBindings = (
-  program: Program
+  program: Program,
+  options: CollectImportBindingsOptions = {}
 ): Map<string, ImportBinding> => {
   const result = new Map<string, ImportBinding>();
 
@@ -392,7 +684,7 @@ const collectImportBindings = (
     }
 
     statement.specifiers.forEach((specifier) => {
-      const binding = getImportBinding(statement, specifier);
+      const binding = getImportBinding(statement, specifier, options);
       if (binding) {
         result.set(binding.local, binding);
       }
@@ -409,16 +701,6 @@ type Range = {
 
 type Replacement = Range & {
   text: string;
-};
-
-const removeRanges = (code: string, ranges: Range[]): string => {
-  let result = code;
-  ranges
-    .sort((a, b) => b.start - a.start)
-    .forEach((range) => {
-      result = result.slice(0, range.start) + result.slice(range.end);
-    });
-  return result;
 };
 
 const applyReplacements = (
@@ -634,7 +916,8 @@ const importSpecifierLocalName = (
 const removeUnusedStaticImports = (
   code: string,
   filename: string,
-  staticImportLocals: Set<string>
+  staticImportLocals: Set<string>,
+  sideEffectImportLocals: Set<string>
 ): string => {
   if (staticImportLocals.size === 0) {
     return code;
@@ -643,6 +926,7 @@ const removeUnusedStaticImports = (
   const program = parseProgram(code, filename);
   const used = collectUsedIdentifierNames(program);
   const ranges: Range[] = [];
+  const replacements: Replacement[] = [];
 
   program.body.forEach((statement) => {
     if (
@@ -652,22 +936,34 @@ const removeUnusedStaticImports = (
       return;
     }
 
-    const removableIndexes = statement.specifiers.flatMap(
-      (specifier, index) => {
-        const localName = importSpecifierLocalName(specifier);
-        return localName &&
-          staticImportLocals.has(localName) &&
-          !used.has(localName)
-          ? [index]
-          : [];
-      }
-    );
+    const removable = statement.specifiers.flatMap((specifier, index) => {
+      const localName = importSpecifierLocalName(specifier);
+      return localName &&
+        staticImportLocals.has(localName) &&
+        !used.has(localName)
+        ? [{ index, localName }]
+        : [];
+    });
 
-    if (removableIndexes.length === 0) {
+    if (removable.length === 0) {
       return;
     }
 
-    if (removableIndexes.length === statement.specifiers.length) {
+    if (removable.length === statement.specifiers.length) {
+      if (
+        removable.some((item) => sideEffectImportLocals.has(item.localName))
+      ) {
+        replacements.push({
+          end: statement.end,
+          start: statement.start,
+          text: `import ${code.slice(
+            statement.source.start,
+            statement.source.end
+          )};`,
+        });
+        return;
+      }
+
       ranges.push({
         end: statement.end,
         start: statement.start,
@@ -675,7 +971,10 @@ const removeUnusedStaticImports = (
     }
   });
 
-  return removeRanges(code, ranges);
+  return applyReplacements(code, [
+    ...ranges.map((range) => ({ ...range, text: '' })),
+    ...replacements,
+  ]);
 };
 
 const replaceStaticWYWMetaExtendsHelpers = (
@@ -722,7 +1021,8 @@ const pruneStaticPreevalCode = (
   filename: string,
   staticValueNames: Set<string>,
   staticImportLocals: Set<string>,
-  staticNullWYWMetaExtendsHelpers: Set<string>
+  staticNullWYWMetaExtendsHelpers: Set<string>,
+  sideEffectImportLocals: Set<string>
 ): string => {
   const codeWithMetadataPruned = replaceStaticWYWMetaExtendsHelpers(
     code,
@@ -746,7 +1046,8 @@ const pruneStaticPreevalCode = (
   return removeUnusedStaticImports(
     helpersRemoved.code,
     filename,
-    importLocalsToPrune
+    importLocalsToPrune,
+    sideEffectImportLocals
   );
 };
 
@@ -824,6 +1125,88 @@ const isStaticWYWMetaValue = (
   );
 };
 
+const staticWYWMetaTreeValueStatus = (
+  value: unknown,
+  seen: Set<unknown> = new Set()
+): { hasMetadata: boolean; safe: boolean } => {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return {
+      hasMetadata: false,
+      safe: true,
+    };
+  }
+
+  if (typeof value !== 'object') {
+    return {
+      hasMetadata: false,
+      safe: false,
+    };
+  }
+
+  if (seen.has(value)) {
+    return {
+      hasMetadata: false,
+      safe: false,
+    };
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    let hasMetadata = false;
+    for (const item of value) {
+      const status = staticWYWMetaTreeValueStatus(item, seen);
+      if (!status.safe) {
+        return {
+          hasMetadata: false,
+          safe: false,
+        };
+      }
+
+      hasMetadata = hasMetadata || status.hasMetadata;
+    }
+
+    return {
+      hasMetadata,
+      safe: true,
+    };
+  }
+
+  if ('__wyw_meta' in value) {
+    return {
+      hasMetadata: isStaticWYWMetaValue(value),
+      safe: isStaticWYWMetaValue(value),
+    };
+  }
+
+  let hasMetadata = false;
+  for (const item of Object.values(value)) {
+    const status = staticWYWMetaTreeValueStatus(item, seen);
+    if (!status.safe) {
+      return {
+        hasMetadata: false,
+        safe: false,
+      };
+    }
+
+    hasMetadata = hasMetadata || status.hasMetadata;
+  }
+
+  return {
+    hasMetadata,
+    safe: true,
+  };
+};
+
+const isStaticWYWMetaTreeValue = (value: unknown): boolean => {
+  const status = staticWYWMetaTreeValueStatus(value);
+  return status.safe && status.hasMetadata;
+};
+
 type StaticProcessorInstance = {
   artifacts: unknown[];
   build: (values: Map<string, unknown>) => void;
@@ -879,17 +1262,50 @@ const isEmptyProcessorClassName = (
     return false;
   }
 
-  try {
-    processor.build(new Map());
-  } catch {
-    cache.set(value, false);
-    return false;
+  if (processor.artifacts.length === 0) {
+    try {
+      processor.build(new Map());
+    } catch {
+      cache.set(value, false);
+      return false;
+    }
   }
 
   const result = processor.artifacts.every((artifact) => {
     const cssText = artifactCssText(artifact);
     return cssText !== null && cssText.trim() === '';
   });
+  cache.set(value, result);
+  return result;
+};
+
+const isProcessorClassName = (
+  value: string,
+  processors: StaticProcessorInstance[],
+  cache: Map<string, boolean>
+): boolean => {
+  if (cache.has(value)) {
+    return cache.get(value)!;
+  }
+
+  const processor = processors.find((item) => item.className === value);
+  if (!processor) {
+    cache.set(value, false);
+    return false;
+  }
+
+  if (processor.artifacts.length === 0) {
+    try {
+      processor.build(new Map());
+    } catch {
+      cache.set(value, false);
+      return false;
+    }
+  }
+
+  const result = processor.artifacts.every(
+    (artifact) => artifactCssText(artifact) !== null
+  );
   cache.set(value, result);
   return result;
 };
@@ -923,6 +1339,41 @@ const isSelectorOnlyProcessorValue = (
     seen.add(value);
     return Object.values(value).every((item) =>
       isSelectorOnlyProcessorValue(item, processors, cache, seen)
+    );
+  }
+
+  return false;
+};
+
+const isProcessorClassValue = (
+  value: unknown,
+  processors: StaticProcessorInstance[],
+  cache: Map<string, boolean>,
+  seen: Set<unknown> = new Set()
+): boolean => {
+  if (typeof value === 'string') {
+    return isProcessorClassName(value, processors, cache);
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return false;
+    }
+
+    seen.add(value);
+    return value.every((item) =>
+      isProcessorClassValue(item, processors, cache, seen)
+    );
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    if (seen.has(value)) {
+      return false;
+    }
+
+    seen.add(value);
+    return Object.values(value).every((item) =>
+      isProcessorClassValue(item, processors, cache, seen)
     );
   }
 
@@ -969,8 +1420,9 @@ type StaticExpressionDependencies = {
 
 type PreparedProcessorTarget = {
   dependencies: StaticExpressionDependencies;
+  evaluationCode?: string;
+  evaluationSpan?: Range;
   expression: Expression;
-  expressionCode?: string;
   opaqueRuntimeBase: boolean;
 };
 
@@ -1585,6 +2037,25 @@ const findWYWMetaExtendsExpression = (expr: Expression): Expression | null => {
   return findObjectPropertyValue(meta, 'extends');
 };
 
+const collectWYWMetaExtendsExpressions = (expr: Expression): Expression[] => {
+  const result: Expression[] = [];
+  const visit = (node: Node): void => {
+    if (node.type === 'ObjectExpression') {
+      const extendsExpression = findWYWMetaExtendsExpression(
+        node as Expression
+      );
+      if (extendsExpression) {
+        result.push(extendsExpression);
+      }
+    }
+
+    getChildren(node).forEach(visit);
+  };
+
+  visit(expr);
+  return result;
+};
+
 const topLevelStatements = (program: Program): Node[] => {
   const result: Node[] = [];
 
@@ -1667,7 +2138,10 @@ const isTopLevelFunctionOrClass = (program: Program, name: string): boolean =>
     return false;
   });
 
-const functionReturnExpression = (expr: Node): Expression | null => {
+const functionReturnExpression = (
+  expr: Node,
+  options: { allowParams?: boolean } = {}
+): Expression | null => {
   const unwrapped = unwrapExpression(expr);
   if (
     unwrapped.type !== 'ArrowFunctionExpression' &&
@@ -1676,7 +2150,11 @@ const functionReturnExpression = (expr: Node): Expression | null => {
     return null;
   }
 
-  if (unwrapped.async || unwrapped.params.length > 0 || !unwrapped.body) {
+  if (
+    unwrapped.async ||
+    (!options.allowParams && unwrapped.params.length > 0) ||
+    !unwrapped.body
+  ) {
     return null;
   }
 
@@ -1731,8 +2209,36 @@ const isKnownReactFactoryCall = (
   );
 };
 
+const isKnownOpaqueRuntimeWrapperImport = (
+  binding: ImportBinding | undefined
+): boolean => {
+  if (!binding) {
+    return false;
+  }
+
+  return (
+    binding.imported === 'observer' &&
+    (binding.source === 'mobx-react' || binding.source === 'mobx-react-lite')
+  );
+};
+
+const isKnownOpaqueRuntimeWrapperCallee = (
+  expr: Node,
+  imports: Map<string, ImportBinding>
+): boolean => {
+  const callee = unwrapExpression(expr);
+  if (callee.type === 'Identifier') {
+    return isKnownOpaqueRuntimeWrapperImport(imports.get(callee.name));
+  }
+
+  return false;
+};
+
 const isKnownOpaqueRuntimeImportSource = (source: string): boolean =>
   /\.svg(?:$|[?#])/.test(source);
+
+const isKnownExternalRuntimeComponentImportSource = (source: string): boolean =>
+  source.startsWith('@radix-ui/react-');
 
 type OpaqueRuntimeImportProof = {
   dependencies: string[];
@@ -1836,6 +2342,92 @@ const objectAssignTargetExpression = (
   return target;
 };
 
+const isFunctionBoundaryNode = (node: Node): boolean =>
+  node.type === 'ArrowFunctionExpression' ||
+  node.type === 'FunctionDeclaration' ||
+  node.type === 'FunctionExpression' ||
+  node.type === 'ClassDeclaration' ||
+  node.type === 'ClassExpression';
+
+const callHasArgumentRootName = (expr: Node, targetName: string): boolean => {
+  const unwrapped = unwrapExpression(expr);
+  return (
+    unwrapped.type === 'CallExpression' &&
+    unwrapped.arguments.some((argument) => {
+      const argumentNode =
+        argument.type === 'SpreadElement' ? argument.argument : argument;
+      return rootIdentifierName(argumentNode) === targetName;
+    })
+  );
+};
+
+const isSafeObjectAssignAliasAugmentation = (
+  program: Program,
+  expr: Node,
+  targetName: string
+): boolean => {
+  const unwrapped = unwrapExpression(expr);
+  if (
+    unwrapped.type !== 'CallExpression' ||
+    !isObjectAssignCallee(program, unwrapped.callee) ||
+    unwrapped.arguments.length < 2
+  ) {
+    return false;
+  }
+
+  const [target, ...aliases] = unwrapped.arguments;
+  if (!target || target.type === 'SpreadElement') {
+    return false;
+  }
+
+  const unwrappedTarget = unwrapExpression(target);
+  if (
+    unwrappedTarget.type !== 'Identifier' ||
+    unwrappedTarget.name !== targetName
+  ) {
+    return false;
+  }
+
+  return aliases.every(
+    (alias) =>
+      alias.type !== 'SpreadElement' &&
+      isSafeObjectAssignAliasExpression(program, alias)
+  );
+};
+
+const hasOnlySafeObjectAssignCallArgumentUses = (
+  program: Program,
+  targetName: string
+): boolean => {
+  let hasSafeUse = false;
+  let hasUnsafeUse = false;
+
+  const visit = (node: Node): void => {
+    if (hasUnsafeUse || isFunctionBoundaryNode(node)) {
+      return;
+    }
+
+    const unwrapped = unwrapExpression(node);
+    if (unwrapped.type === 'CallExpression') {
+      if (callHasArgumentRootName(unwrapped, targetName)) {
+        if (
+          isSafeObjectAssignAliasAugmentation(program, unwrapped, targetName)
+        ) {
+          hasSafeUse = true;
+        } else {
+          hasUnsafeUse = true;
+          return;
+        }
+      }
+    }
+
+    getChildren(node).forEach(visit);
+  };
+
+  topLevelStatements(program).forEach(visit);
+  return hasSafeUse && !hasUnsafeUse;
+};
+
 const resolveObjectAssignProcessorExpression = (
   program: Program,
   expr: Expression
@@ -1856,7 +2448,7 @@ const isOpaqueRuntimeComponentExpression = (
   opaqueImportNames: Set<string> = new Set(),
   seen: Set<string> = new Set()
 ): boolean => {
-  const imports = collectImportBindings(program);
+  const imports = collectImportBindings(program, { includeNamespace: true });
   const unwrapped = unwrapExpression(expr);
 
   if (isStaticMetaObjectExpression(unwrapped)) {
@@ -1877,11 +2469,32 @@ const isOpaqueRuntimeComponentExpression = (
 
   if (
     unwrapped.type === 'CallExpression' &&
-    unwrapped.callee.type === 'Identifier' &&
-    unwrapped.arguments.length === 0
+    unwrapped.arguments.length === 1 &&
+    isKnownOpaqueRuntimeWrapperCallee(unwrapped.callee, imports)
   ) {
+    const [argument] = unwrapped.arguments;
+    return argument.type !== 'SpreadElement'
+      ? isOpaqueRuntimeComponentExpression(
+          program,
+          argument,
+          opaqueImportNames,
+          seen
+        )
+      : false;
+  }
+
+  if (
+    unwrapped.type === 'CallExpression' &&
+    unwrapped.callee.type === 'Identifier'
+  ) {
+    const allowParams = unwrapped.arguments.every(
+      (argument) =>
+        argument.type !== 'SpreadElement' && isSafeStaticExpression(argument)
+    );
     const local = findTopLevelConstExpression(program, unwrapped.callee.name);
-    const returned = local ? functionReturnExpression(local) : null;
+    const returned = local
+      ? functionReturnExpression(local, { allowParams })
+      : null;
     return returned
       ? isOpaqueRuntimeComponentExpression(
           program,
@@ -1890,6 +2503,17 @@ const isOpaqueRuntimeComponentExpression = (
           seen
         )
       : false;
+  }
+
+  if (unwrapped.type === 'MemberExpression' && !unwrapped.computed) {
+    const name = rootIdentifierName(unwrapped);
+    const imported = name ? imports.get(name) : undefined;
+    return (
+      !!name &&
+      !!imported &&
+      (opaqueImportNames.has(name) ||
+        isKnownExternalRuntimeComponentImportSource(imported.source))
+    );
   }
 
   if (unwrapped.type !== 'Identifier') {
@@ -1906,7 +2530,8 @@ const isOpaqueRuntimeComponentExpression = (
   if (imported) {
     return (
       opaqueImportNames.has(name) ||
-      isKnownOpaqueRuntimeImportSource(imported.source)
+      isKnownOpaqueRuntimeImportSource(imported.source) ||
+      isKnownExternalRuntimeComponentImportSource(imported.source)
     );
   }
 
@@ -1935,15 +2560,20 @@ const collectOpaqueRuntimeReferenceNames = (
 
   if (
     unwrapped.type === 'CallExpression' &&
-    unwrapped.callee.type === 'Identifier' &&
-    unwrapped.arguments.length === 0
+    unwrapped.callee.type === 'Identifier'
   ) {
+    const allowParams = unwrapped.arguments.every(
+      (argument) =>
+        argument.type !== 'SpreadElement' && isSafeStaticExpression(argument)
+    );
     if (seenHelpers.has(unwrapped.callee.name)) {
       return;
     }
 
     const local = findTopLevelConstExpression(program, unwrapped.callee.name);
-    const returned = local ? functionReturnExpression(local) : null;
+    const returned = local
+      ? functionReturnExpression(local, { allowParams })
+      : null;
     if (returned) {
       seenHelpers.add(unwrapped.callee.name);
       collectOpaqueRuntimeReferenceNames(program, returned, names, seenHelpers);
@@ -1987,50 +2617,121 @@ const collectWYWMetaExtendsHelperNames = (program: Program): Set<string> => {
   return result;
 };
 
-const replaceExpressionChild = (
+const replaceExpressionChildren = (
   code: string,
   expression: Expression,
-  child: Expression,
-  replacement: string
+  replacements: Array<{ child: Expression; replacement: string }>
 ): string => {
   const expressionCode = code.slice(expression.start, expression.end);
-  return (
-    expressionCode.slice(0, child.start - expression.start) +
-    replacement +
-    expressionCode.slice(child.end - expression.start)
+  return applyReplacements(
+    expressionCode,
+    replacements.map(({ child, replacement }) => ({
+      end: child.end - expression.start,
+      start: child.start - expression.start,
+      text: replacement,
+    }))
   );
+};
+
+const parseSyntheticExpression = (
+  expressionCode: string,
+  filename: string
+): Expression | null => {
+  const program = parseProgram(
+    `const __wyw_static_target = ${expressionCode};`,
+    filename
+  );
+  const declaration = program.body[0];
+  if (declaration?.type !== 'VariableDeclaration') {
+    return null;
+  }
+
+  const [declarator] = declaration.declarations;
+  return declarator?.init ?? null;
 };
 
 const prepareProcessorTarget = (
   code: string,
+  filename: string,
   program: Program,
   target: Extract<ExportTarget, { kind: 'expression' }>,
   opaqueImportNames: Set<string> = new Set()
 ): PreparedProcessorTarget | null => {
+  const ignoredMutableCallArgumentNames =
+    target.localName &&
+    hasOnlySafeObjectAssignCallArgumentUses(program, target.localName)
+      ? new Set([target.localName])
+      : undefined;
+  const dependencyOptions: StaticExpressionOptions = {
+    allowMetadataCalls: true,
+    ignoredMutableCallArgumentNames,
+  };
   const expression = resolveObjectAssignProcessorExpression(
     program,
     target.expression
   );
-  const extendsExpression = findWYWMetaExtendsExpression(expression);
-  if (
-    extendsExpression &&
-    isOpaqueRuntimeComponentExpression(
-      program,
-      extendsExpression,
-      opaqueImportNames
-    )
-  ) {
-    return {
-      dependencies: { imports: [] },
-      expression,
-      expressionCode: replaceExpressionChild(
-        code,
-        expression,
+  const extendsExpressions = collectWYWMetaExtendsExpressions(expression);
+  const opaqueExtendsExpressions = extendsExpressions.filter(
+    (extendsExpression) =>
+      isOpaqueRuntimeComponentExpression(
+        program,
         extendsExpression,
-        'null'
-      ),
-      opaqueRuntimeBase: true,
-    };
+        opaqueImportNames
+      )
+  );
+
+  if (opaqueExtendsExpressions.length > 0) {
+    const replacements = opaqueExtendsExpressions.map((extendsExpression) => ({
+      child: extendsExpression,
+      replacement: 'null',
+    }));
+    const expressionCode = replaceExpressionChildren(
+      code,
+      expression,
+      replacements
+    );
+    const syntheticExpression = parseSyntheticExpression(
+      expressionCode,
+      filename
+    );
+    if (!syntheticExpression) {
+      return null;
+    }
+
+    const dependencies = collectStaticExpressionDependencies(
+      program,
+      {
+        ...target,
+        expression: syntheticExpression,
+      },
+      dependencyOptions
+    );
+
+    return dependencies
+      ? {
+          dependencies,
+          evaluationCode: applyReplacements(
+            code,
+            replacements.map(({ child, replacement }) => ({
+              end: child.end,
+              start: child.start,
+              text: replacement,
+            }))
+          ),
+          evaluationSpan: {
+            end:
+              expression.end +
+              replacements.reduce(
+                (delta, { child, replacement }) =>
+                  delta + replacement.length - (child.end - child.start),
+                0
+              ),
+            start: expression.start,
+          },
+          expression,
+          opaqueRuntimeBase: true,
+        }
+      : null;
   }
 
   const dependencies = collectStaticExpressionDependencies(
@@ -2039,9 +2740,7 @@ const prepareProcessorTarget = (
       ...target,
       expression,
     },
-    {
-      allowMetadataCalls: true,
-    }
+    dependencyOptions
   );
   return dependencies
     ? {
@@ -2143,7 +2842,10 @@ const collectStaticExpressionDependencies = (
   }
 
   for (const name of mutableReferencedNames) {
-    if (mutationHints.callArgumentNames.has(name)) {
+    if (
+      mutationHints.callArgumentNames.has(name) &&
+      !options.ignoredMutableCallArgumentNames?.has(name)
+    ) {
       return null;
     }
   }
@@ -2351,6 +3053,7 @@ function* resolveImportValue(
       dependency.resolved,
       ...resolved.dependencies.filter((item) => item !== dependency.resolved),
     ],
+    sideEffectDependencies: resolved.sideEffectDependencies,
     value: resolved.value,
   };
 }
@@ -2391,19 +3094,80 @@ function* resolveExportAsOpaqueRuntimeImport(
 
   const program = parseProgram(loadedAndParsed.code, filename);
   const target = findExportTarget(program, exportedName);
-  if (!target || target.kind !== 'import') {
+  if (!target) {
     memo.set(memoKey, null);
     stack.delete(memoKey);
     return null;
   }
 
-  const resolved = yield* resolveImportAsOpaqueRuntime(
-    action,
-    filename,
-    target,
-    stack,
-    memo
+  if (target.kind === 'import') {
+    const resolved = yield* resolveImportAsOpaqueRuntime(
+      action,
+      filename,
+      target,
+      stack,
+      memo
+    );
+    memo.set(memoKey, resolved);
+    stack.delete(memoKey);
+    return resolved;
+  }
+
+  if (isOpaqueRuntimeComponentExpression(program, target.expression)) {
+    const resolved = {
+      dependencies: [filename],
+      names: new Set<string>(),
+    };
+    memo.set(memoKey, resolved);
+    stack.delete(memoKey);
+    return resolved;
+  }
+
+  const imports = collectImportBindings(program, { includeNamespace: true });
+  const referencedNames = new Set<string>();
+  collectOpaqueRuntimeReferenceNames(
+    program,
+    target.expression,
+    referencedNames
   );
+  const opaqueImportNames = new Set<string>();
+  const dependencies = new Set<string>([filename]);
+
+  for (const name of referencedNames) {
+    const binding = imports.get(name);
+    if (
+      !binding ||
+      binding.source === 'react' ||
+      isKnownOpaqueRuntimeWrapperImport(binding)
+    ) {
+      continue;
+    }
+
+    const proof = yield* resolveImportAsOpaqueRuntime(
+      action,
+      filename,
+      binding,
+      stack,
+      memo
+    );
+    if (!proof) {
+      continue;
+    }
+
+    opaqueImportNames.add(name);
+    proof.dependencies.forEach((dependency) => dependencies.add(dependency));
+  }
+
+  const resolved = isOpaqueRuntimeComponentExpression(
+    program,
+    target.expression,
+    opaqueImportNames
+  )
+    ? {
+        dependencies: [...dependencies],
+        names: opaqueImportNames,
+      }
+    : null;
   memo.set(memoKey, resolved);
   stack.delete(memoKey);
   return resolved;
@@ -2441,6 +3205,13 @@ function* resolveImportAsOpaqueRuntime(
   if (knownSourceDependency) {
     return {
       dependencies: [knownSourceDependency],
+      names: new Set(),
+    };
+  }
+
+  if (isKnownExternalRuntimeComponentImportSource(binding.source)) {
+    return {
+      dependencies: [],
       names: new Set(),
     };
   }
@@ -2491,20 +3262,22 @@ function* collectOpaqueRuntimeImportProof(
   program: Program,
   expression: Expression
 ): SyncScenarioFor<OpaqueRuntimeImportProof> {
-  const extendsExpression = findWYWMetaExtendsExpression(expression);
-  if (!extendsExpression) {
+  const extendsExpressions = collectWYWMetaExtendsExpressions(expression);
+  if (extendsExpressions.length === 0) {
     return {
       dependencies: [],
       names: new Set(),
     };
   }
 
-  const imports = collectImportBindings(program);
+  const imports = collectImportBindings(program, { includeNamespace: true });
   const referencedNames = new Set<string>();
-  collectOpaqueRuntimeReferenceNames(
-    program,
-    extendsExpression,
-    referencedNames
+  extendsExpressions.forEach((extendsExpression) =>
+    collectOpaqueRuntimeReferenceNames(
+      program,
+      extendsExpression,
+      referencedNames
+    )
   );
 
   const dependencies = new Set<string>();
@@ -2637,6 +3410,7 @@ function* resolveProcessorStaticExport(
   );
   const preparedTarget = prepareProcessorTarget(
     preevalCode,
+    filename,
     preevalProgram,
     target,
     opaqueRuntimeImportProof.names
@@ -2654,6 +3428,7 @@ function* resolveProcessorStaticExport(
 
   const env = new Map<string, unknown>();
   const dependencies = new Set<string>([filename]);
+  const sideEffectDependencies = new Set<string>();
   opaqueRuntimeImportProof.dependencies.forEach((dependency) =>
     dependencies.add(dependency)
   );
@@ -2681,19 +3456,28 @@ function* resolveProcessorStaticExport(
 
     env.set(binding.local, createOxcStaticCallableValue(resolved.value));
     resolved.dependencies.forEach((dependency) => dependencies.add(dependency));
+    resolved.sideEffectDependencies?.forEach((dependency) =>
+      sideEffectDependencies.add(dependency)
+    );
   }
 
-  const value = preparedTarget.expressionCode
-    ? evaluateOxcStaticExpression(preparedTarget.expressionCode, filename, env)
-    : evaluateOxcStaticExpressionAt(
-        preevalCode,
-        filename,
-        {
-          end: preparedTarget.expression.end,
-          start: preparedTarget.expression.start,
-        },
-        env
-      );
+  const value =
+    preparedTarget.evaluationCode && preparedTarget.evaluationSpan
+      ? evaluateOxcStaticExpressionAt(
+          preparedTarget.evaluationCode,
+          filename,
+          preparedTarget.evaluationSpan,
+          env
+        )
+      : evaluateOxcStaticExpressionAt(
+          preevalCode,
+          filename,
+          {
+            end: preparedTarget.expression.end,
+            start: preparedTarget.expression.start,
+          },
+          env
+        );
   if (!isOxcStaticSerializableValue(value)) {
     debugStaticResolve(action, {
       exported: exportedName,
@@ -2705,13 +3489,24 @@ function* resolveProcessorStaticExport(
     return null;
   }
 
+  const isStaticMeta = isStaticWYWMetaValue(value);
+  const isStaticMetaTree = !isStaticMeta && isStaticWYWMetaTreeValue(value);
+  const processors = preevalResult.metadata
+    .processors as unknown as StaticProcessorInstance[];
+  const isSelectorOnly =
+    !isStaticMeta &&
+    !isStaticMetaTree &&
+    isSelectorOnlyProcessorValue(value, processors, new Map());
+  const isSideEffectClassValue =
+    !isStaticMeta &&
+    !isStaticMetaTree &&
+    !isSelectorOnly &&
+    isProcessorClassValue(value, processors, new Map());
   if (
-    !isStaticWYWMetaValue(value) &&
-    !isSelectorOnlyProcessorValue(
-      value,
-      preevalResult.metadata.processors as unknown as StaticProcessorInstance[],
-      new Map()
-    )
+    !isStaticMeta &&
+    !isStaticMetaTree &&
+    !isSelectorOnly &&
+    !isSideEffectClassValue
   ) {
     debugStaticResolve(action, {
       exported: exportedName,
@@ -2723,18 +3518,26 @@ function* resolveProcessorStaticExport(
     return null;
   }
 
+  let resolvedReason: string | undefined;
+  if (preparedTarget.opaqueRuntimeBase) {
+    resolvedReason = 'opaque-runtime-component';
+  } else if (isSideEffectClassValue) {
+    resolvedReason = 'non-empty-css-artifact-side-effect';
+  }
+
   debugStaticResolve(action, {
     exported: exportedName,
     filename,
     phase: 'processor-metadata',
-    reason: preparedTarget.opaqueRuntimeBase
-      ? 'opaque-runtime-component'
-      : undefined,
+    reason: resolvedReason,
     status: 'resolved',
   });
 
   return {
     dependencies: [...dependencies],
+    sideEffectDependencies: isSideEffectClassValue
+      ? [filename, ...sideEffectDependencies]
+      : [...sideEffectDependencies],
     value,
   };
 }
@@ -2776,6 +3579,7 @@ function* resolveObjectAssignStaticExport(
           filename,
           ...resolved.dependencies.filter((item) => item !== filename),
         ],
+        sideEffectDependencies: resolved.sideEffectDependencies,
         value: resolved.value,
       };
     }
@@ -2796,6 +3600,7 @@ function* resolveObjectAssignStaticExport(
 
   const env = new Map<string, unknown>();
   const dependencies = new Set<string>([filename]);
+  const sideEffectDependencies = new Set<string>();
 
   for (const binding of staticDependencies.imports) {
     const resolved = yield* resolveImportValue(
@@ -2811,6 +3616,9 @@ function* resolveObjectAssignStaticExport(
 
     env.set(binding.local, resolved.value);
     resolved.dependencies.forEach((item) => dependencies.add(item));
+    resolved.sideEffectDependencies?.forEach((item) =>
+      sideEffectDependencies.add(item)
+    );
   }
 
   const value = evaluateOxcStaticExpressionAt(
@@ -2825,6 +3633,7 @@ function* resolveObjectAssignStaticExport(
   return isStaticWYWMetaValue(value)
     ? {
         dependencies: [...dependencies],
+        sideEffectDependencies: [...sideEffectDependencies],
         value,
       }
     : null;
@@ -2856,16 +3665,8 @@ function* resolveStaticExport(
 
   stack.add(memoKey);
 
-  const loadedAndParsed = action.services.loadAndParseFn(
-    action.services,
-    filename,
-    undefined,
-    action.services.log
-  );
-  if (
-    loadedAndParsed.evaluator === 'ignored' ||
-    loadedAndParsed.evaluator !== oxcShaker
-  ) {
+  const analysis = getStaticFileAnalysis(action, filename);
+  if (!analysis) {
     memo.set(memoKey, null);
     stack.delete(memoKey);
     debugStaticResolve(action, {
@@ -2878,12 +3679,36 @@ function* resolveStaticExport(
     return null;
   }
 
-  const { code } = loadedAndParsed;
-  const program = parseProgram(code, filename);
+  const { code, codeHash, program } = analysis;
+  const finish = (
+    result: StaticExportResult | null
+  ): StaticExportResult | null => {
+    memo.set(memoKey, result);
+    stack.delete(memoKey);
+    setStaticExportCachedResult(
+      action,
+      filename,
+      exportedName,
+      codeHash,
+      result
+    );
+    return result;
+  };
+
+  const cachedResult = getStaticExportCachedResult(
+    action,
+    filename,
+    exportedName,
+    codeHash
+  );
+  if (cachedResult !== undefined) {
+    memo.set(memoKey, cachedResult);
+    stack.delete(memoKey);
+    return cachedResult;
+  }
+
   const target = findExportTarget(program, exportedName);
   if (!target) {
-    memo.set(memoKey, null);
-    stack.delete(memoKey);
     debugStaticResolve(action, {
       exported: exportedName,
       filename,
@@ -2891,7 +3716,7 @@ function* resolveStaticExport(
       reason: 'no-export-target',
       status: 'rejected',
     });
-    return null;
+    return finish(null);
   }
 
   if (target.kind === 'import') {
@@ -2902,8 +3727,6 @@ function* resolveStaticExport(
       stack,
       memo
     );
-    memo.set(memoKey, resolved);
-    stack.delete(memoKey);
     debugStaticResolve(action, {
       exported: exportedName,
       filename,
@@ -2913,7 +3736,7 @@ function* resolveStaticExport(
       source: target.source,
       status: resolved ? 'resolved' : 'rejected',
     });
-    return resolved;
+    return finish(resolved);
   }
 
   const objectAssignResult = yield* resolveObjectAssignStaticExport(
@@ -2926,8 +3749,6 @@ function* resolveStaticExport(
     memo
   );
   if (objectAssignResult) {
-    memo.set(memoKey, objectAssignResult);
-    stack.delete(memoKey);
     debugStaticResolve(action, {
       exported: exportedName,
       filename,
@@ -2935,7 +3756,7 @@ function* resolveStaticExport(
       reason: 'object-assign',
       status: 'resolved',
     });
-    return objectAssignResult;
+    return finish(objectAssignResult);
   }
 
   const staticDependencies = collectStaticExpressionDependencies(
@@ -2959,8 +3780,6 @@ function* resolveStaticExport(
       stack,
       memo
     );
-    memo.set(memoKey, metadataResult);
-    stack.delete(memoKey);
     debugStaticResolve(action, {
       exported: exportedName,
       filename,
@@ -2968,11 +3787,12 @@ function* resolveStaticExport(
       reason: metadataResult ? undefined : 'resolve-failed',
       status: metadataResult ? 'resolved' : 'rejected',
     });
-    return metadataResult;
+    return finish(metadataResult);
   }
 
   const env = new Map<string, unknown>();
   const dependencies = new Set<string>([filename]);
+  const sideEffectDependencies = new Set<string>();
 
   for (const binding of staticDependencies.imports) {
     const resolved = yield* resolveImportValue(
@@ -2983,8 +3803,6 @@ function* resolveStaticExport(
       memo
     );
     if (!resolved) {
-      memo.set(memoKey, null);
-      stack.delete(memoKey);
       debugStaticResolve(action, {
         exported: exportedName,
         filename,
@@ -2994,11 +3812,14 @@ function* resolveStaticExport(
         source: binding.source,
         status: 'rejected',
       });
-      return null;
+      return finish(null);
     }
 
     env.set(binding.local, resolved.value);
     resolved.dependencies.forEach((item) => dependencies.add(item));
+    resolved.sideEffectDependencies?.forEach((item) =>
+      sideEffectDependencies.add(item)
+    );
   }
 
   const value = evaluateOxcStaticExpressionAt(
@@ -3011,8 +3832,6 @@ function* resolveStaticExport(
     env
   );
   if (!isOxcStaticSerializableValue(value)) {
-    memo.set(memoKey, null);
-    stack.delete(memoKey);
     debugStaticResolve(action, {
       exported: exportedName,
       filename,
@@ -3020,22 +3839,21 @@ function* resolveStaticExport(
       reason: 'non-serializable',
       status: 'rejected',
     });
-    return null;
+    return finish(null);
   }
 
   const result = {
     dependencies: [...dependencies],
+    sideEffectDependencies: [...sideEffectDependencies],
     value,
   };
-  memo.set(memoKey, result);
-  stack.delete(memoKey);
   debugStaticResolve(action, {
     exported: exportedName,
     filename,
     phase: 'export',
     status: 'resolved',
   });
-  return result;
+  return finish(result);
 }
 
 function* resolveCandidateValue(
@@ -3046,6 +3864,8 @@ function* resolveCandidateValue(
 ): SyncScenarioFor<StaticExportResult | null> {
   const env = new Map<string, unknown>();
   const dependencies = new Set<string>();
+  const sideEffectDependencies = new Set<string>();
+  const sideEffectImportLocals = new Set<string>();
 
   for (const item of candidate.imports) {
     const resolved = yield* resolveImportValue(
@@ -3070,6 +3890,10 @@ function* resolveCandidateValue(
 
     env.set(item.local, resolved.value);
     resolved.dependencies.forEach((dependency) => dependencies.add(dependency));
+    resolved.sideEffectDependencies?.forEach((dependency) => {
+      sideEffectDependencies.add(dependency);
+      sideEffectImportLocals.add(item.importLocal ?? item.local);
+    });
   }
 
   const value = evaluateOxcStaticExpression(candidate.source, filename, env);
@@ -3093,6 +3917,8 @@ function* resolveCandidateValue(
 
   return {
     dependencies: [...dependencies],
+    sideEffectDependencies: [...sideEffectDependencies],
+    sideEffectImportLocals: [...sideEffectImportLocals],
     value,
   };
 }
@@ -3158,6 +3984,7 @@ export function* resolveStaticOxcPreevalValues(
     preevalResult.staticValueCache ?? new Map<string, unknown>();
   const staticDependencies = new Set(preevalResult.staticDependencies ?? []);
   const staticImportLocals = new Set<string>();
+  const sideEffectImportLocals = new Set<string>();
   const staticNullWYWMetaExtendsHelpers = new Set(
     preevalResult.staticNullWYWMetaExtendsHelpers ?? []
   );
@@ -3165,6 +3992,7 @@ export function* resolveStaticOxcPreevalValues(
   const opaqueRuntimeBaseHelpers = collectWYWMetaExtendsHelperNames(
     parseProgram(preevalResult.baseCode ?? preevalResult.code, filename)
   );
+  const evalDependencyNames = new Set(preevalResult.dependencyNames ?? []);
   let changed = false;
   let hasKnownStaticCandidate = false;
 
@@ -3172,6 +4000,21 @@ export function* resolveStaticOxcPreevalValues(
     const isOpaqueRuntimeBaseHelper = opaqueRuntimeBaseHelpers.has(
       candidate.name
     );
+    if (
+      !evalDependencyNames.has(candidate.name) &&
+      !isOpaqueRuntimeBaseHelper &&
+      !staticValueCache.has(candidate.name)
+    ) {
+      debugStaticResolve(this, {
+        candidate: candidate.name,
+        filename,
+        phase: 'candidate',
+        reason: 'not-eval-dependency',
+        status: 'skipped',
+      });
+      continue;
+    }
+
     if (staticValueCache.has(candidate.name)) {
       hasKnownStaticCandidate = true;
       candidate.imports.forEach((item) =>
@@ -3236,6 +4079,9 @@ export function* resolveStaticOxcPreevalValues(
     resolved.dependencies.forEach((dependency) =>
       staticDependencies.add(dependency)
     );
+    resolved.sideEffectImportLocals?.forEach((local) =>
+      sideEffectImportLocals.add(local)
+    );
     changed = true;
   }
 
@@ -3252,15 +4098,34 @@ export function* resolveStaticOxcPreevalValues(
   preevalResult.staticNullWYWMetaExtendsHelpers = [
     ...staticNullWYWMetaExtendsHelpers,
   ];
+  const originalBaseCode = preevalResult.baseCode ?? preevalResult.code;
   const baseCode = pruneStaticPreevalCode(
-    preevalResult.baseCode ?? preevalResult.code,
+    originalBaseCode,
     filename,
     new Set(staticValueCache.keys()),
     staticImportLocals,
-    staticNullWYWMetaExtendsHelpers
+    staticNullWYWMetaExtendsHelpers,
+    sideEffectImportLocals
   );
+  const evalBaseCode =
+    sideEffectImportLocals.size > 0
+      ? pruneStaticPreevalCode(
+          originalBaseCode,
+          filename,
+          new Set(staticValueCache.keys()),
+          staticImportLocals,
+          staticNullWYWMetaExtendsHelpers,
+          new Set()
+        )
+      : baseCode;
   preevalResult.baseCode = baseCode;
   preevalResult.code = appendOxcWywPreval(baseCode, filename, dependencyNames);
+  preevalResult.evalCode = appendOxcWywPreval(
+    evalBaseCode,
+    filename,
+    dependencyNames
+  );
+  preevalResult.staticSideEffectImportLocals = [...sideEffectImportLocals];
 
   for (const dependency of staticDependencies) {
     this.entrypoint.addInvalidationDependency({

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -80,6 +80,14 @@ type StaticFileHashCacheEntry = {
   size: number;
 };
 
+type StaticMetadataPreevalCacheEntry =
+  | {
+      result: null;
+    }
+  | {
+      result: ReturnType<typeof runOxcPreevalStage>;
+    };
+
 type StaticExportCacheEntry =
   | {
       result: null;
@@ -205,6 +213,11 @@ const staticExportResultCaches = new WeakMap<
   Map<string, StaticExportCacheEntry>
 >();
 
+const staticMetadataPreevalCaches = new WeakMap<
+  object,
+  Map<string, StaticMetadataPreevalCacheEntry>
+>();
+
 const hashStaticContent = (content: string | Buffer): string =>
   createHash('sha256').update(content).digest('hex');
 
@@ -250,6 +263,11 @@ const staticExportResultCache = (
 ): Map<string, StaticExportCacheEntry> =>
   getWeakCacheMap(staticExportResultCaches, action.services.cache);
 
+const staticMetadataPreevalCache = (
+  action: ITransformAction
+): Map<string, StaticMetadataPreevalCacheEntry> =>
+  getWeakCacheMap(staticMetadataPreevalCaches, action.services.cache);
+
 const staticFileAnalysisCacheKey = (
   action: ITransformAction,
   filename: string,
@@ -263,6 +281,12 @@ const staticExportCacheKey = (
   codeHash: string
 ): string =>
   `${staticCachePrefix(action)}\0${filename}\0${exportedName}\0${codeHash}`;
+
+const staticMetadataPreevalCacheKey = (
+  action: ITransformAction,
+  filename: string,
+  codeHash: string
+): string => `${staticCachePrefix(action)}\0${filename}\0${codeHash}`;
 
 const getStaticFileContentHash = (
   action: ITransformAction,
@@ -438,6 +462,44 @@ const getStaticFileAnalysis = (
   };
   cache.set(cacheKey, analysis);
   return analysis;
+};
+
+const getStaticMetadataPreevalResult = (
+  action: ITransformAction,
+  filename: string,
+  code: string,
+  codeHash: string
+): ReturnType<typeof runOxcPreevalStage> | null => {
+  const cache = staticMetadataPreevalCache(action);
+  const cacheKey = staticMetadataPreevalCacheKey(action, filename, codeHash);
+  const cached = cache.get(cacheKey);
+  if (cached) {
+    return cached.result;
+  }
+
+  const root = action.services.options.root ?? process.cwd();
+  try {
+    const result = action.services.eventEmitter.perf(
+      'transform:preeval:staticMetadata',
+      () =>
+        runOxcPreevalStage(
+          code,
+          {
+            filename,
+            root,
+          },
+          {
+            ...action.services.options.pluginOptions,
+            eventEmitter: action.services.eventEmitter,
+          }
+        )
+    );
+    cache.set(cacheKey, { result });
+    return result;
+  } catch {
+    cache.set(cacheKey, { result: null });
+    return null;
+  }
 };
 
 const getChildren = (node: Node): Node[] => {
@@ -4163,6 +4225,7 @@ function* resolveProcessorStaticExport(
   action: ITransformAction,
   filename: string,
   code: string,
+  codeHash: string,
   program: Program,
   exportedName: string,
   stack: Set<string>,
@@ -4193,24 +4256,13 @@ function* resolveProcessorStaticExport(
     return null;
   }
 
-  let preevalResult: ReturnType<typeof runOxcPreevalStage>;
-  try {
-    preevalResult = action.services.eventEmitter.perf(
-      'transform:preeval:staticMetadata',
-      () =>
-        runOxcPreevalStage(
-          code,
-          {
-            filename,
-            root,
-          },
-          {
-            ...action.services.options.pluginOptions,
-            eventEmitter: action.services.eventEmitter,
-          }
-        )
-    );
-  } catch {
+  const preevalResult = getStaticMetadataPreevalResult(
+    action,
+    filename,
+    code,
+    codeHash
+  );
+  if (!preevalResult) {
     debugStaticResolve(action, {
       exported: exportedName,
       filename,
@@ -4864,6 +4916,7 @@ function* resolveStaticExport(
       action,
       filename,
       code,
+      codeHash,
       program,
       exportedName,
       stack,

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -88,14 +88,21 @@ type StaticMetadataPreevalCacheEntry =
       result: ReturnType<typeof runOxcPreevalStage>;
     };
 
+// Null entries carry an attempt counter so we can retry a bounded number of
+// times before accepting the failure as stable. This avoids both:
+// (a) poisoning the cache forever from a transient resolver failure
+// (b) thundering-herd retries where every consumer re-walks a stable miss
 type StaticExportCacheEntry =
   | {
+      attempts: number;
       result: null;
     }
   | {
       dependencyHashes: Map<string, string>;
       result: StaticExportResult;
     };
+
+const STATIC_EXPORT_MAX_NULL_ATTEMPTS = 2;
 
 type StaticImportValueFeatures = {
   staticImportValues?: FeatureFlag;
@@ -382,6 +389,12 @@ const getStaticExportCachedResult = (
   }
 
   if (cached.result === null) {
+    // Bounded retry: until the attempt counter has been bumped enough times
+    // that we accept the null as stable, treat it as a cache miss so the
+    // caller re-walks. The counter is updated in setStaticExportCachedResult.
+    if (cached.attempts < STATIC_EXPORT_MAX_NULL_ATTEMPTS) {
+      return undefined;
+    }
     return null;
   }
 
@@ -404,6 +417,7 @@ const setStaticExportCachedResult = (
     return;
   }
 
+  const cache = staticExportResultCache(action);
   const cacheKey = staticExportCacheKey(
     action,
     filename,
@@ -411,7 +425,10 @@ const setStaticExportCachedResult = (
     codeHash
   );
   if (!result) {
-    staticExportResultCache(action).set(cacheKey, { result: null });
+    const existing = cache.get(cacheKey);
+    const attempts =
+      existing && existing.result === null ? existing.attempts + 1 : 1;
+    cache.set(cacheKey, { attempts, result: null });
     return;
   }
 
@@ -423,7 +440,7 @@ const setStaticExportCachedResult = (
     return;
   }
 
-  staticExportResultCache(action).set(cacheKey, {
+  cache.set(cacheKey, {
     dependencyHashes,
     result,
   });

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -2608,6 +2608,56 @@ const hasOnlySafeObjectAssignCallArgumentUses = (
   return hasSafeUse && !hasUnsafeUse;
 };
 
+const objectAssignAugmentationAliasExpressions = (
+  program: Program,
+  targetName: string
+): Expression[] | null => {
+  const aliases: Expression[] = [];
+  let hasUnsafeUse = false;
+
+  const visit = (node: Node): void => {
+    if (hasUnsafeUse || isFunctionBoundaryNode(node)) {
+      return;
+    }
+
+    const unwrapped = unwrapExpression(node);
+    if (unwrapped.type === 'CallExpression') {
+      if (callHasArgumentRootName(unwrapped, targetName)) {
+        if (
+          isSafeObjectAssignAliasAugmentation(program, unwrapped, targetName)
+        ) {
+          const [, ...nextAliases] = unwrapped.arguments;
+          aliases.push(...(nextAliases as Expression[]));
+        } else {
+          hasUnsafeUse = true;
+        }
+
+        return;
+      }
+    }
+
+    getChildren(node).forEach(visit);
+  };
+
+  topLevelStatements(program).forEach(visit);
+  return !hasUnsafeUse && aliases.length > 0 ? aliases : null;
+};
+
+const objectAssignAliasExpressionsForTarget = (
+  program: Program,
+  target: Extract<ExportTarget, { kind: 'expression' }>
+): Expression[] | null => {
+  const aliases = [
+    ...(objectAssignAliasExpressions(program, target.expression) ?? []),
+    ...(target.localName
+      ? objectAssignAugmentationAliasExpressions(program, target.localName) ??
+        []
+      : []),
+  ];
+
+  return aliases.length > 0 ? aliases : null;
+};
+
 const resolveObjectAssignProcessorExpression = (
   program: Program,
   expr: Expression
@@ -3915,9 +3965,9 @@ function* resolveProcessorStaticExport(
     return null;
   }
 
-  const processorObjectAssignAliases = objectAssignAliasExpressions(
+  const processorObjectAssignAliases = objectAssignAliasExpressionsForTarget(
     preevalProgram,
-    target.expression
+    target
   );
   const processorExpression = resolveObjectAssignProcessorExpression(
     preevalProgram,
@@ -4121,9 +4171,9 @@ function* resolveObjectAssignStaticExport(
   stack: Set<string>,
   memo: Map<string, StaticExportResult | null>
 ): SyncScenarioFor<StaticExportResult | null> {
-  const objectAssignAliases = objectAssignAliasExpressions(
+  const objectAssignAliases = objectAssignAliasExpressionsForTarget(
     program,
-    target.expression
+    target
   );
   const objectAssignTarget = objectAssignTargetExpression(
     program,

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -571,6 +571,18 @@ const unwrapExpression = (expr: Node): Node => {
   }
 };
 
+const isProcessEnvMember = (node: Node): boolean => {
+  if (node.type !== 'MemberExpression' || node.computed) {
+    return false;
+  }
+
+  if (node.property.type !== 'Identifier' || node.property.name !== 'env') {
+    return false;
+  }
+
+  return node.object.type === 'Identifier' && node.object.name === 'process';
+};
+
 const isSafeLiteral = (
   node: Node
 ): node is Node & {
@@ -1873,6 +1885,12 @@ const collectStaticExpressionReferences = (
   }
 
   if (unwrapped.type === 'MemberExpression') {
+    if (isProcessEnvMember(unwrapped) || isProcessEnvMember(unwrapped.object)) {
+      // process.env / process.env.X is an opaque build-time global —
+      // don't treat `process` as an unresolved local reference.
+      return true;
+    }
+
     return (
       collectStaticExpressionReferences(
         unwrapped.object,

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -2,6 +2,7 @@
 
 import { isAbsolute, relative } from 'path';
 
+import { isFeatureEnabled, type FeatureFlag } from '@wyw-in-js/shared';
 import type {
   ExportNamedDeclaration,
   ExportSpecifier,
@@ -44,6 +45,7 @@ type ExportTarget =
   | {
       expression: Expression;
       kind: 'expression';
+      localName?: string;
     }
   | {
       imported: 'default' | string;
@@ -56,6 +58,10 @@ type StaticExportResult = {
   value: unknown;
 };
 
+type StaticImportValueFeatures = {
+  staticImportValues?: FeatureFlag;
+};
+
 const isInsideRoot = (filename: string, root: string): boolean => {
   const relativePath = relative(root, filename);
   return (
@@ -63,6 +69,25 @@ const isInsideRoot = (filename: string, root: string): boolean => {
     (!!relativePath &&
       !relativePath.startsWith('..') &&
       !isAbsolute(relativePath))
+  );
+};
+
+const isEnvDisabled = (value: string): boolean =>
+  value === '0' || value === 'false' || value === 'no' || value === 'off';
+
+const isStaticImportValuesEnabled = (
+  action: ITransformAction,
+  filename: string
+): boolean => {
+  const envValue = process.env.WYW_STATIC_IMPORT_VALUES?.trim().toLowerCase();
+  if (envValue) {
+    return !isEnvDisabled(envValue);
+  }
+
+  return isFeatureEnabled(
+    action.services.options.pluginOptions.features as StaticImportValueFeatures,
+    'staticImportValues',
+    filename
   );
 };
 
@@ -92,7 +117,12 @@ const unwrapExpression = (expr: Node): Node => {
   }
 };
 
-const isSafeLiteral = (node: Node): boolean => {
+const isSafeLiteral = (
+  node: Node
+): node is Node & {
+  type: 'Literal';
+  value: boolean | null | number | string;
+} => {
   if (node.type !== 'Literal') {
     return false;
   }
@@ -254,80 +284,8 @@ const collectImportBindings = (
   return result;
 };
 
-const isSafeVariableDeclaration = (statement: VariableDeclaration): boolean =>
-  statement.kind === 'const' &&
-  statement.declarations.every(
-    (declarator) => declarator.init && isSafeStaticExpression(declarator.init)
-  );
-
 const isTypeOnlyExport = (statement: ExportNamedDeclaration): boolean =>
   statement.exportKind === 'type';
-
-const isSafeStaticStatement = (statement: Node): boolean => {
-  if (statement.type.startsWith('TS') || statement.type.startsWith('JSDoc')) {
-    return statement.type !== 'TSEnumDeclaration';
-  }
-
-  if (statement.type === 'EmptyStatement') {
-    return true;
-  }
-
-  if (statement.type === 'FunctionDeclaration') {
-    return true;
-  }
-
-  if (statement.type === 'ImportDeclaration') {
-    return (
-      isTypeOnlyImport(statement) ||
-      (statement.specifiers.length > 0 &&
-        statement.specifiers.every(
-          (specifier) => specifier.type !== 'ImportNamespaceSpecifier'
-        ))
-    );
-  }
-
-  if (statement.type === 'VariableDeclaration') {
-    return isSafeVariableDeclaration(statement);
-  }
-
-  if (statement.type === 'ExportNamedDeclaration') {
-    if (isTypeOnlyExport(statement)) {
-      return true;
-    }
-
-    if (statement.source) {
-      return statement.specifiers.every(
-        (specifier) => specifier.type === 'ExportSpecifier'
-      );
-    }
-
-    if (!statement.declaration) {
-      return true;
-    }
-
-    return (
-      statement.declaration.type === 'FunctionDeclaration' ||
-      (statement.declaration.type === 'VariableDeclaration' &&
-        isSafeVariableDeclaration(statement.declaration))
-    );
-  }
-
-  if (statement.type === 'ExportDefaultDeclaration') {
-    return (
-      statement.declaration.type === 'FunctionDeclaration' ||
-      isSafeStaticExpression(statement.declaration)
-    );
-  }
-
-  if (statement.type === 'ExpressionStatement') {
-    return isSafeLiteral(statement.expression);
-  }
-
-  return false;
-};
-
-const isSafeStaticProgram = (program: Program): boolean =>
-  program.body.every((statement) => isSafeStaticStatement(statement));
 
 const collectProcessorImportLocals = (
   action: ITransformAction,
@@ -593,6 +551,553 @@ const collectLocalConstExpressions = (
   return result;
 };
 
+type StaticExpressionDependencies = {
+  imports: ImportBinding[];
+};
+
+const mutatingMethodNames = new Set([
+  'add',
+  'clear',
+  'copyWithin',
+  'delete',
+  'fill',
+  'pop',
+  'push',
+  'reverse',
+  'set',
+  'shift',
+  'sort',
+  'splice',
+  'unshift',
+]);
+
+const rootIdentifierName = (expr: Node): string | null => {
+  const unwrapped = unwrapExpression(expr);
+
+  if (unwrapped.type === 'Identifier') {
+    return unwrapped.name;
+  }
+
+  if (unwrapped.type === 'MemberExpression') {
+    return rootIdentifierName(unwrapped.object);
+  }
+
+  if (unwrapped.type === 'ChainExpression') {
+    return rootIdentifierName(unwrapped.expression);
+  }
+
+  return null;
+};
+
+const staticMemberName = (expr: Node): string | null => {
+  const unwrapped = unwrapExpression(expr);
+
+  if (unwrapped.type === 'Identifier') {
+    return unwrapped.name;
+  }
+
+  if (isSafeLiteral(unwrapped) && typeof unwrapped.value === 'string') {
+    return unwrapped.value;
+  }
+
+  return null;
+};
+
+const expressionMayProduceMutableValue = (
+  expr: Node,
+  locals: Map<string, Expression>,
+  visiting: Set<string>
+): boolean => {
+  const unwrapped = unwrapExpression(expr);
+
+  if (
+    unwrapped.type === 'ObjectExpression' ||
+    unwrapped.type === 'ArrayExpression'
+  ) {
+    return true;
+  }
+
+  if (unwrapped.type === 'Identifier') {
+    const local = locals.get(unwrapped.name);
+    if (!local || visiting.has(unwrapped.name)) {
+      return true;
+    }
+
+    visiting.add(unwrapped.name);
+    const result = expressionMayProduceMutableValue(local, locals, visiting);
+    visiting.delete(unwrapped.name);
+    return result;
+  }
+
+  if (unwrapped.type === 'ConditionalExpression') {
+    return (
+      expressionMayProduceMutableValue(
+        unwrapped.consequent,
+        locals,
+        visiting
+      ) ||
+      expressionMayProduceMutableValue(unwrapped.alternate, locals, visiting)
+    );
+  }
+
+  if (
+    unwrapped.type === 'LogicalExpression' ||
+    unwrapped.type === 'MemberExpression'
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+const collectStaticExpressionReferences = (
+  expr: Node,
+  references: Set<string>
+): boolean => {
+  const unwrapped = unwrapExpression(expr);
+
+  if (isSafeLiteral(unwrapped)) {
+    return true;
+  }
+
+  if (unwrapped.type === 'Identifier') {
+    references.add(unwrapped.name);
+    return true;
+  }
+
+  if (unwrapped.type === 'TemplateLiteral') {
+    return unwrapped.expressions.every((item) =>
+      collectStaticExpressionReferences(item, references)
+    );
+  }
+
+  if (unwrapped.type === 'UnaryExpression') {
+    return collectStaticExpressionReferences(unwrapped.argument, references);
+  }
+
+  if (
+    unwrapped.type === 'BinaryExpression' ||
+    unwrapped.type === 'LogicalExpression'
+  ) {
+    return (
+      collectStaticExpressionReferences(unwrapped.left, references) &&
+      collectStaticExpressionReferences(unwrapped.right, references)
+    );
+  }
+
+  if (unwrapped.type === 'ConditionalExpression') {
+    return (
+      collectStaticExpressionReferences(unwrapped.test, references) &&
+      collectStaticExpressionReferences(unwrapped.consequent, references) &&
+      collectStaticExpressionReferences(unwrapped.alternate, references)
+    );
+  }
+
+  if (unwrapped.type === 'MemberExpression') {
+    return (
+      collectStaticExpressionReferences(unwrapped.object, references) &&
+      (!unwrapped.computed ||
+        collectStaticExpressionReferences(unwrapped.property, references))
+    );
+  }
+
+  if (unwrapped.type === 'ArrayExpression') {
+    return unwrapped.elements.every((item) => {
+      if (!item) {
+        return false;
+      }
+
+      return item.type === 'SpreadElement'
+        ? collectStaticExpressionReferences(item.argument, references)
+        : collectStaticExpressionReferences(item, references);
+    });
+  }
+
+  if (unwrapped.type === 'ObjectExpression') {
+    return unwrapped.properties.every((property) => {
+      if (property.type === 'SpreadElement') {
+        return collectStaticExpressionReferences(property.argument, references);
+      }
+
+      const propertyNode = property as AnyNode;
+      if (
+        propertyNode.computed ||
+        !propertyNode.value ||
+        typeof propertyNode.value !== 'object'
+      ) {
+        return false;
+      }
+
+      return collectStaticExpressionReferences(
+        propertyNode.value as Node,
+        references
+      );
+    });
+  }
+
+  return false;
+};
+
+const collectExpressionMutationHints = (
+  expr: Node,
+  mutatedNames: Set<string>,
+  callArgumentNames: Set<string>
+): void => {
+  const unwrapped = unwrapExpression(expr);
+
+  if (unwrapped.type === 'AssignmentExpression') {
+    const rootName = rootIdentifierName(unwrapped.left);
+    if (rootName) {
+      mutatedNames.add(rootName);
+    }
+
+    collectExpressionMutationHints(
+      unwrapped.right,
+      mutatedNames,
+      callArgumentNames
+    );
+    return;
+  }
+
+  if (unwrapped.type === 'UpdateExpression') {
+    const rootName = rootIdentifierName(unwrapped.argument);
+    if (rootName) {
+      mutatedNames.add(rootName);
+    }
+
+    return;
+  }
+
+  if (unwrapped.type === 'UnaryExpression') {
+    if (unwrapped.operator === 'delete') {
+      const rootName = rootIdentifierName(unwrapped.argument);
+      if (rootName) {
+        mutatedNames.add(rootName);
+      }
+    }
+
+    collectExpressionMutationHints(
+      unwrapped.argument,
+      mutatedNames,
+      callArgumentNames
+    );
+    return;
+  }
+
+  if (unwrapped.type === 'CallExpression') {
+    const callee = unwrapExpression(unwrapped.callee);
+    if (callee.type === 'MemberExpression') {
+      const methodName = staticMemberName(callee.property);
+      const rootName = rootIdentifierName(callee.object);
+      if (rootName && methodName && mutatingMethodNames.has(methodName)) {
+        mutatedNames.add(rootName);
+      }
+
+      collectExpressionMutationHints(
+        callee.object,
+        mutatedNames,
+        callArgumentNames
+      );
+      if (callee.computed) {
+        collectExpressionMutationHints(
+          callee.property,
+          mutatedNames,
+          callArgumentNames
+        );
+      }
+    } else {
+      collectExpressionMutationHints(
+        unwrapped.callee,
+        mutatedNames,
+        callArgumentNames
+      );
+    }
+
+    unwrapped.arguments.forEach((argument) => {
+      const argumentNode =
+        argument.type === 'SpreadElement' ? argument.argument : argument;
+      const rootName = rootIdentifierName(argumentNode);
+      if (rootName) {
+        callArgumentNames.add(rootName);
+      }
+
+      collectExpressionMutationHints(
+        argumentNode,
+        mutatedNames,
+        callArgumentNames
+      );
+    });
+    return;
+  }
+
+  if (unwrapped.type === 'TaggedTemplateExpression') {
+    collectExpressionMutationHints(
+      unwrapped.tag,
+      mutatedNames,
+      callArgumentNames
+    );
+    unwrapped.quasi.expressions.forEach((item) =>
+      collectExpressionMutationHints(item, mutatedNames, callArgumentNames)
+    );
+    return;
+  }
+
+  if (unwrapped.type === 'ConditionalExpression') {
+    collectExpressionMutationHints(
+      unwrapped.test,
+      mutatedNames,
+      callArgumentNames
+    );
+    collectExpressionMutationHints(
+      unwrapped.consequent,
+      mutatedNames,
+      callArgumentNames
+    );
+    collectExpressionMutationHints(
+      unwrapped.alternate,
+      mutatedNames,
+      callArgumentNames
+    );
+    return;
+  }
+
+  if (
+    unwrapped.type === 'BinaryExpression' ||
+    unwrapped.type === 'LogicalExpression'
+  ) {
+    collectExpressionMutationHints(
+      unwrapped.left,
+      mutatedNames,
+      callArgumentNames
+    );
+    collectExpressionMutationHints(
+      unwrapped.right,
+      mutatedNames,
+      callArgumentNames
+    );
+    return;
+  }
+
+  if (unwrapped.type === 'MemberExpression') {
+    collectExpressionMutationHints(
+      unwrapped.object,
+      mutatedNames,
+      callArgumentNames
+    );
+    if (unwrapped.computed) {
+      collectExpressionMutationHints(
+        unwrapped.property,
+        mutatedNames,
+        callArgumentNames
+      );
+    }
+    return;
+  }
+
+  if (unwrapped.type === 'ArrayExpression') {
+    unwrapped.elements.forEach((item) => {
+      if (!item) {
+        return;
+      }
+
+      collectExpressionMutationHints(
+        item.type === 'SpreadElement' ? item.argument : item,
+        mutatedNames,
+        callArgumentNames
+      );
+    });
+    return;
+  }
+
+  if (unwrapped.type === 'ObjectExpression') {
+    unwrapped.properties.forEach((property) => {
+      if (property.type === 'SpreadElement') {
+        collectExpressionMutationHints(
+          property.argument,
+          mutatedNames,
+          callArgumentNames
+        );
+        return;
+      }
+
+      const propertyNode = property as AnyNode;
+      if (propertyNode.computed && propertyNode.key) {
+        collectExpressionMutationHints(
+          propertyNode.key as Node,
+          mutatedNames,
+          callArgumentNames
+        );
+      }
+
+      if (propertyNode.value && typeof propertyNode.value === 'object') {
+        collectExpressionMutationHints(
+          propertyNode.value as Node,
+          mutatedNames,
+          callArgumentNames
+        );
+      }
+    });
+  }
+};
+
+const collectTopLevelMutationHints = (
+  program: Program
+): { callArgumentNames: Set<string>; mutatedNames: Set<string> } => {
+  const callArgumentNames = new Set<string>();
+  const mutatedNames = new Set<string>();
+
+  const collectDeclaration = (declaration: VariableDeclaration): void => {
+    declaration.declarations.forEach((declarator) => {
+      if (declarator.init) {
+        collectExpressionMutationHints(
+          declarator.init,
+          mutatedNames,
+          callArgumentNames
+        );
+      }
+    });
+  };
+
+  program.body.forEach((statement) => {
+    if (statement.type === 'VariableDeclaration') {
+      collectDeclaration(statement);
+      return;
+    }
+
+    if (statement.type === 'ExpressionStatement') {
+      collectExpressionMutationHints(
+        statement.expression,
+        mutatedNames,
+        callArgumentNames
+      );
+      return;
+    }
+
+    if (statement.type === 'ExportNamedDeclaration') {
+      if (statement.declaration?.type === 'VariableDeclaration') {
+        collectDeclaration(statement.declaration);
+      }
+
+      return;
+    }
+
+    if (statement.type === 'ExportDefaultDeclaration') {
+      if (
+        statement.declaration.type !== 'FunctionDeclaration' &&
+        statement.declaration.type !== 'ClassDeclaration'
+      ) {
+        collectExpressionMutationHints(
+          statement.declaration,
+          mutatedNames,
+          callArgumentNames
+        );
+      }
+    }
+  });
+
+  return { callArgumentNames, mutatedNames };
+};
+
+const collectStaticExpressionDependencies = (
+  program: Program,
+  target: Extract<ExportTarget, { kind: 'expression' }>
+): StaticExpressionDependencies | null => {
+  const imports = collectImportBindings(program);
+  const locals = collectLocalConstExpressions(program);
+  const collectedImports = new Map<string, ImportBinding>();
+  const referencedNames = new Set<string>();
+  const mutableReferencedNames = new Set<string>();
+  const visitedLocals = new Set<string>();
+  const visitingLocals = new Set<string>();
+
+  const markMutable = (name: string, expression: Node): void => {
+    if (expressionMayProduceMutableValue(expression, locals, new Set())) {
+      mutableReferencedNames.add(name);
+    }
+  };
+
+  const collectLocal = (name: string): boolean => {
+    const expression = locals.get(name);
+    if (!expression || visitingLocals.has(name)) {
+      return false;
+    }
+
+    referencedNames.add(name);
+    markMutable(name, expression);
+
+    if (visitedLocals.has(name)) {
+      return true;
+    }
+
+    visitingLocals.add(name);
+    const result = collectExpression(expression);
+    visitingLocals.delete(name);
+
+    if (result) {
+      visitedLocals.add(name);
+    }
+
+    return result;
+  };
+
+  const collectExpression = (expr: Node): boolean => {
+    if (!isSafeStaticExpression(expr)) {
+      return false;
+    }
+
+    const references = new Set<string>();
+    if (!collectStaticExpressionReferences(expr, references)) {
+      return false;
+    }
+
+    for (const reference of references) {
+      referencedNames.add(reference);
+
+      const importBinding = imports.get(reference);
+      if (importBinding) {
+        collectedImports.set(
+          `${importBinding.source}\0${importBinding.imported}\0${importBinding.local}`,
+          importBinding
+        );
+        mutableReferencedNames.add(reference);
+        continue;
+      }
+
+      if (!collectLocal(reference)) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  if (target.localName) {
+    referencedNames.add(target.localName);
+    markMutable(target.localName, target.expression);
+  }
+
+  if (!collectExpression(target.expression)) {
+    return null;
+  }
+
+  const mutationHints = collectTopLevelMutationHints(program);
+  for (const name of referencedNames) {
+    if (mutationHints.mutatedNames.has(name)) {
+      return null;
+    }
+  }
+
+  for (const name of mutableReferencedNames) {
+    if (mutationHints.callArgumentNames.has(name)) {
+      return null;
+    }
+  }
+
+  return {
+    imports: [...collectedImports.values()],
+  };
+};
+
 const getExportSpecifierNames = (
   specifier: ExportSpecifier
 ): { exported: string; local: string } => ({
@@ -638,6 +1143,7 @@ const findExportTarget = (
             return {
               expression: declarator.init,
               kind: 'expression',
+              localName: declarator.id.name,
             };
           }
         }
@@ -669,6 +1175,7 @@ const findExportTarget = (
           return {
             expression: local,
             kind: 'expression',
+            localName: names.local,
           };
         }
       }
@@ -694,6 +1201,7 @@ const findExportTarget = (
           return {
             expression: local,
             kind: 'expression',
+            localName: declaration.name,
           };
         }
 
@@ -873,19 +1381,6 @@ function* resolveStaticExport(
 
   const { code } = loadedAndParsed;
   const program = parseProgram(code, filename);
-  if (!isSafeStaticProgram(program)) {
-    const metadataResult = resolveProcessorMetadataExport(
-      action,
-      filename,
-      code,
-      program,
-      exportedName
-    );
-    memo.set(memoKey, metadataResult);
-    stack.delete(memoKey);
-    return metadataResult;
-  }
-
   const target = findExportTarget(program, exportedName);
   if (!target) {
     memo.set(memoKey, null);
@@ -906,11 +1401,27 @@ function* resolveStaticExport(
     return resolved;
   }
 
-  const imports = collectImportBindings(program);
+  const staticDependencies = collectStaticExpressionDependencies(
+    program,
+    target
+  );
+  if (!staticDependencies) {
+    const metadataResult = resolveProcessorMetadataExport(
+      action,
+      filename,
+      code,
+      program,
+      exportedName
+    );
+    memo.set(memoKey, metadataResult);
+    stack.delete(memoKey);
+    return metadataResult;
+  }
+
   const env = new Map<string, unknown>();
   const dependencies = new Set<string>([filename]);
 
-  for (const binding of imports.values()) {
+  for (const binding of staticDependencies.imports) {
     const resolved = yield* resolveImportValue(
       action,
       filename,
@@ -1002,6 +1513,10 @@ export function* resolveStaticOxcPreevalValues(
       ? this.entrypoint.name
       : this.entrypoint.loadedAndParsed.evalConfig.filename ??
         this.entrypoint.name;
+  if (!isStaticImportValuesEnabled(this, filename)) {
+    return false;
+  }
+
   const staticValueCache =
     preevalResult.staticValueCache ?? new Map<string, unknown>();
   const staticDependencies = new Set(preevalResult.staticDependencies ?? []);

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -3541,6 +3541,287 @@ const findExportTarget = (
   return null;
 };
 
+const exportedLocalName = (
+  program: Program,
+  exportedName: string
+): string | null => {
+  for (const statement of program.body) {
+    if (statement.type === 'ExportNamedDeclaration') {
+      if (statement.source || statement.declaration) {
+        continue;
+      }
+
+      for (const specifier of statement.specifiers) {
+        if (specifier.type !== 'ExportSpecifier') {
+          continue;
+        }
+
+        const names = getExportSpecifierNames(specifier);
+        if (names.exported === exportedName) {
+          return names.local;
+        }
+      }
+    }
+
+    if (
+      exportedName === 'default' &&
+      statement.type === 'ExportDefaultDeclaration' &&
+      statement.declaration.type === 'Identifier'
+    ) {
+      return statement.declaration.name;
+    }
+  }
+
+  return null;
+};
+
+const isIdentifierNamed = (node: Node, name: string): boolean =>
+  node.type === 'Identifier' && node.name === name;
+
+const enumLiteralValue = (node: Node): number | string | null => {
+  const unwrapped = unwrapExpression(node);
+  if (unwrapped.type === 'Literal') {
+    const { value } = unwrapped;
+    return typeof value === 'string' || typeof value === 'number'
+      ? value
+      : null;
+  }
+
+  if (unwrapped.type === 'UnaryExpression') {
+    const argument = unwrapExpression(unwrapped.argument);
+    if (
+      (unwrapped.operator === '-' || unwrapped.operator === '+') &&
+      argument.type === 'Literal' &&
+      typeof argument.value === 'number'
+    ) {
+      return unwrapped.operator === '-' ? -argument.value : argument.value;
+    }
+  }
+
+  return null;
+};
+
+const enumMemberKey = (node: Node, computed: boolean): string | null => {
+  const unwrapped = unwrapExpression(node);
+  if (!computed && unwrapped.type === 'Identifier') {
+    return unwrapped.name;
+  }
+
+  const value = enumLiteralValue(unwrapped);
+  return typeof value === 'string' || typeof value === 'number'
+    ? String(value)
+    : null;
+};
+
+const enumSimpleAssignment = (
+  node: Node,
+  enumParamName: string
+): { key: string; value: number | string } | null => {
+  const unwrapped = unwrapExpression(node);
+  if (unwrapped.type !== 'AssignmentExpression' || unwrapped.operator !== '=') {
+    return null;
+  }
+
+  const left = unwrapExpression(unwrapped.left);
+  if (
+    left.type !== 'MemberExpression' ||
+    !isIdentifierNamed(unwrapExpression(left.object), enumParamName)
+  ) {
+    return null;
+  }
+
+  const key = enumMemberKey(left.property, left.computed);
+  const value = enumLiteralValue(unwrapped.right);
+  return key !== null && value !== null ? { key, value } : null;
+};
+
+const collectEnumIifeAssignments = (
+  call: Node,
+  localName: string
+): Record<string, number | string> | null => {
+  const unwrapped = unwrapExpression(
+    call.type === 'ExpressionStatement' ? call.expression : call
+  );
+  if (unwrapped.type !== 'CallExpression' || unwrapped.arguments.length !== 1) {
+    return null;
+  }
+
+  const callee = unwrapExpression(unwrapped.callee);
+  if (
+    callee.type !== 'FunctionExpression' ||
+    callee.async ||
+    !callee.body ||
+    callee.params.length !== 1 ||
+    callee.params[0]?.type !== 'Identifier'
+  ) {
+    return null;
+  }
+
+  const enumParamName = callee.params[0].name;
+  const argument = unwrapExpression(unwrapped.arguments[0]);
+  if (argument.type !== 'LogicalExpression' || argument.operator !== '||') {
+    return null;
+  }
+
+  const fallback = unwrapExpression(argument.right);
+  if (
+    !isIdentifierNamed(unwrapExpression(argument.left), localName) ||
+    fallback.type !== 'AssignmentExpression' ||
+    fallback.operator !== '=' ||
+    !isIdentifierNamed(unwrapExpression(fallback.left), localName) ||
+    unwrapExpression(fallback.right).type !== 'ObjectExpression'
+  ) {
+    return null;
+  }
+
+  const result: Record<string, number | string> = {};
+  for (const statement of callee.body.body) {
+    if (statement.type !== 'ExpressionStatement') {
+      return null;
+    }
+
+    const expression = unwrapExpression(statement.expression);
+    if (
+      expression.type !== 'AssignmentExpression' ||
+      expression.operator !== '='
+    ) {
+      return null;
+    }
+
+    const left = unwrapExpression(expression.left);
+    if (
+      left.type === 'MemberExpression' &&
+      isIdentifierNamed(unwrapExpression(left.object), enumParamName)
+    ) {
+      const numericEnumAssignment = enumSimpleAssignment(
+        left.property,
+        enumParamName
+      );
+      const reverseValue = enumLiteralValue(expression.right);
+      if (
+        numericEnumAssignment &&
+        typeof numericEnumAssignment.value === 'number' &&
+        typeof reverseValue === 'string'
+      ) {
+        result[numericEnumAssignment.key] = numericEnumAssignment.value;
+        result[String(numericEnumAssignment.value)] = reverseValue;
+        continue;
+      }
+    }
+
+    const assignment = enumSimpleAssignment(expression, enumParamName);
+    if (!assignment) {
+      return null;
+    }
+
+    result[assignment.key] = assignment.value;
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+};
+
+const enumIifeLocalName = (statement: Node): string | null => {
+  if (statement.type !== 'ExpressionStatement') {
+    return null;
+  }
+
+  const expression = unwrapExpression(statement.expression);
+  if (
+    expression.type !== 'CallExpression' ||
+    expression.arguments.length !== 1
+  ) {
+    return null;
+  }
+
+  const argument = unwrapExpression(expression.arguments[0]);
+  if (argument.type !== 'LogicalExpression' || argument.operator !== '||') {
+    return null;
+  }
+
+  const fallback = unwrapExpression(argument.right);
+  if (
+    argument.left.type !== 'Identifier' ||
+    fallback.type !== 'AssignmentExpression' ||
+    fallback.left.type !== 'Identifier'
+  ) {
+    return null;
+  }
+
+  return argument.left.name === fallback.left.name ? argument.left.name : null;
+};
+
+const isEnumVarDeclaration = (
+  statement: Node
+): statement is VariableDeclaration =>
+  statement.type === 'VariableDeclaration' &&
+  statement.kind === 'var' &&
+  statement.declarations.length > 0 &&
+  statement.declarations.every(
+    (declarator) =>
+      declarator.id.type === 'Identifier' && declarator.init === null
+  );
+
+const isTypeScriptEnumOnlyModule = (program: Program): boolean =>
+  program.body.every((statement) => {
+    if (isEnumVarDeclaration(statement)) {
+      return true;
+    }
+
+    const localName = enumIifeLocalName(statement);
+    if (localName) {
+      return collectEnumIifeAssignments(statement, localName) !== null;
+    }
+
+    if (statement.type === 'ExportDefaultDeclaration') {
+      return statement.declaration.type === 'Identifier';
+    }
+
+    return (
+      statement.type === 'ExportNamedDeclaration' &&
+      !statement.source &&
+      !statement.declaration &&
+      statement.specifiers.every(
+        (specifier) => specifier.type === 'ExportSpecifier'
+      )
+    );
+  });
+
+const typeScriptEnumStaticExportValue = (
+  program: Program,
+  exportedName: string
+): Record<string, number | string> | null => {
+  if (!isTypeScriptEnumOnlyModule(program)) {
+    return null;
+  }
+
+  const localName = exportedLocalName(program, exportedName);
+  if (!localName) {
+    return null;
+  }
+
+  const hasDeclaration = program.body.some(
+    (statement) =>
+      isEnumVarDeclaration(statement) &&
+      statement.declarations.some(
+        (declarator) =>
+          declarator.id.type === 'Identifier' &&
+          declarator.id.name === localName
+      )
+  );
+  if (!hasDeclaration) {
+    return null;
+  }
+
+  for (const statement of program.body) {
+    const enumValue = collectEnumIifeAssignments(statement, localName);
+    if (enumValue) {
+      return enumValue;
+    }
+  }
+
+  return null;
+};
+
 function* resolveDependency(
   action: ITransformAction,
   importer: string,
@@ -4478,6 +4759,21 @@ function* resolveStaticExport(
     memo.set(memoKey, cachedResult);
     stack.delete(memoKey);
     return cachedResult;
+  }
+
+  const enumValue = typeScriptEnumStaticExportValue(program, exportedName);
+  if (enumValue) {
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'export',
+      reason: 'typescript-enum',
+      status: 'resolved',
+    });
+    return finish({
+      dependencies: [filename],
+      value: enumValue,
+    });
   }
 
   const target = findExportTarget(program, exportedName);

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -1,0 +1,726 @@
+/* eslint-disable no-restricted-syntax,no-continue,@typescript-eslint/no-use-before-define */
+
+import type {
+  ExportNamedDeclaration,
+  ExportSpecifier,
+  Expression,
+  ImportDeclaration,
+  ImportSpecifier,
+  ModuleExportName,
+  Node,
+  Program,
+  VariableDeclaration,
+} from 'oxc-parser';
+
+import { oxcShaker } from '../../shaker';
+import {
+  evaluateOxcStaticExpression,
+  evaluateOxcStaticExpressionAt,
+  isOxcStaticSerializableValue,
+  type OxcStaticValueCandidate,
+} from '../../utils/collectOxcTemplateDependencies';
+import { appendOxcWywPreval } from '../../utils/oxcPreevalStage';
+import { parseOxcProgramCached } from '../../utils/parseOxc';
+import { Entrypoint } from '../Entrypoint';
+import type { IEntrypointDependency } from '../Entrypoint.types';
+import type { ITransformAction, SyncScenarioFor } from '../types';
+
+type AnyNode = Node & Record<string, unknown>;
+
+type ImportBinding = {
+  imported: 'default' | string;
+  local: string;
+  source: string;
+};
+
+type ExportTarget =
+  | {
+      expression: Expression;
+      kind: 'expression';
+    }
+  | {
+      imported: 'default' | string;
+      kind: 'import';
+      source: string;
+    };
+
+type StaticExportResult = {
+  dependencies: string[];
+  value: unknown;
+};
+
+const parseProgram = (code: string, filename: string): Program =>
+  parseOxcProgramCached(filename, code, 'unambiguous');
+
+const moduleExportName = (node: ModuleExportName): string =>
+  node.type === 'Literal' ? String(node.value) : node.name;
+
+const unwrapExpression = (expr: Node): Node => {
+  let current = expr;
+
+  for (;;) {
+    if (
+      current.type === 'TSAsExpression' ||
+      current.type === 'TSSatisfiesExpression' ||
+      current.type === 'TSNonNullExpression' ||
+      current.type === 'TSInstantiationExpression' ||
+      current.type === 'TSTypeAssertion' ||
+      current.type === 'ParenthesizedExpression'
+    ) {
+      current = current.expression;
+      continue;
+    }
+
+    return current;
+  }
+};
+
+const isSafeLiteral = (node: Node): boolean => {
+  if (node.type !== 'Literal') {
+    return false;
+  }
+
+  const { value } = node as AnyNode;
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+};
+
+const isSafeStaticExpression = (expr: Node): boolean => {
+  const unwrapped = unwrapExpression(expr);
+
+  if (isSafeLiteral(unwrapped)) {
+    return true;
+  }
+
+  if (unwrapped.type === 'Identifier') {
+    return true;
+  }
+
+  if (unwrapped.type === 'TemplateLiteral') {
+    return unwrapped.expressions.every((item) => isSafeStaticExpression(item));
+  }
+
+  if (unwrapped.type === 'UnaryExpression') {
+    return isSafeStaticExpression(unwrapped.argument);
+  }
+
+  if (
+    unwrapped.type === 'BinaryExpression' ||
+    unwrapped.type === 'LogicalExpression'
+  ) {
+    return (
+      isSafeStaticExpression(unwrapped.left) &&
+      isSafeStaticExpression(unwrapped.right)
+    );
+  }
+
+  if (unwrapped.type === 'ConditionalExpression') {
+    return (
+      isSafeStaticExpression(unwrapped.test) &&
+      isSafeStaticExpression(unwrapped.consequent) &&
+      isSafeStaticExpression(unwrapped.alternate)
+    );
+  }
+
+  if (unwrapped.type === 'MemberExpression') {
+    return (
+      isSafeStaticExpression(unwrapped.object) &&
+      (unwrapped.computed
+        ? isSafeStaticExpression(unwrapped.property)
+        : unwrapped.property.type === 'Identifier')
+    );
+  }
+
+  if (unwrapped.type === 'ArrayExpression') {
+    return unwrapped.elements.every((item) => {
+      if (!item) {
+        return false;
+      }
+
+      return item.type === 'SpreadElement'
+        ? isSafeStaticExpression(item.argument)
+        : isSafeStaticExpression(item);
+    });
+  }
+
+  if (unwrapped.type === 'ObjectExpression') {
+    return unwrapped.properties.every((property) => {
+      if (property.type === 'SpreadElement') {
+        return isSafeStaticExpression(property.argument);
+      }
+
+      const propertyNode = property as AnyNode;
+      if (propertyNode.computed || propertyNode.method) {
+        return false;
+      }
+
+      return (
+        propertyNode.value &&
+        typeof propertyNode.value === 'object' &&
+        isSafeStaticExpression(propertyNode.value as Node)
+      );
+    });
+  }
+
+  return false;
+};
+
+const isTypeOnlyImport = (statement: ImportDeclaration): boolean => {
+  if (statement.importKind === 'type') {
+    return true;
+  }
+
+  return statement.specifiers.every(
+    (specifier) =>
+      specifier.type === 'ImportSpecifier' &&
+      (specifier as ImportSpecifier).importKind === 'type'
+  );
+};
+
+const getImportBinding = (
+  statement: ImportDeclaration,
+  specifier: ImportDeclaration['specifiers'][number]
+): ImportBinding | null => {
+  const local = specifier.local?.name;
+  if (!local) {
+    return null;
+  }
+
+  if (specifier.type === 'ImportDefaultSpecifier') {
+    return {
+      imported: 'default',
+      local,
+      source: statement.source.value,
+    };
+  }
+
+  if (specifier.type !== 'ImportSpecifier') {
+    return null;
+  }
+
+  if (
+    statement.importKind === 'type' ||
+    (specifier as ImportSpecifier).importKind === 'type'
+  ) {
+    return null;
+  }
+
+  return {
+    imported: moduleExportName((specifier as ImportSpecifier).imported),
+    local,
+    source: statement.source.value,
+  };
+};
+
+const collectImportBindings = (
+  program: Program
+): Map<string, ImportBinding> => {
+  const result = new Map<string, ImportBinding>();
+
+  program.body.forEach((statement) => {
+    if (statement.type !== 'ImportDeclaration' || isTypeOnlyImport(statement)) {
+      return;
+    }
+
+    statement.specifiers.forEach((specifier) => {
+      const binding = getImportBinding(statement, specifier);
+      if (binding) {
+        result.set(binding.local, binding);
+      }
+    });
+  });
+
+  return result;
+};
+
+const isSafeVariableDeclaration = (statement: VariableDeclaration): boolean =>
+  statement.kind === 'const' &&
+  statement.declarations.every(
+    (declarator) => declarator.init && isSafeStaticExpression(declarator.init)
+  );
+
+const isTypeOnlyExport = (statement: ExportNamedDeclaration): boolean =>
+  statement.exportKind === 'type';
+
+const isSafeStaticStatement = (statement: Node): boolean => {
+  if (statement.type.startsWith('TS') || statement.type.startsWith('JSDoc')) {
+    return statement.type !== 'TSEnumDeclaration';
+  }
+
+  if (statement.type === 'EmptyStatement') {
+    return true;
+  }
+
+  if (statement.type === 'ImportDeclaration') {
+    return (
+      isTypeOnlyImport(statement) ||
+      (statement.specifiers.length > 0 &&
+        statement.specifiers.every(
+          (specifier) => specifier.type !== 'ImportNamespaceSpecifier'
+        ))
+    );
+  }
+
+  if (statement.type === 'VariableDeclaration') {
+    return isSafeVariableDeclaration(statement);
+  }
+
+  if (statement.type === 'ExportNamedDeclaration') {
+    if (isTypeOnlyExport(statement)) {
+      return true;
+    }
+
+    if (statement.source) {
+      return statement.specifiers.every(
+        (specifier) => specifier.type === 'ExportSpecifier'
+      );
+    }
+
+    if (!statement.declaration) {
+      return true;
+    }
+
+    return (
+      statement.declaration.type === 'VariableDeclaration' &&
+      isSafeVariableDeclaration(statement.declaration)
+    );
+  }
+
+  if (statement.type === 'ExportDefaultDeclaration') {
+    return isSafeStaticExpression(statement.declaration);
+  }
+
+  if (statement.type === 'ExpressionStatement') {
+    return isSafeLiteral(statement.expression);
+  }
+
+  return false;
+};
+
+const isSafeStaticProgram = (program: Program): boolean =>
+  program.body.every((statement) => isSafeStaticStatement(statement));
+
+const collectLocalConstExpressions = (
+  program: Program
+): Map<string, Expression> => {
+  const result = new Map<string, Expression>();
+
+  const collect = (declaration: VariableDeclaration): void => {
+    if (declaration.kind !== 'const') {
+      return;
+    }
+
+    declaration.declarations.forEach((declarator) => {
+      if (declarator.id.type === 'Identifier' && declarator.init) {
+        result.set(declarator.id.name, declarator.init);
+      }
+    });
+  };
+
+  program.body.forEach((statement) => {
+    if (statement.type === 'VariableDeclaration') {
+      collect(statement);
+      return;
+    }
+
+    if (
+      statement.type === 'ExportNamedDeclaration' &&
+      statement.declaration?.type === 'VariableDeclaration'
+    ) {
+      collect(statement.declaration);
+    }
+  });
+
+  return result;
+};
+
+const getExportSpecifierNames = (
+  specifier: ExportSpecifier
+): { exported: string; local: string } => ({
+  exported: moduleExportName(specifier.exported),
+  local: moduleExportName(specifier.local),
+});
+
+const findExportTarget = (
+  program: Program,
+  exportedName: string
+): ExportTarget | null => {
+  const imports = collectImportBindings(program);
+  const locals = collectLocalConstExpressions(program);
+
+  for (const statement of program.body) {
+    if (statement.type === 'ExportNamedDeclaration') {
+      if (statement.source) {
+        for (const specifier of statement.specifiers) {
+          if (specifier.type !== 'ExportSpecifier') {
+            continue;
+          }
+
+          const names = getExportSpecifierNames(specifier);
+          if (names.exported === exportedName) {
+            return {
+              imported: names.local,
+              kind: 'import',
+              source: statement.source.value,
+            };
+          }
+        }
+
+        continue;
+      }
+
+      if (statement.declaration?.type === 'VariableDeclaration') {
+        for (const declarator of statement.declaration.declarations) {
+          if (
+            declarator.id.type === 'Identifier' &&
+            declarator.id.name === exportedName &&
+            declarator.init
+          ) {
+            return {
+              expression: declarator.init,
+              kind: 'expression',
+            };
+          }
+        }
+
+        continue;
+      }
+
+      for (const specifier of statement.specifiers) {
+        if (specifier.type !== 'ExportSpecifier') {
+          continue;
+        }
+
+        const names = getExportSpecifierNames(specifier);
+        if (names.exported !== exportedName) {
+          continue;
+        }
+
+        const importBinding = imports.get(names.local);
+        if (importBinding) {
+          return {
+            imported: importBinding.imported,
+            kind: 'import',
+            source: importBinding.source,
+          };
+        }
+
+        const local = locals.get(names.local);
+        if (local) {
+          return {
+            expression: local,
+            kind: 'expression',
+          };
+        }
+      }
+    }
+
+    if (
+      exportedName === 'default' &&
+      statement.type === 'ExportDefaultDeclaration'
+    ) {
+      const { declaration } = statement;
+      if (declaration.type === 'Identifier') {
+        const importBinding = imports.get(declaration.name);
+        if (importBinding) {
+          return {
+            imported: importBinding.imported,
+            kind: 'import',
+            source: importBinding.source,
+          };
+        }
+
+        const local = locals.get(declaration.name);
+        if (local) {
+          return {
+            expression: local,
+            kind: 'expression',
+          };
+        }
+
+        return null;
+      }
+
+      return {
+        expression: declaration as Expression,
+        kind: 'expression',
+      };
+    }
+  }
+
+  return null;
+};
+
+function* resolveDependency(
+  action: ITransformAction,
+  importer: string,
+  source: string,
+  imported: string
+): SyncScenarioFor<IEntrypointDependency | null> {
+  const entrypoint =
+    importer === action.entrypoint.name
+      ? action.entrypoint
+      : Entrypoint.createRoot(action.services, importer, [imported], undefined);
+  const imports = new Map([[source, [imported]]]);
+  const [resolved] = yield* action.getNext('resolveImports', entrypoint, {
+    imports,
+    phase: 'initial',
+  });
+
+  return resolved ?? null;
+}
+
+function* resolveImportValue(
+  action: ITransformAction,
+  importer: string,
+  binding: Pick<ImportBinding, 'imported' | 'source'>,
+  stack: Set<string>,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<StaticExportResult | null> {
+  const dependency = yield* resolveDependency(
+    action,
+    importer,
+    binding.source,
+    binding.imported
+  );
+  if (!dependency?.resolved) {
+    return null;
+  }
+
+  const resolved = yield* resolveStaticExport(
+    action,
+    dependency.resolved,
+    binding.imported,
+    stack,
+    memo
+  );
+  if (!resolved) {
+    return null;
+  }
+
+  return {
+    dependencies: [
+      dependency.resolved,
+      ...resolved.dependencies.filter((item) => item !== dependency.resolved),
+    ],
+    value: resolved.value,
+  };
+}
+
+function* resolveStaticExport(
+  action: ITransformAction,
+  filename: string,
+  exportedName: string,
+  stack: Set<string>,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<StaticExportResult | null> {
+  const memoKey = `${filename}\0${exportedName}`;
+  if (memo.has(memoKey)) {
+    return memo.get(memoKey) ?? null;
+  }
+
+  if (stack.has(memoKey)) {
+    memo.set(memoKey, null);
+    return null;
+  }
+
+  stack.add(memoKey);
+
+  const loadedAndParsed = action.services.loadAndParseFn(
+    action.services,
+    filename,
+    undefined,
+    action.services.log
+  );
+  if (
+    loadedAndParsed.evaluator === 'ignored' ||
+    loadedAndParsed.evaluator !== oxcShaker
+  ) {
+    memo.set(memoKey, null);
+    stack.delete(memoKey);
+    return null;
+  }
+
+  const { code } = loadedAndParsed;
+  const program = parseProgram(code, filename);
+  if (!isSafeStaticProgram(program)) {
+    memo.set(memoKey, null);
+    stack.delete(memoKey);
+    return null;
+  }
+
+  const target = findExportTarget(program, exportedName);
+  if (!target) {
+    memo.set(memoKey, null);
+    stack.delete(memoKey);
+    return null;
+  }
+
+  if (target.kind === 'import') {
+    const resolved = yield* resolveImportValue(
+      action,
+      filename,
+      target,
+      stack,
+      memo
+    );
+    memo.set(memoKey, resolved);
+    stack.delete(memoKey);
+    return resolved;
+  }
+
+  const imports = collectImportBindings(program);
+  const env = new Map<string, unknown>();
+  const dependencies = new Set<string>([filename]);
+
+  for (const binding of imports.values()) {
+    const resolved = yield* resolveImportValue(
+      action,
+      filename,
+      binding,
+      stack,
+      memo
+    );
+    if (!resolved) {
+      memo.set(memoKey, null);
+      stack.delete(memoKey);
+      return null;
+    }
+
+    env.set(binding.local, resolved.value);
+    resolved.dependencies.forEach((item) => dependencies.add(item));
+  }
+
+  const value = evaluateOxcStaticExpressionAt(
+    code,
+    filename,
+    {
+      end: target.expression.end,
+      start: target.expression.start,
+    },
+    env
+  );
+  if (!isOxcStaticSerializableValue(value)) {
+    memo.set(memoKey, null);
+    stack.delete(memoKey);
+    return null;
+  }
+
+  const result = {
+    dependencies: [...dependencies],
+    value,
+  };
+  memo.set(memoKey, result);
+  stack.delete(memoKey);
+  return result;
+}
+
+function* resolveCandidateValue(
+  action: ITransformAction,
+  candidate: OxcStaticValueCandidate,
+  filename: string,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<StaticExportResult | null> {
+  const env = new Map<string, unknown>();
+  const dependencies = new Set<string>();
+
+  for (const item of candidate.imports) {
+    const resolved = yield* resolveImportValue(
+      action,
+      filename,
+      item,
+      new Set(),
+      memo
+    );
+    if (!resolved) {
+      return null;
+    }
+
+    env.set(item.local, resolved.value);
+    resolved.dependencies.forEach((dependency) => dependencies.add(dependency));
+  }
+
+  const value = evaluateOxcStaticExpression(candidate.source, filename, env);
+  if (!isOxcStaticSerializableValue(value)) {
+    return null;
+  }
+
+  return {
+    dependencies: [...dependencies],
+    value,
+  };
+}
+
+export function* resolveStaticOxcPreevalValues(
+  this: ITransformAction
+): SyncScenarioFor<boolean> {
+  const preevalResult = this.entrypoint.getPreevalResult();
+  const candidates = preevalResult?.staticValueCandidates ?? [];
+  if (!preevalResult || candidates.length === 0) {
+    return false;
+  }
+
+  const filename =
+    this.entrypoint.loadedAndParsed.evaluator === 'ignored'
+      ? this.entrypoint.name
+      : this.entrypoint.loadedAndParsed.evalConfig.filename ??
+        this.entrypoint.name;
+  const staticValueCache =
+    preevalResult.staticValueCache ?? new Map<string, unknown>();
+  const staticDependencies = new Set(preevalResult.staticDependencies ?? []);
+  const memo = new Map<string, StaticExportResult | null>();
+  let changed = false;
+
+  for (const candidate of candidates) {
+    if (staticValueCache.has(candidate.name)) {
+      continue;
+    }
+
+    const resolved = yield* resolveCandidateValue(
+      this,
+      candidate,
+      filename,
+      memo
+    );
+    if (!resolved) {
+      continue;
+    }
+
+    staticValueCache.set(candidate.name, resolved.value);
+    resolved.dependencies.forEach((dependency) =>
+      staticDependencies.add(dependency)
+    );
+    changed = true;
+  }
+
+  if (!changed) {
+    return false;
+  }
+
+  const dependencyNames = (preevalResult.dependencyNames ?? []).filter(
+    (name) => !staticValueCache.has(name)
+  );
+  preevalResult.dependencyNames = dependencyNames;
+  preevalResult.staticValueCache = staticValueCache;
+  preevalResult.staticDependencies = [...staticDependencies];
+  preevalResult.code = appendOxcWywPreval(
+    preevalResult.baseCode ?? preevalResult.code,
+    filename,
+    dependencyNames
+  );
+
+  for (const dependency of staticDependencies) {
+    this.entrypoint.addInvalidationDependency({
+      only: ['*'],
+      resolved: dependency,
+      source: dependency,
+    });
+    this.entrypoint.markInvalidateOnDependencyChange(dependency);
+  }
+
+  return true;
+}

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -2628,6 +2628,17 @@ type ObjectAssignAliasResolution = {
   values: Record<string, unknown>[];
 };
 
+type ObjectAssignAliasPropertyResolution = {
+  dependencies: string[];
+  sideEffectDependencies: string[];
+  value: unknown;
+};
+
+type ObjectAssignAliasPropertyEntry = {
+  key: string;
+  value: Expression;
+};
+
 const mergeStaticObjectAssignAliases = (
   targetValue: unknown,
   aliasValues: Record<string, unknown>[]
@@ -2644,6 +2655,260 @@ const mergeStaticObjectAssignAliases = (
   return result;
 };
 
+const objectAssignAliasObjectExpression = (
+  program: Program,
+  alias: Expression,
+  seen: Set<string> = new Set()
+): Expression | null => {
+  const unwrapped = unwrapExpression(alias);
+  if (unwrapped.type === 'ObjectExpression') {
+    return unwrapped as Expression;
+  }
+
+  if (unwrapped.type !== 'Identifier' || seen.has(unwrapped.name)) {
+    return null;
+  }
+
+  const local = findTopLevelConstExpression(program, unwrapped.name);
+  if (!local) {
+    return null;
+  }
+
+  seen.add(unwrapped.name);
+  const result = objectAssignAliasObjectExpression(program, local, seen);
+  seen.delete(unwrapped.name);
+  return result;
+};
+
+const objectAssignAliasPropertyEntries = (
+  program: Program,
+  alias: Expression
+): ObjectAssignAliasPropertyEntry[] | null => {
+  const aliasObject = objectAssignAliasObjectExpression(program, alias);
+  if (!aliasObject || aliasObject.type !== 'ObjectExpression') {
+    return null;
+  }
+
+  const entries: ObjectAssignAliasPropertyEntry[] = [];
+  for (const property of aliasObject.properties) {
+    if (property.type === 'SpreadElement') {
+      return null;
+    }
+
+    const propertyNode = property as AnyNode;
+    if (
+      propertyNode.computed ||
+      propertyNode.method ||
+      !propertyNode.key ||
+      !propertyNode.value ||
+      typeof propertyNode.key !== 'object' ||
+      typeof propertyNode.value !== 'object'
+    ) {
+      return null;
+    }
+
+    const key = objectPropertyKeyName(propertyNode.key as Node);
+    if (!key) {
+      return null;
+    }
+
+    entries.push({
+      key,
+      value: propertyNode.value as Expression,
+    });
+  }
+
+  return entries;
+};
+
+function* resolveObjectAssignAliasExpressionValue(
+  action: ITransformAction,
+  filename: string,
+  code: string,
+  program: Program,
+  expression: Expression,
+  ignoredMutableCallArgumentNames: Set<string>,
+  stack: Set<string>,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<ObjectAssignAliasPropertyResolution | null> {
+  const staticDependencies = collectStaticExpressionDependencies(
+    program,
+    {
+      expression,
+      kind: 'expression',
+    },
+    {
+      allowMetadataCalls: true,
+      ignoredMutableCallArgumentNames,
+    }
+  );
+  if (!staticDependencies) {
+    return null;
+  }
+
+  const env = new Map<string, unknown>();
+  const dependencies = new Set<string>();
+  const sideEffectDependencies = new Set<string>();
+
+  for (const binding of staticDependencies.imports) {
+    const resolved = yield* resolveImportValue(
+      action,
+      filename,
+      binding,
+      stack,
+      memo
+    );
+    if (
+      !resolved ||
+      !bindStaticResolvedValue(env, expression, binding.local, resolved)
+    ) {
+      return null;
+    }
+
+    resolved.dependencies.forEach((item) => dependencies.add(item));
+    resolved.sideEffectDependencies?.forEach((item) =>
+      sideEffectDependencies.add(item)
+    );
+  }
+
+  const value = evaluateOxcStaticExpressionAt(
+    code,
+    filename,
+    {
+      end: expression.end,
+      start: expression.start,
+    },
+    env
+  );
+  return isStaticObjectAssignAliasValue(value)
+    ? {
+        dependencies: [...dependencies],
+        sideEffectDependencies: [...sideEffectDependencies],
+        value,
+      }
+    : null;
+}
+
+function* resolveObjectAssignAliasPropertyValue(
+  action: ITransformAction,
+  filename: string,
+  code: string,
+  program: Program,
+  expression: Expression,
+  ignoredMutableCallArgumentNames: Set<string>,
+  stack: Set<string>,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<ObjectAssignAliasPropertyResolution | null> {
+  const expressionValue = yield* resolveObjectAssignAliasExpressionValue(
+    action,
+    filename,
+    code,
+    program,
+    expression,
+    ignoredMutableCallArgumentNames,
+    stack,
+    memo
+  );
+  if (expressionValue) {
+    return expressionValue;
+  }
+
+  const unwrapped = unwrapExpression(expression);
+  if (
+    unwrapped.type !== 'Identifier' ||
+    !findExportTarget(program, unwrapped.name)
+  ) {
+    return null;
+  }
+
+  const resolved = yield* resolveStaticExport(
+    action,
+    filename,
+    unwrapped.name,
+    stack,
+    memo
+  );
+  return resolved && isStaticObjectAssignAliasValue(resolved.value)
+    ? {
+        dependencies: resolved.dependencies,
+        sideEffectDependencies: resolved.sideEffectDependencies ?? [],
+        value: resolved.value,
+      }
+    : null;
+}
+
+function* resolveObjectAssignAliasValue(
+  action: ITransformAction,
+  filename: string,
+  code: string,
+  program: Program,
+  alias: Expression,
+  ignoredMutableCallArgumentNames: Set<string>,
+  stack: Set<string>,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<{
+  dependencies: string[];
+  sideEffectDependencies: string[];
+  value: Record<string, unknown>;
+} | null> {
+  const aliasValue = yield* resolveObjectAssignAliasExpressionValue(
+    action,
+    filename,
+    code,
+    program,
+    alias,
+    ignoredMutableCallArgumentNames,
+    stack,
+    memo
+  );
+  if (aliasValue && isPlainObjectRecord(aliasValue.value)) {
+    return Object.values(aliasValue.value).every(isStaticObjectAssignAliasValue)
+      ? {
+          dependencies: aliasValue.dependencies,
+          sideEffectDependencies: aliasValue.sideEffectDependencies,
+          value: aliasValue.value,
+        }
+      : null;
+  }
+
+  const entries = objectAssignAliasPropertyEntries(program, alias);
+  if (!entries) {
+    return null;
+  }
+
+  const dependencies = new Set<string>();
+  const sideEffectDependencies = new Set<string>();
+  const value: Record<string, unknown> = {};
+
+  for (const entry of entries) {
+    const resolved = yield* resolveObjectAssignAliasPropertyValue(
+      action,
+      filename,
+      code,
+      program,
+      entry.value,
+      ignoredMutableCallArgumentNames,
+      stack,
+      memo
+    );
+    if (!resolved || !isStaticObjectAssignAliasValue(resolved.value)) {
+      return null;
+    }
+
+    value[entry.key] = resolved.value;
+    resolved.dependencies.forEach((item) => dependencies.add(item));
+    resolved.sideEffectDependencies.forEach((item) =>
+      sideEffectDependencies.add(item)
+    );
+  }
+
+  return {
+    dependencies: [...dependencies],
+    sideEffectDependencies: [...sideEffectDependencies],
+    value,
+  };
+}
+
 function* resolveObjectAssignAliasValues(
   action: ITransformAction,
   filename: string,
@@ -2653,7 +2918,6 @@ function* resolveObjectAssignAliasValues(
   stack: Set<string>,
   memo: Map<string, StaticExportResult | null>
 ): SyncScenarioFor<ObjectAssignAliasResolution | null> {
-  const env = new Map<string, unknown>();
   const dependencies = new Set<string>();
   const sideEffectDependencies = new Set<string>();
   const values: Record<string, unknown>[] = [];
@@ -2666,59 +2930,25 @@ function* resolveObjectAssignAliasValues(
   });
 
   for (const alias of aliases) {
-    const staticDependencies = collectStaticExpressionDependencies(
-      program,
-      {
-        expression: alias,
-        kind: 'expression',
-      },
-      {
-        allowMetadataCalls: true,
-        ignoredMutableCallArgumentNames,
-      }
-    );
-    if (!staticDependencies) {
-      return null;
-    }
-
-    for (const binding of staticDependencies.imports) {
-      const resolved = yield* resolveImportValue(
-        action,
-        filename,
-        binding,
-        stack,
-        memo
-      );
-      if (
-        !resolved ||
-        !bindStaticResolvedValue(env, alias, binding.local, resolved)
-      ) {
-        return null;
-      }
-
-      resolved.dependencies.forEach((item) => dependencies.add(item));
-      resolved.sideEffectDependencies?.forEach((item) =>
-        sideEffectDependencies.add(item)
-      );
-    }
-
-    const value = evaluateOxcStaticExpressionAt(
-      code,
+    const aliasValue = yield* resolveObjectAssignAliasValue(
+      action,
       filename,
-      {
-        end: alias.end,
-        start: alias.start,
-      },
-      env
+      code,
+      program,
+      alias,
+      ignoredMutableCallArgumentNames,
+      stack,
+      memo
     );
-    if (
-      !isPlainObjectRecord(value) ||
-      !Object.values(value).every(isStaticObjectAssignAliasValue)
-    ) {
+    if (!aliasValue) {
       return null;
     }
 
-    values.push(value);
+    aliasValue.dependencies.forEach((item) => dependencies.add(item));
+    aliasValue.sideEffectDependencies.forEach((item) =>
+      sideEffectDependencies.add(item)
+    );
+    values.push(aliasValue.value);
   }
 
   return {

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -4,7 +4,6 @@ import { isAbsolute, relative } from 'path';
 
 import { isFeatureEnabled, type FeatureFlag } from '@wyw-in-js/shared';
 import type {
-  ExportNamedDeclaration,
   ExportSpecifier,
   Expression,
   ImportDeclaration,
@@ -18,6 +17,7 @@ import type {
 import { oxcShaker } from '../../shaker';
 import { collectOxcProcessorImportsFromProgram } from '../../utils/collectOxcExportsAndImports';
 import {
+  createOxcStaticCallableValue,
   evaluateOxcStaticExpression,
   evaluateOxcStaticExpressionAt,
   isOxcStaticSerializableValue,
@@ -62,6 +62,10 @@ type StaticImportValueFeatures = {
   staticImportValues?: FeatureFlag;
 };
 
+type StaticExpressionOptions = {
+  allowMetadataCalls?: boolean;
+};
+
 const isInsideRoot = (filename: string, root: string): boolean => {
   const relativePath = relative(root, filename);
   return (
@@ -93,6 +97,35 @@ const isStaticImportValuesEnabled = (
 
 const parseProgram = (code: string, filename: string): Program =>
   parseOxcProgramCached(filename, code, 'unambiguous');
+
+const getChildren = (node: Node): Node[] => {
+  const children: Node[] = [];
+  Object.entries(node as AnyNode).forEach(([key, value]) => {
+    if (
+      key === 'comments' ||
+      key === 'errors' ||
+      key === 'parent' ||
+      key === 'span'
+    ) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => {
+        if (item && typeof item === 'object' && 'type' in item) {
+          children.push(item as Node);
+        }
+      });
+      return;
+    }
+
+    if (value && typeof value === 'object' && 'type' in value) {
+      children.push(value as Node);
+    }
+  });
+
+  return children;
+};
 
 const moduleExportName = (node: ModuleExportName): string =>
   node.type === 'Literal' ? String(node.value) : node.name;
@@ -136,7 +169,10 @@ const isSafeLiteral = (
   );
 };
 
-const isSafeStaticExpression = (expr: Node): boolean => {
+const isSafeStaticExpression = (
+  expr: Node,
+  options: StaticExpressionOptions = {}
+): boolean => {
   const unwrapped = unwrapExpression(expr);
 
   if (isSafeLiteral(unwrapped)) {
@@ -148,11 +184,13 @@ const isSafeStaticExpression = (expr: Node): boolean => {
   }
 
   if (unwrapped.type === 'TemplateLiteral') {
-    return unwrapped.expressions.every((item) => isSafeStaticExpression(item));
+    return unwrapped.expressions.every((item) =>
+      isSafeStaticExpression(item, options)
+    );
   }
 
   if (unwrapped.type === 'UnaryExpression') {
-    return isSafeStaticExpression(unwrapped.argument);
+    return isSafeStaticExpression(unwrapped.argument, options);
   }
 
   if (
@@ -160,25 +198,44 @@ const isSafeStaticExpression = (expr: Node): boolean => {
     unwrapped.type === 'LogicalExpression'
   ) {
     return (
-      isSafeStaticExpression(unwrapped.left) &&
-      isSafeStaticExpression(unwrapped.right)
+      isSafeStaticExpression(unwrapped.left, options) &&
+      isSafeStaticExpression(unwrapped.right, options)
     );
   }
 
   if (unwrapped.type === 'ConditionalExpression') {
     return (
-      isSafeStaticExpression(unwrapped.test) &&
-      isSafeStaticExpression(unwrapped.consequent) &&
-      isSafeStaticExpression(unwrapped.alternate)
+      isSafeStaticExpression(unwrapped.test, options) &&
+      isSafeStaticExpression(unwrapped.consequent, options) &&
+      isSafeStaticExpression(unwrapped.alternate, options)
     );
   }
 
   if (unwrapped.type === 'MemberExpression') {
     return (
-      isSafeStaticExpression(unwrapped.object) &&
+      isSafeStaticExpression(unwrapped.object, options) &&
       (unwrapped.computed
-        ? isSafeStaticExpression(unwrapped.property)
+        ? isSafeStaticExpression(unwrapped.property, options)
         : unwrapped.property.type === 'Identifier')
+    );
+  }
+
+  if (options.allowMetadataCalls && unwrapped.type === 'CallExpression') {
+    return (
+      unwrapped.callee.type === 'Identifier' && unwrapped.arguments.length === 0
+    );
+  }
+
+  if (
+    options.allowMetadataCalls &&
+    (unwrapped.type === 'ArrowFunctionExpression' ||
+      unwrapped.type === 'FunctionExpression')
+  ) {
+    return (
+      !unwrapped.async &&
+      unwrapped.params.length === 0 &&
+      !!unwrapped.body &&
+      isSafeFunctionBodyExpression(unwrapped.body, options)
     );
   }
 
@@ -189,8 +246,8 @@ const isSafeStaticExpression = (expr: Node): boolean => {
       }
 
       return item.type === 'SpreadElement'
-        ? isSafeStaticExpression(item.argument)
-        : isSafeStaticExpression(item);
+        ? isSafeStaticExpression(item.argument, options)
+        : isSafeStaticExpression(item, options);
     });
   }
 
@@ -208,7 +265,7 @@ const isSafeStaticExpression = (expr: Node): boolean => {
       return (
         propertyNode.value &&
         typeof propertyNode.value === 'object' &&
-        isSafeStaticExpression(propertyNode.value as Node)
+        isSafeStaticExpression(propertyNode.value as Node, options)
       );
     });
   }
@@ -284,8 +341,231 @@ const collectImportBindings = (
   return result;
 };
 
-const isTypeOnlyExport = (statement: ExportNamedDeclaration): boolean =>
-  statement.exportKind === 'type';
+type Range = {
+  end: number;
+  start: number;
+};
+
+const removeRanges = (code: string, ranges: Range[]): string => {
+  let result = code;
+  ranges
+    .sort((a, b) => b.start - a.start)
+    .forEach((range) => {
+      result = result.slice(0, range.start) + result.slice(range.end);
+    });
+  return result;
+};
+
+const isIdentifierBindingPosition = (
+  node: Node,
+  parent: Node | null
+): boolean => {
+  if (node.type !== 'Identifier' || !parent) {
+    return false;
+  }
+
+  if (
+    (parent.type === 'VariableDeclarator' && parent.id === node) ||
+    (parent.type === 'FunctionDeclaration' && parent.id === node) ||
+    (parent.type === 'FunctionExpression' && parent.id === node) ||
+    (parent.type === 'ClassDeclaration' && parent.id === node) ||
+    (parent.type === 'ClassExpression' && parent.id === node)
+  ) {
+    return true;
+  }
+
+  if (
+    (parent.type === 'ArrowFunctionExpression' ||
+      parent.type === 'FunctionDeclaration' ||
+      parent.type === 'FunctionExpression') &&
+    parent.params.some((param) => param === node)
+  ) {
+    return true;
+  }
+
+  return (
+    (parent.type === 'ImportSpecifier' && parent.local === node) ||
+    (parent.type === 'ImportDefaultSpecifier' && parent.local === node) ||
+    (parent.type === 'ImportNamespaceSpecifier' && parent.local === node)
+  );
+};
+
+const isPropertyKeyOnlyIdentifier = (
+  node: Node,
+  parent: Node | null
+): boolean =>
+  node.type === 'Identifier' &&
+  !!parent &&
+  ((parent.type === 'MemberExpression' &&
+    parent.property === node &&
+    !parent.computed) ||
+    (parent.type === 'Property' &&
+      parent.key === node &&
+      !parent.computed &&
+      !parent.shorthand));
+
+const collectUsedIdentifierNames = (program: Program): Set<string> => {
+  const used = new Set<string>();
+
+  const walk = (node: Node, parent: Node | null): void => {
+    if (node.type === 'ImportDeclaration') {
+      return;
+    }
+
+    if (
+      node.type === 'Identifier' &&
+      !isIdentifierBindingPosition(node, parent) &&
+      !isPropertyKeyOnlyIdentifier(node, parent)
+    ) {
+      used.add(node.name);
+    }
+
+    getChildren(node).forEach((child) => walk(child, node));
+  };
+
+  walk(program, null);
+  return used;
+};
+
+const removableStaticHelperNames = (
+  program: Program,
+  staticValueNames: Set<string>
+): Set<string> => {
+  const used = collectUsedIdentifierNames(program);
+  const result = new Set<string>();
+
+  program.body.forEach((statement) => {
+    if (statement.type !== 'VariableDeclaration') {
+      return;
+    }
+
+    statement.declarations.forEach((declarator) => {
+      if (
+        declarator.id.type === 'Identifier' &&
+        staticValueNames.has(declarator.id.name) &&
+        !used.has(declarator.id.name)
+      ) {
+        result.add(declarator.id.name);
+      }
+    });
+  });
+
+  return result;
+};
+
+const removeStaticHelperDeclarations = (
+  code: string,
+  filename: string,
+  staticValueNames: Set<string>
+): { code: string; removed: Set<string> } => {
+  if (staticValueNames.size === 0) {
+    return { code, removed: new Set() };
+  }
+
+  const program = parseProgram(code, filename);
+  const removableNames = removableStaticHelperNames(program, staticValueNames);
+  const ranges: Range[] = [];
+
+  program.body.forEach((statement) => {
+    if (
+      statement.type !== 'VariableDeclaration' ||
+      statement.declarations.length === 0
+    ) {
+      return;
+    }
+
+    if (
+      statement.declarations.every(
+        (declarator) =>
+          declarator.id.type === 'Identifier' &&
+          removableNames.has(declarator.id.name)
+      )
+    ) {
+      ranges.push({
+        end: statement.end,
+        start: statement.start,
+      });
+    }
+  });
+
+  return {
+    code: removeRanges(code, ranges),
+    removed: removableNames,
+  };
+};
+
+const importSpecifierLocalName = (
+  specifier: ImportDeclaration['specifiers'][number]
+): string | null => specifier.local?.name ?? null;
+
+const removeUnusedStaticImports = (
+  code: string,
+  filename: string,
+  staticImportLocals: Set<string>
+): string => {
+  if (staticImportLocals.size === 0) {
+    return code;
+  }
+
+  const program = parseProgram(code, filename);
+  const used = collectUsedIdentifierNames(program);
+  const ranges: Range[] = [];
+
+  program.body.forEach((statement) => {
+    if (
+      statement.type !== 'ImportDeclaration' ||
+      statement.specifiers.length === 0
+    ) {
+      return;
+    }
+
+    const removableIndexes = statement.specifiers.flatMap(
+      (specifier, index) => {
+        const localName = importSpecifierLocalName(specifier);
+        return localName &&
+          staticImportLocals.has(localName) &&
+          !used.has(localName)
+          ? [index]
+          : [];
+      }
+    );
+
+    if (removableIndexes.length === 0) {
+      return;
+    }
+
+    if (removableIndexes.length === statement.specifiers.length) {
+      ranges.push({
+        end: statement.end,
+        start: statement.start,
+      });
+    }
+  });
+
+  return removeRanges(code, ranges);
+};
+
+const pruneStaticPreevalCode = (
+  code: string,
+  filename: string,
+  staticValueNames: Set<string>,
+  staticImportLocals: Set<string>
+): string => {
+  const helpersRemoved = removeStaticHelperDeclarations(
+    code,
+    filename,
+    staticValueNames
+  );
+  if (helpersRemoved.removed.size === 0) {
+    return code;
+  }
+
+  return removeUnusedStaticImports(
+    helpersRemoved.code,
+    filename,
+    staticImportLocals
+  );
+};
 
 const collectProcessorImportLocals = (
   action: ITransformAction,
@@ -332,177 +612,18 @@ const collectProcessorImportLocals = (
   return result;
 };
 
-const isSafeProcessorImport = (
-  statement: ImportDeclaration,
-  processorImportLocals: Set<string>
+const isStaticWYWMetaValue = (
+  value: unknown,
+  seen: Set<unknown> = new Set()
 ): boolean => {
-  if (isTypeOnlyImport(statement)) {
-    return true;
-  }
-
-  return (
-    statement.specifiers.length > 0 &&
-    statement.specifiers.every((specifier) => {
-      if (
-        specifier.type === 'ImportSpecifier' &&
-        (specifier as ImportSpecifier).importKind === 'type'
-      ) {
-        return true;
-      }
-
-      return (
-        specifier.type !== 'ImportNamespaceSpecifier' &&
-        !!specifier.local?.name &&
-        processorImportLocals.has(specifier.local.name)
-      );
-    })
-  );
-};
-
-const expressionRootIdentifierName = (expr: Node): string | null => {
-  const unwrapped = unwrapExpression(expr);
-
-  if (unwrapped.type === 'Identifier') {
-    return unwrapped.name;
-  }
-
-  if (unwrapped.type === 'MemberExpression') {
-    return expressionRootIdentifierName(unwrapped.object);
-  }
-
-  if (unwrapped.type === 'CallExpression') {
-    return expressionRootIdentifierName(unwrapped.callee);
-  }
-
-  if (unwrapped.type === 'TaggedTemplateExpression') {
-    return expressionRootIdentifierName(unwrapped.tag);
-  }
-
-  return null;
-};
-
-const isProcessorUsageExpression = (
-  expr: Node,
-  processorImportLocals: Set<string>
-): boolean => {
-  const unwrapped = unwrapExpression(expr);
-
-  if (
-    unwrapped.type !== 'CallExpression' &&
-    unwrapped.type !== 'TaggedTemplateExpression'
-  ) {
-    return false;
-  }
-
-  const rootName = expressionRootIdentifierName(unwrapped);
-  return !!rootName && processorImportLocals.has(rootName);
-};
-
-const isSafeProcessorMetadataVariableDeclaration = (
-  statement: VariableDeclaration,
-  processorImportLocals: Set<string>
-): boolean =>
-  statement.kind === 'const' &&
-  statement.declarations.every(
-    (declarator) =>
-      declarator.init &&
-      (isSafeStaticExpression(declarator.init) ||
-        isProcessorUsageExpression(declarator.init, processorImportLocals))
-  );
-
-const isSafeProcessorMetadataStatement = (
-  statement: Node,
-  processorImportLocals: Set<string>
-): boolean => {
-  if (statement.type.startsWith('TS') || statement.type.startsWith('JSDoc')) {
-    return statement.type !== 'TSEnumDeclaration';
-  }
-
-  if (statement.type === 'EmptyStatement') {
-    return true;
-  }
-
-  if (statement.type === 'FunctionDeclaration') {
-    return true;
-  }
-
-  if (statement.type === 'ImportDeclaration') {
-    return isSafeProcessorImport(statement, processorImportLocals);
-  }
-
-  if (statement.type === 'VariableDeclaration') {
-    return isSafeProcessorMetadataVariableDeclaration(
-      statement,
-      processorImportLocals
-    );
-  }
-
-  if (statement.type === 'ExportNamedDeclaration') {
-    if (isTypeOnlyExport(statement)) {
-      return true;
-    }
-
-    if (statement.source) {
-      return statement.specifiers.every(
-        (specifier) => specifier.type === 'ExportSpecifier'
-      );
-    }
-
-    if (!statement.declaration) {
-      return true;
-    }
-
-    return (
-      statement.declaration.type === 'FunctionDeclaration' ||
-      (statement.declaration.type === 'VariableDeclaration' &&
-        isSafeProcessorMetadataVariableDeclaration(
-          statement.declaration,
-          processorImportLocals
-        ))
-    );
-  }
-
-  if (statement.type === 'ExportDefaultDeclaration') {
-    return (
-      statement.declaration.type === 'FunctionDeclaration' ||
-      isSafeStaticExpression(statement.declaration) ||
-      isProcessorUsageExpression(statement.declaration, processorImportLocals)
-    );
-  }
-
-  if (statement.type === 'ExpressionStatement') {
-    return isSafeLiteral(statement.expression);
-  }
-
-  return false;
-};
-
-const isSafeProcessorMetadataProgram = (
-  action: ITransformAction,
-  program: Program,
-  code: string,
-  filename: string
-): boolean => {
-  const processorImportLocals = collectProcessorImportLocals(
-    action,
-    program,
-    code,
-    filename
-  );
-
-  if (processorImportLocals.size === 0) {
-    return false;
-  }
-
-  return program.body.every((statement) =>
-    isSafeProcessorMetadataStatement(statement, processorImportLocals)
-  );
-};
-
-const isStaticWYWMetaValue = (value: unknown): boolean => {
   if (typeof value !== 'object' || value === null) {
     return false;
   }
+
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
 
   const meta = (value as { __wyw_meta?: unknown }).__wyw_meta;
   if (typeof meta !== 'object' || meta === null) {
@@ -514,7 +635,115 @@ const isStaticWYWMetaValue = (value: unknown): boolean => {
     extends?: unknown;
   };
 
-  return typeof className === 'string' && extended === null;
+  return (
+    typeof className === 'string' &&
+    (extended === null || isStaticWYWMetaValue(extended, seen))
+  );
+};
+
+type StaticProcessorInstance = {
+  artifacts: unknown[];
+  build: (values: Map<string, unknown>) => void;
+  className: string;
+};
+
+const artifactCssText = (artifact: unknown): string | null => {
+  if (!Array.isArray(artifact) || artifact[0] !== 'css') {
+    return null;
+  }
+
+  const payload = artifact[1];
+  if (Array.isArray(payload)) {
+    const [rules] = payload;
+    if (typeof rules === 'object' && rules !== null) {
+      return Object.values(rules)
+        .map((rule) =>
+          typeof rule === 'object' &&
+          rule !== null &&
+          'cssText' in rule &&
+          typeof (rule as { cssText?: unknown }).cssText === 'string'
+            ? (rule as { cssText: string }).cssText
+            : ''
+        )
+        .join('');
+    }
+  }
+
+  if (
+    typeof payload === 'object' &&
+    payload !== null &&
+    'cssText' in payload &&
+    typeof (payload as { cssText?: unknown }).cssText === 'string'
+  ) {
+    return (payload as { cssText: string }).cssText;
+  }
+
+  return null;
+};
+
+const isEmptyProcessorClassName = (
+  value: string,
+  processors: StaticProcessorInstance[],
+  cache: Map<string, boolean>
+): boolean => {
+  if (cache.has(value)) {
+    return cache.get(value)!;
+  }
+
+  const processor = processors.find((item) => item.className === value);
+  if (!processor) {
+    cache.set(value, false);
+    return false;
+  }
+
+  try {
+    processor.build(new Map());
+  } catch {
+    cache.set(value, false);
+    return false;
+  }
+
+  const result = processor.artifacts.every((artifact) => {
+    const cssText = artifactCssText(artifact);
+    return cssText !== null && cssText.trim() === '';
+  });
+  cache.set(value, result);
+  return result;
+};
+
+const isSelectorOnlyProcessorValue = (
+  value: unknown,
+  processors: StaticProcessorInstance[],
+  cache: Map<string, boolean>,
+  seen: Set<unknown> = new Set()
+): boolean => {
+  if (typeof value === 'string') {
+    return isEmptyProcessorClassName(value, processors, cache);
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return false;
+    }
+
+    seen.add(value);
+    return value.every((item) =>
+      isSelectorOnlyProcessorValue(item, processors, cache, seen)
+    );
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    if (seen.has(value)) {
+      return false;
+    }
+
+    seen.add(value);
+    return Object.values(value).every((item) =>
+      isSelectorOnlyProcessorValue(item, processors, cache, seen)
+    );
+  }
+
+  return false;
 };
 
 const collectLocalConstExpressions = (
@@ -650,9 +879,73 @@ const expressionMayProduceMutableValue = (
   return false;
 };
 
+const isSafeFunctionBodyExpression = (
+  body: Node,
+  options: StaticExpressionOptions
+): boolean => {
+  if (body.type !== 'BlockStatement') {
+    return isSafeStaticExpression(body, options);
+  }
+
+  return body.body.every((statement) => {
+    if (statement.type === 'VariableDeclaration') {
+      return (
+        statement.kind === 'const' &&
+        statement.declarations.every(
+          (declarator) =>
+            declarator.init &&
+            declarator.id.type === 'Identifier' &&
+            isSafeStaticExpression(declarator.init, options)
+        )
+      );
+    }
+
+    return (
+      statement.type === 'ReturnStatement' &&
+      !!statement.argument &&
+      isSafeStaticExpression(statement.argument, options)
+    );
+  });
+};
+
+const collectStaticFunctionBodyReferences = (
+  body: Node,
+  references: Set<string>,
+  options: StaticExpressionOptions
+): boolean => {
+  if (body.type !== 'BlockStatement') {
+    return collectStaticExpressionReferences(body, references, options);
+  }
+
+  return body.body.every((statement) => {
+    if (statement.type === 'VariableDeclaration') {
+      return (
+        statement.kind === 'const' &&
+        statement.declarations.every(
+          (declarator) =>
+            declarator.init &&
+            declarator.id.type === 'Identifier' &&
+            collectStaticExpressionReferences(
+              declarator.init,
+              references,
+              options
+            )
+        )
+      );
+    }
+
+    return (
+      statement.type === 'ReturnStatement' &&
+      !!statement.argument &&
+      collectStaticExpressionReferences(statement.argument, references, options)
+    );
+  });
+};
+
 const collectStaticExpressionReferences = (
   expr: Node,
-  references: Set<string>
+  references: Set<string>,
+  options: StaticExpressionOptions = {}
 ): boolean => {
   const unwrapped = unwrapExpression(expr);
 
@@ -667,12 +960,16 @@ const collectStaticExpressionReferences = (
 
   if (unwrapped.type === 'TemplateLiteral') {
     return unwrapped.expressions.every((item) =>
-      collectStaticExpressionReferences(item, references)
+      collectStaticExpressionReferences(item, references, options)
     );
   }
 
   if (unwrapped.type === 'UnaryExpression') {
-    return collectStaticExpressionReferences(unwrapped.argument, references);
+    return collectStaticExpressionReferences(
+      unwrapped.argument,
+      references,
+      options
+    );
   }
 
   if (
@@ -680,24 +977,67 @@ const collectStaticExpressionReferences = (
     unwrapped.type === 'LogicalExpression'
   ) {
     return (
-      collectStaticExpressionReferences(unwrapped.left, references) &&
-      collectStaticExpressionReferences(unwrapped.right, references)
+      collectStaticExpressionReferences(unwrapped.left, references, options) &&
+      collectStaticExpressionReferences(unwrapped.right, references, options)
     );
   }
 
   if (unwrapped.type === 'ConditionalExpression') {
     return (
-      collectStaticExpressionReferences(unwrapped.test, references) &&
-      collectStaticExpressionReferences(unwrapped.consequent, references) &&
-      collectStaticExpressionReferences(unwrapped.alternate, references)
+      collectStaticExpressionReferences(unwrapped.test, references, options) &&
+      collectStaticExpressionReferences(
+        unwrapped.consequent,
+        references,
+        options
+      ) &&
+      collectStaticExpressionReferences(
+        unwrapped.alternate,
+        references,
+        options
+      )
     );
   }
 
   if (unwrapped.type === 'MemberExpression') {
     return (
-      collectStaticExpressionReferences(unwrapped.object, references) &&
+      collectStaticExpressionReferences(
+        unwrapped.object,
+        references,
+        options
+      ) &&
       (!unwrapped.computed ||
-        collectStaticExpressionReferences(unwrapped.property, references))
+        collectStaticExpressionReferences(
+          unwrapped.property,
+          references,
+          options
+        ))
+    );
+  }
+
+  if (options.allowMetadataCalls && unwrapped.type === 'CallExpression') {
+    if (
+      unwrapped.callee.type !== 'Identifier' ||
+      unwrapped.arguments.length !== 0
+    ) {
+      return false;
+    }
+
+    references.add(unwrapped.callee.name);
+    return true;
+  }
+
+  if (
+    options.allowMetadataCalls &&
+    (unwrapped.type === 'ArrowFunctionExpression' ||
+      unwrapped.type === 'FunctionExpression')
+  ) {
+    if (unwrapped.async || unwrapped.params.length !== 0) {
+      return false;
+    }
+
+    return (
+      !!unwrapped.body &&
+      collectStaticFunctionBodyReferences(unwrapped.body, references, options)
     );
   }
 
@@ -708,15 +1048,19 @@ const collectStaticExpressionReferences = (
       }
 
       return item.type === 'SpreadElement'
-        ? collectStaticExpressionReferences(item.argument, references)
-        : collectStaticExpressionReferences(item, references);
+        ? collectStaticExpressionReferences(item.argument, references, options)
+        : collectStaticExpressionReferences(item, references, options);
     });
   }
 
   if (unwrapped.type === 'ObjectExpression') {
     return unwrapped.properties.every((property) => {
       if (property.type === 'SpreadElement') {
-        return collectStaticExpressionReferences(property.argument, references);
+        return collectStaticExpressionReferences(
+          property.argument,
+          references,
+          options
+        );
       }
 
       const propertyNode = property as AnyNode;
@@ -730,7 +1074,8 @@ const collectStaticExpressionReferences = (
 
       return collectStaticExpressionReferences(
         propertyNode.value as Node,
-        references
+        references,
+        options
       );
     });
   }
@@ -1000,7 +1345,8 @@ const collectTopLevelMutationHints = (
 
 const collectStaticExpressionDependencies = (
   program: Program,
-  target: Extract<ExportTarget, { kind: 'expression' }>
+  target: Extract<ExportTarget, { kind: 'expression' }>,
+  options: StaticExpressionOptions = {}
 ): StaticExpressionDependencies | null => {
   const imports = collectImportBindings(program);
   const locals = collectLocalConstExpressions(program);
@@ -1041,12 +1387,12 @@ const collectStaticExpressionDependencies = (
   };
 
   const collectExpression = (expr: Node): boolean => {
-    if (!isSafeStaticExpression(expr)) {
+    if (!isSafeStaticExpression(expr, options)) {
       return false;
     }
 
     const references = new Set<string>();
-    if (!collectStaticExpressionReferences(expr, references)) {
+    if (!collectStaticExpressionReferences(expr, references, options)) {
       return false;
     }
 
@@ -1274,19 +1620,23 @@ function* resolveImportValue(
   };
 }
 
-const resolveProcessorMetadataExport = (
+function* resolveProcessorStaticExport(
   action: ITransformAction,
   filename: string,
   code: string,
   program: Program,
-  exportedName: string
-): StaticExportResult | null => {
+  exportedName: string,
+  stack: Set<string>,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<StaticExportResult | null> {
   const root = action.services.options.root ?? process.cwd();
   if (!isInsideRoot(filename, root)) {
     return null;
   }
 
-  if (!isSafeProcessorMetadataProgram(action, program, code, filename)) {
+  if (
+    collectProcessorImportLocals(action, program, code, filename).size === 0
+  ) {
     return null;
   }
 
@@ -1322,8 +1672,34 @@ const resolveProcessorMetadataExport = (
     return null;
   }
 
-  if (!isSafeStaticExpression(target.expression)) {
+  const staticDependencies = collectStaticExpressionDependencies(
+    preevalProgram,
+    target,
+    {
+      allowMetadataCalls: true,
+    }
+  );
+  if (!staticDependencies) {
     return null;
+  }
+
+  const env = new Map<string, unknown>();
+  const dependencies = new Set<string>([filename]);
+
+  for (const binding of staticDependencies.imports) {
+    const resolved = yield* resolveImportValue(
+      action,
+      filename,
+      binding,
+      stack,
+      memo
+    );
+    if (!resolved) {
+      return null;
+    }
+
+    env.set(binding.local, createOxcStaticCallableValue(resolved.value));
+    resolved.dependencies.forEach((dependency) => dependencies.add(dependency));
   }
 
   const value = evaluateOxcStaticExpressionAt(
@@ -1333,17 +1709,28 @@ const resolveProcessorMetadataExport = (
       end: target.expression.end,
       start: target.expression.start,
     },
-    new Map()
+    env
   );
-  if (!isStaticWYWMetaValue(value) || !isOxcStaticSerializableValue(value)) {
+  if (!isOxcStaticSerializableValue(value)) {
+    return null;
+  }
+
+  if (
+    !isStaticWYWMetaValue(value) &&
+    !isSelectorOnlyProcessorValue(
+      value,
+      preevalResult.metadata.processors as unknown as StaticProcessorInstance[],
+      new Map()
+    )
+  ) {
     return null;
   }
 
   return {
-    dependencies: [filename],
+    dependencies: [...dependencies],
     value,
   };
-};
+}
 
 function* resolveStaticExport(
   action: ITransformAction,
@@ -1406,12 +1793,14 @@ function* resolveStaticExport(
     target
   );
   if (!staticDependencies) {
-    const metadataResult = resolveProcessorMetadataExport(
+    const metadataResult = yield* resolveProcessorStaticExport(
       action,
       filename,
       code,
       program,
-      exportedName
+      exportedName,
+      stack,
+      memo
     );
     memo.set(memoKey, metadataResult);
     stack.delete(memoKey);
@@ -1520,6 +1909,7 @@ export function* resolveStaticOxcPreevalValues(
   const staticValueCache =
     preevalResult.staticValueCache ?? new Map<string, unknown>();
   const staticDependencies = new Set(preevalResult.staticDependencies ?? []);
+  const staticImportLocals = new Set<string>();
   const memo = new Map<string, StaticExportResult | null>();
   let changed = false;
 
@@ -1539,6 +1929,9 @@ export function* resolveStaticOxcPreevalValues(
     }
 
     staticValueCache.set(candidate.name, resolved.value);
+    candidate.imports.forEach((item) =>
+      staticImportLocals.add(item.importLocal ?? item.local)
+    );
     resolved.dependencies.forEach((dependency) =>
       staticDependencies.add(dependency)
     );
@@ -1555,11 +1948,14 @@ export function* resolveStaticOxcPreevalValues(
   preevalResult.dependencyNames = dependencyNames;
   preevalResult.staticValueCache = staticValueCache;
   preevalResult.staticDependencies = [...staticDependencies];
-  preevalResult.code = appendOxcWywPreval(
+  const baseCode = pruneStaticPreevalCode(
     preevalResult.baseCode ?? preevalResult.code,
     filename,
-    dependencyNames
+    new Set(staticValueCache.keys()),
+    staticImportLocals
   );
+  preevalResult.baseCode = baseCode;
+  preevalResult.code = appendOxcWywPreval(baseCode, filename, dependencyNames);
 
   for (const dependency of staticDependencies) {
     this.entrypoint.addInvalidationDependency({

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -61,6 +61,7 @@ type ExportTarget =
     };
 
 type StaticExportResult = {
+  callable?: 'zero-arg';
   dependencies: string[];
   sideEffectDependencies?: string[];
   sideEffectImportLocals?: string[];
@@ -835,6 +836,89 @@ const collectImportLocalReferences = (
   };
 
   walk(node, null);
+};
+
+const parseStaticExpressionSource = (
+  source: string,
+  filename: string
+): Expression | null => {
+  try {
+    const program = parseProgram(
+      `const __wyw_static_value = ${source};`,
+      filename
+    );
+    const declaration = program.body[0];
+    if (declaration?.type !== 'VariableDeclaration') {
+      return null;
+    }
+
+    const [declarator] = declaration.declarations;
+    return declarator?.init ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const expressionUsesNameOnlyAsZeroArgCalls = (
+  expression: Node,
+  name: string
+): boolean => {
+  let seen = false;
+  let valid = true;
+
+  const walk = (node: Node, parent: Node | null): void => {
+    if (!valid) {
+      return;
+    }
+
+    if (
+      node.type === 'Identifier' &&
+      node.name === name &&
+      !isIdentifierBindingPosition(node, parent) &&
+      !isPropertyKeyOnlyIdentifier(node, parent)
+    ) {
+      if (
+        parent?.type === 'CallExpression' &&
+        parent.callee === node &&
+        parent.arguments.length === 0
+      ) {
+        seen = true;
+      } else {
+        valid = false;
+        return;
+      }
+    }
+
+    getChildren(node).forEach((child) => walk(child, node));
+  };
+
+  walk(expression, null);
+  return seen && valid;
+};
+
+const bindStaticResolvedValue = (
+  env: Map<string, unknown>,
+  expression: Node,
+  local: string,
+  resolved: StaticExportResult,
+  options: { wrapNonCallable?: boolean } = {}
+): boolean => {
+  if (resolved.callable === 'zero-arg') {
+    if (!expressionUsesNameOnlyAsZeroArgCalls(expression, local)) {
+      return false;
+    }
+
+    env.set(local, createOxcStaticCallableValue(resolved.value));
+    return true;
+  }
+
+  env.set(
+    local,
+    options.wrapNonCallable
+      ? createOxcStaticCallableValue(resolved.value)
+      : resolved.value
+  );
+  return true;
 };
 
 const removeStaticHelperDeclarations = (
@@ -3049,6 +3133,7 @@ function* resolveImportValue(
   });
 
   return {
+    callable: resolved.callable,
     dependencies: [
       dependency.resolved,
       ...resolved.dependencies.filter((item) => item !== dependency.resolved),
@@ -3454,7 +3539,29 @@ function* resolveProcessorStaticExport(
       return null;
     }
 
-    env.set(binding.local, createOxcStaticCallableValue(resolved.value));
+    if (
+      !bindStaticResolvedValue(
+        env,
+        preparedTarget.expression,
+        binding.local,
+        resolved,
+        {
+          wrapNonCallable: true,
+        }
+      )
+    ) {
+      debugStaticResolve(action, {
+        exported: exportedName,
+        filename,
+        imported: binding.imported,
+        phase: 'processor-metadata',
+        reason: 'callable-usage-unsupported',
+        source: binding.source,
+        status: 'rejected',
+      });
+      return null;
+    }
+
     resolved.dependencies.forEach((dependency) => dependencies.add(dependency));
     resolved.sideEffectDependencies?.forEach((dependency) =>
       sideEffectDependencies.add(dependency)
@@ -3614,7 +3721,10 @@ function* resolveObjectAssignStaticExport(
       return null;
     }
 
-    env.set(binding.local, resolved.value);
+    if (!bindStaticResolvedValue(env, expression, binding.local, resolved)) {
+      return null;
+    }
+
     resolved.dependencies.forEach((item) => dependencies.add(item));
     resolved.sideEffectDependencies?.forEach((item) =>
       sideEffectDependencies.add(item)
@@ -3632,6 +3742,108 @@ function* resolveObjectAssignStaticExport(
   );
   return isStaticWYWMetaValue(value)
     ? {
+        dependencies: [...dependencies],
+        sideEffectDependencies: [...sideEffectDependencies],
+        value,
+      }
+    : null;
+}
+
+const zeroArgFunctionReturnExpression = (
+  expression: Expression
+): Expression | null => {
+  const unwrapped = unwrapExpression(expression);
+  if (
+    unwrapped.type !== 'ArrowFunctionExpression' &&
+    unwrapped.type !== 'FunctionExpression'
+  ) {
+    return null;
+  }
+
+  if (unwrapped.async || unwrapped.params.length !== 0 || !unwrapped.body) {
+    return null;
+  }
+
+  if (unwrapped.body.type !== 'BlockStatement') {
+    return unwrapped.body as Expression;
+  }
+
+  if (unwrapped.body.body.length !== 1) {
+    return null;
+  }
+
+  const [statement] = unwrapped.body.body;
+  return statement?.type === 'ReturnStatement' && statement.argument
+    ? statement.argument
+    : null;
+};
+
+function* resolveZeroArgFunctionStaticExport(
+  action: ITransformAction,
+  filename: string,
+  code: string,
+  program: Program,
+  target: Extract<ExportTarget, { kind: 'expression' }>,
+  stack: Set<string>,
+  memo: Map<string, StaticExportResult | null>
+): SyncScenarioFor<StaticExportResult | null> {
+  const returnExpression = zeroArgFunctionReturnExpression(target.expression);
+  if (!returnExpression) {
+    return null;
+  }
+
+  const staticDependencies = collectStaticExpressionDependencies(
+    program,
+    {
+      ...target,
+      expression: returnExpression,
+    },
+    { allowMetadataCalls: true }
+  );
+  if (!staticDependencies) {
+    return null;
+  }
+
+  const env = new Map<string, unknown>();
+  const dependencies = new Set<string>([filename]);
+  const sideEffectDependencies = new Set<string>();
+
+  for (const binding of staticDependencies.imports) {
+    const resolved = yield* resolveImportValue(
+      action,
+      filename,
+      binding,
+      stack,
+      memo
+    );
+    if (!resolved) {
+      return null;
+    }
+
+    if (
+      !bindStaticResolvedValue(env, returnExpression, binding.local, resolved)
+    ) {
+      return null;
+    }
+
+    resolved.dependencies.forEach((item) => dependencies.add(item));
+    resolved.sideEffectDependencies?.forEach((item) =>
+      sideEffectDependencies.add(item)
+    );
+  }
+
+  const value = evaluateOxcStaticExpressionAt(
+    code,
+    filename,
+    {
+      end: returnExpression.end,
+      start: returnExpression.start,
+    },
+    env
+  );
+  return isOxcStaticSerializableValue(value)
+    ? {
+        callable: 'zero-arg',
         dependencies: [...dependencies],
         sideEffectDependencies: [...sideEffectDependencies],
         value,
@@ -3759,6 +3971,26 @@ function* resolveStaticExport(
     return finish(objectAssignResult);
   }
 
+  const zeroArgFunctionResult = yield* resolveZeroArgFunctionStaticExport(
+    action,
+    filename,
+    code,
+    program,
+    target,
+    stack,
+    memo
+  );
+  if (zeroArgFunctionResult) {
+    debugStaticResolve(action, {
+      exported: exportedName,
+      filename,
+      phase: 'export',
+      reason: 'zero-arg-function',
+      status: 'resolved',
+    });
+    return finish(zeroArgFunctionResult);
+  }
+
   const staticDependencies = collectStaticExpressionDependencies(
     program,
     target
@@ -3815,7 +4047,21 @@ function* resolveStaticExport(
       return finish(null);
     }
 
-    env.set(binding.local, resolved.value);
+    if (
+      !bindStaticResolvedValue(env, target.expression, binding.local, resolved)
+    ) {
+      debugStaticResolve(action, {
+        exported: exportedName,
+        filename,
+        imported: binding.imported,
+        phase: 'export',
+        reason: 'callable-usage-unsupported',
+        source: binding.source,
+        status: 'rejected',
+      });
+      return finish(null);
+    }
+
     resolved.dependencies.forEach((item) => dependencies.add(item));
     resolved.sideEffectDependencies?.forEach((item) =>
       sideEffectDependencies.add(item)
@@ -3866,6 +4112,7 @@ function* resolveCandidateValue(
   const dependencies = new Set<string>();
   const sideEffectDependencies = new Set<string>();
   const sideEffectImportLocals = new Set<string>();
+  let candidateExpression: Expression | null | undefined;
 
   for (const item of candidate.imports) {
     const resolved = yield* resolveImportValue(
@@ -3888,7 +4135,41 @@ function* resolveCandidateValue(
       return null;
     }
 
-    env.set(item.local, resolved.value);
+    if (resolved.callable === 'zero-arg' && candidateExpression === undefined) {
+      candidateExpression = parseStaticExpressionSource(
+        candidate.source,
+        filename
+      );
+    }
+
+    const expressionForBinding =
+      resolved.callable === 'zero-arg' ? candidateExpression : null;
+    if (
+      (resolved.callable === 'zero-arg' && !expressionForBinding) ||
+      (expressionForBinding &&
+        !bindStaticResolvedValue(
+          env,
+          expressionForBinding,
+          item.local,
+          resolved
+        ))
+    ) {
+      debugStaticResolve(action, {
+        candidate: candidate.name,
+        filename,
+        imported: item.imported,
+        phase: 'candidate',
+        reason: 'candidate-callable-usage-unsupported',
+        source: item.source,
+        status: 'rejected',
+      });
+      return null;
+    }
+
+    if (!expressionForBinding) {
+      env.set(item.local, resolved.value);
+    }
+
     resolved.dependencies.forEach((dependency) => dependencies.add(dependency));
     resolved.sideEffectDependencies?.forEach((dependency) => {
       sideEffectDependencies.add(dependency);

--- a/packages/transform/src/transform/generators/transform.ts
+++ b/packages/transform/src/transform/generators/transform.ts
@@ -5,7 +5,10 @@ import { emitOxcCommonJS, stripTypesAndJsxWithOxc } from '../../utils/oxcEmit';
 import { runOxcPreevalStage } from '../../utils/oxcPreevalStage';
 import { shakeOxcToESM } from '../../utils/oxcShaker';
 import type { Entrypoint } from '../Entrypoint';
-import type { IEntrypointDependency } from '../Entrypoint.types';
+import type {
+  IEntrypointDependency,
+  IPreevalResult,
+} from '../Entrypoint.types';
 import type {
   ITransformAction,
   Services,
@@ -64,6 +67,55 @@ const normalizeOxcPreparedESM = (code: string): string =>
     .replace(/\n{2,}/g, '\n')
     .replace(/^const /gm, 'var ');
 
+const ensureOxcPreevalResult = (
+  services: Services,
+  item: Entrypoint,
+  originalAst: unknown | null
+): IPreevalResult => {
+  const cached = item.getPreevalResult();
+  if (cached) {
+    return cached;
+  }
+
+  const { loadedAndParsed } = item;
+  if (loadedAndParsed.evaluator === 'ignored') {
+    throw new Error('Cannot run Oxc preeval for an ignored entrypoint.');
+  }
+
+  const filename = loadedAndParsed.evalConfig.filename ?? item.name;
+  const { eventEmitter } = services;
+  const { pluginOptions } = services.options;
+  const root = services.options.root ?? process.cwd();
+
+  const preevalStageResult = eventEmitter.perf('transform:preeval', () => {
+    const result = runOxcPreevalStage(
+      loadedAndParsed.code,
+      {
+        filename,
+        root,
+      },
+      {
+        ...pluginOptions,
+        eventEmitter,
+      }
+    );
+
+    return {
+      ast: originalAst,
+      baseCode: result.baseCode,
+      code: result.code,
+      dependencyNames: result.dependencyNames,
+      metadata: result.metadata,
+      staticDependencies: result.staticDependencies,
+      staticValueCache: result.staticValueCache,
+      staticValueCandidates: result.staticValueCandidates,
+    };
+  });
+
+  item.setPreevalResult(preevalStageResult);
+  return preevalStageResult;
+};
+
 const prepareOxcCodeImpl = (
   services: Services,
   item: Entrypoint,
@@ -81,35 +133,11 @@ const prepareOxcCodeImpl = (
   const { pluginOptions } = services.options;
   const root = services.options.root ?? process.cwd();
 
-  let preevalStageResult = item.getPreevalResult();
-  if (!preevalStageResult) {
-    preevalStageResult = eventEmitter.perf('transform:preeval', () => {
-      const result = runOxcPreevalStage(
-        loadedAndParsed.code,
-        {
-          filename,
-          root,
-        },
-        {
-          ...pluginOptions,
-          eventEmitter,
-        }
-      );
-
-      return {
-        ast: originalAst,
-        baseCode: result.baseCode,
-        code: result.code,
-        dependencyNames: result.dependencyNames,
-        metadata: result.metadata,
-        staticDependencies: result.staticDependencies,
-        staticValueCache: result.staticValueCache,
-        staticValueCandidates: result.staticValueCandidates,
-      };
-    });
-
-    item.setPreevalResult(preevalStageResult);
-  }
+  const preevalStageResult = ensureOxcPreevalResult(
+    services,
+    item,
+    originalAst
+  );
 
   const transformMetadata = preevalStageResult.metadata;
   if (
@@ -224,22 +252,16 @@ export function* internalTransform(
 
   log('>> (%o)', only);
 
-  let [preparedCode, imports, metadata] = prepareFn(
+  if (loadedAndParsed.evaluator === oxcShaker) {
+    ensureOxcPreevalResult(this.services, this.entrypoint, null);
+    yield* resolveStaticOxcPreevalValues.call(this);
+  }
+
+  const [preparedCode, imports, metadata] = prepareFn(
     this.services,
     this.entrypoint,
     null
   );
-  if (loadedAndParsed.evaluator === oxcShaker) {
-    const didResolveStaticValues =
-      yield* resolveStaticOxcPreevalValues.call(this);
-    if (didResolveStaticValues) {
-      [preparedCode, imports, metadata] = prepareFn(
-        this.services,
-        this.entrypoint,
-        null
-      );
-    }
-  }
   let finalPreparedCode = preparedCode;
 
   if (loadedAndParsed.evaluator === oxcShaker) {

--- a/packages/transform/src/transform/generators/transform.ts
+++ b/packages/transform/src/transform/generators/transform.ts
@@ -105,7 +105,9 @@ const ensureOxcPreevalResult = (
       baseCode: result.baseCode,
       code: result.code,
       dependencyNames: result.dependencyNames,
+      evalCode: result.code,
       metadata: result.metadata,
+      staticSideEffectImportLocals: [],
       staticDependencies: result.staticDependencies,
       staticValueCache: result.staticValueCache,
       staticValueCandidates: result.staticValueCandidates,
@@ -140,16 +142,17 @@ const prepareOxcCodeImpl = (
   );
 
   const transformMetadata = preevalStageResult.metadata;
+  const preevalCode =
+    options.stripForEvalRuntime && preevalStageResult.evalCode
+      ? preevalStageResult.evalCode
+      : preevalStageResult.code;
   if (
     isPrevalOnly(only) &&
     !transformMetadata &&
     options.shortCircuitOnMissingMetadata !== false
   ) {
     log('[evaluator:end] no metadata');
-    const strippedCode = stripTypesAndJsxWithOxc(
-      preevalStageResult.code,
-      filename
-    ).code;
+    const strippedCode = stripTypesAndJsxWithOxc(preevalCode, filename).code;
 
     return [
       normalizeOxcPreparedESM(strippedCode),
@@ -160,10 +163,10 @@ const prepareOxcCodeImpl = (
 
   log('[preeval] metadata %O', transformMetadata);
   log('[evaluator:start] using %s', loadedAndParsed.evaluator.name);
-  log.extend('source')('%s', preevalStageResult.code);
+  log.extend('source')('%s', preevalCode);
 
   const shaken = eventEmitter.perf('transform:evaluator', () =>
-    shakeOxcToESM(preevalStageResult.code, filename, {
+    shakeOxcToESM(preevalCode, filename, {
       importOverrides: pluginOptions.importOverrides,
       onlyExports: only,
       root,

--- a/packages/transform/src/transform/generators/transform.ts
+++ b/packages/transform/src/transform/generators/transform.ts
@@ -13,6 +13,7 @@ import type {
 } from '../types';
 
 import { rewriteOptimizedOxcBarrelImports } from './rewriteOxcBarrelImports';
+import { resolveStaticOxcPreevalValues } from './resolveStaticOxcValues';
 
 const EMPTY_FILE = '=== empty file ===';
 
@@ -97,8 +98,13 @@ const prepareOxcCodeImpl = (
 
       return {
         ast: originalAst,
+        baseCode: result.baseCode,
         code: result.code,
+        dependencyNames: result.dependencyNames,
         metadata: result.metadata,
+        staticDependencies: result.staticDependencies,
+        staticValueCache: result.staticValueCache,
+        staticValueCandidates: result.staticValueCandidates,
       };
     });
 
@@ -218,11 +224,22 @@ export function* internalTransform(
 
   log('>> (%o)', only);
 
-  const [preparedCode, imports, metadata] = prepareFn(
+  let [preparedCode, imports, metadata] = prepareFn(
     this.services,
     this.entrypoint,
     null
   );
+  if (loadedAndParsed.evaluator === oxcShaker) {
+    const didResolveStaticValues =
+      yield* resolveStaticOxcPreevalValues.call(this);
+    if (didResolveStaticValues) {
+      [preparedCode, imports, metadata] = prepareFn(
+        this.services,
+        this.entrypoint,
+        null
+      );
+    }
+  }
   let finalPreparedCode = preparedCode;
 
   if (loadedAndParsed.evaluator === oxcShaker) {

--- a/packages/transform/src/transform/generators/transform.ts
+++ b/packages/transform/src/transform/generators/transform.ts
@@ -54,6 +54,12 @@ type PrepareCodeFn = (
 const isPrevalOnly = (only: string[]) =>
   only.length === 1 && only[0] === '__wywPreval';
 
+const hasWywPrevalExport = (code: string, filename: string): boolean =>
+  Object.hasOwn(
+    collectOxcExportsAndImports(code, filename).exports,
+    '__wywPreval'
+  );
+
 type PrepareCodeOptions = {
   emitCommonJS?: boolean;
   shortCircuitOnMissingMetadata?: boolean;
@@ -149,6 +155,7 @@ const prepareOxcCodeImpl = (
   if (
     isPrevalOnly(only) &&
     !transformMetadata &&
+    !hasWywPrevalExport(preevalCode, filename) &&
     options.shortCircuitOnMissingMetadata !== false
   ) {
     log('[evaluator:end] no metadata');

--- a/packages/transform/src/transform/generators/workflow.ts
+++ b/packages/transform/src/transform/generators/workflow.ts
@@ -17,7 +17,6 @@ const isLoadedEntrypointWithoutArtifacts = (
 export function* workflow(
   this: IWorkflowAction
 ): SyncScenarioForAction<IWorkflowAction> {
-  const action = this;
   const { cache, options } = this.services;
   const { entrypoint } = this;
 
@@ -47,12 +46,13 @@ export function* workflow(
 
   const originalCode = entrypoint.loadedAndParsed.code ?? '';
 
-  const restartOnSupersede = function* (
+  function* restartOnSupersede(
+    this: IWorkflowAction,
     error: unknown
   ): SyncScenarioForAction<IWorkflowAction> {
     if (isAborted(error) && entrypoint.supersededWith) {
       entrypoint.log('workflow aborted, schedule the next attempt');
-      return yield* action.getNext(
+      return yield* this.getNext(
         'workflow',
         entrypoint.supersededWith,
         undefined,
@@ -61,7 +61,7 @@ export function* workflow(
     }
 
     throw error;
-  };
+  }
 
   // File is ignored or does not contain any tags. Return original code.
   if (!entrypoint.hasWywMetadata()) {
@@ -153,6 +153,6 @@ export function* workflow(
       sourceMap: collectStageResult.map,
     };
   } catch (error) {
-    return yield* restartOnSupersede(error);
+    return yield* restartOnSupersede.call(this, error);
   }
 }

--- a/packages/transform/src/transform/helpers/loadWywOptions.ts
+++ b/packages/transform/src/transform/helpers/loadWywOptions.ts
@@ -141,14 +141,14 @@ export function loadWywOptions(
     ...rest
   } = overrides;
 
-  const defaultFeatures: FeatureFlags = {
+  const defaultFeatures = {
     dangerousCodeRemover: true,
     globalCache: true,
     happyDOM: true,
     softErrors: false,
     staticImportValues: true,
     useWeakRefInEval: true,
-  };
+  } satisfies FeatureFlags & { staticImportValues: boolean };
   const defaultEval: EvalOptionsV2 = {
     mode: 'strict',
     require: 'warn-and-run',

--- a/packages/transform/src/transform/helpers/loadWywOptions.ts
+++ b/packages/transform/src/transform/helpers/loadWywOptions.ts
@@ -146,7 +146,7 @@ export function loadWywOptions(
     globalCache: true,
     happyDOM: true,
     softErrors: false,
-    staticImportValues: true,
+    staticImportValues: false,
     useWeakRefInEval: true,
   } satisfies FeatureFlags & { staticImportValues: boolean };
   const defaultEval: EvalOptionsV2 = {

--- a/packages/transform/src/transform/isStaticallyEvaluatableModule.ts
+++ b/packages/transform/src/transform/isStaticallyEvaluatableModule.ts
@@ -49,30 +49,28 @@ const isTypeOnlyImport = (statement: ImportDeclaration): boolean => {
 const isTypeOnlyReExport = (statement: ExportNamedDeclaration): boolean =>
   !!statement.source && statement.exportKind === 'type';
 
+const isWrapperExpression = (node: Node): node is Node & { expression: Node } =>
+  node.type === 'TSAsExpression' ||
+  node.type === 'TSSatisfiesExpression' ||
+  node.type === 'TSNonNullExpression' ||
+  node.type === 'TSInstantiationExpression' ||
+  node.type === 'TSTypeAssertion' ||
+  node.type === 'ParenthesizedExpression';
+
 const unwrapExpression = (expr: Node): Node => {
   let current = expr;
 
-  for (;;) {
-    if (
-      current.type === 'TSAsExpression' ||
-      current.type === 'TSSatisfiesExpression' ||
-      current.type === 'TSNonNullExpression' ||
-      current.type === 'TSInstantiationExpression' ||
-      current.type === 'TSTypeAssertion' ||
-      current.type === 'ParenthesizedExpression'
-    ) {
-      current = current.expression;
-      continue;
-    }
-
-    return current;
+  while (isWrapperExpression(current)) {
+    current = current.expression;
   }
+
+  return current;
 };
 
 const isSafeLiteral = (expr: Node): boolean =>
   getNodeType(expr) === 'Literal' &&
   (() => {
-    const value = (expr as Node & { value?: unknown }).value;
+    const { value } = expr as Node & { value?: unknown };
     return (
       value === null ||
       typeof value === 'string' ||
@@ -104,8 +102,8 @@ const isSafeExpression = (expr: Node): boolean => {
   }
 
   if (type === 'TemplateLiteral') {
-    return (unwrapped as Node & { expressions: Node[] }).expressions.every((item) =>
-      isSafeExpression(item)
+    return (unwrapped as Node & { expressions: Node[] }).expressions.every(
+      (item) => isSafeExpression(item)
     );
   }
 
@@ -116,8 +114,7 @@ const isSafeExpression = (expr: Node): boolean => {
   if (type === 'BinaryExpression' || type === 'LogicalExpression') {
     const binaryLike = unwrapped as Node & { left: Node; right: Node };
     return (
-      isSafeExpression(binaryLike.left) &&
-      isSafeExpression(binaryLike.right)
+      isSafeExpression(binaryLike.left) && isSafeExpression(binaryLike.right)
     );
   }
 
@@ -135,43 +132,47 @@ const isSafeExpression = (expr: Node): boolean => {
   }
 
   if (type === 'ArrayExpression') {
-    return (unwrapped as Node & { elements: Array<Node | null> }).elements.every(
-      (item) => {
-        if (!item) {
-          return true;
-        }
-
-        if (item.type === 'SpreadElement') {
-          return false;
-        }
-
-        return isSafeExpression(item);
-      }
-    );
-  }
-
-  if (type === 'ObjectExpression') {
-    return (unwrapped as Node & { properties: Node[] }).properties.every((property) => {
-      if (property.type === 'SpreadElement') {
-        return false;
-      }
-
-      const propertyNode = property as Node & {
-        computed?: boolean;
-        method?: boolean;
-        value?: Node;
-      };
-
-      if (propertyNode.computed) {
-        return false;
-      }
-
-      if (propertyNode.method) {
+    return (
+      unwrapped as Node & { elements: Array<Node | null> }
+    ).elements.every((item) => {
+      if (!item) {
         return true;
       }
 
-      return isNode(propertyNode.value) && isSafeExpression(propertyNode.value);
+      if (item.type === 'SpreadElement') {
+        return false;
+      }
+
+      return isSafeExpression(item);
     });
+  }
+
+  if (type === 'ObjectExpression') {
+    return (unwrapped as Node & { properties: Node[] }).properties.every(
+      (property) => {
+        if (property.type === 'SpreadElement') {
+          return false;
+        }
+
+        const propertyNode = property as Node & {
+          computed?: boolean;
+          method?: boolean;
+          value?: Node;
+        };
+
+        if (propertyNode.computed) {
+          return false;
+        }
+
+        if (propertyNode.method) {
+          return true;
+        }
+
+        return (
+          isNode(propertyNode.value) && isSafeExpression(propertyNode.value)
+        );
+      }
+    );
   }
 
   if (
@@ -231,7 +232,7 @@ const isSafeStatement = (statement: Node): boolean => {
   }
 
   if (statement.type === 'ExportDefaultDeclaration') {
-    const declaration = statement.declaration;
+    const { declaration } = statement;
     if (!isNode(declaration)) {
       return false;
     }
@@ -253,7 +254,10 @@ const isSafeStatement = (statement: Node): boolean => {
     return isSafeVariableDeclaration(statement);
   }
 
-  if (statement.type === 'FunctionDeclaration' || statement.type === 'EmptyStatement') {
+  if (
+    statement.type === 'FunctionDeclaration' ||
+    statement.type === 'EmptyStatement'
+  ) {
     return true;
   }
 
@@ -268,5 +272,7 @@ export function isStaticallyEvaluatableModule(
   code: string,
   filename: string
 ): boolean {
-  return parseOxc(code, filename).body.every((statement) => isSafeStatement(statement));
+  return parseOxc(code, filename).body.every((statement) =>
+    isSafeStatement(statement)
+  );
 }

--- a/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.test.ts
+++ b/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.test.ts
@@ -162,7 +162,9 @@ describe('collectOxcTemplateDependencies', () => {
       ].join('\n'),
     });
     expect(result.code).toContain('const _exp = () => ((props) => {');
-    expect(result.code).toContain('const lines = Math.ceil(props.value.length / 55);');
+    expect(result.code).toContain(
+      'const lines = Math.ceil(props.value.length / 55);'
+    );
     expect(result.code).toContain('return `');
     expect(result.code).toContain('${11 + lines * 24}px');
   });
@@ -273,7 +275,7 @@ describe('collectOxcTemplateDependencies', () => {
     const result = collectOxcTemplateDependencies(code, filename, true);
 
     expect(result.code).toContain(
-      `const _exp = () => (({\"fontSize\":12,\"fontWeight\":\"bold\"}));`
+      'const _exp = () => (({"fontSize":12,"fontWeight":"bold"}));'
     );
   });
 
@@ -304,7 +306,7 @@ describe('collectOxcTemplateDependencies', () => {
     expect(result.code).toContain('const _exp = () => ({ value: dynamic });');
     expect(result.code).not.toContain('const _exp = () => { value: dynamic };');
     expect(() =>
-      // eslint-disable-next-line no-new-func
+      // eslint-disable-next-line no-new-func,@typescript-eslint/no-implied-eval
       new Function(`const dynamic = 1; return (() => ({ value: dynamic }))()`)()
     ).not.toThrow();
   });
@@ -318,7 +320,9 @@ describe('collectOxcTemplateDependencies', () => {
 
     const result = collectOxcTemplateDependencies(code, filename, true);
 
-    expect(result.code).toContain('const _exp = () => ((sideEffect(), value));');
+    expect(result.code).toContain(
+      'const _exp = () => ((sideEffect(), value));'
+    );
   });
 
   it('does not inline tagged-template root objects into selector helpers', () => {

--- a/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.test.ts
+++ b/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.test.ts
@@ -184,9 +184,9 @@ describe('collectOxcTemplateDependencies', () => {
 
     const result = collectOxcTemplateDependencies(code, filename, true);
 
-    expect(result.code).toContain('let arg = str;');
-    expect(result.code).toContain('let variable = arg + "2";');
-    expect(result.code).toContain('const _exp = () => (variable);');
+    expect(result.code).toContain('let _arg = str;');
+    expect(result.code).toContain('let _variable = _arg + "2";');
+    expect(result.code).toContain('const _exp = () => (_variable);');
     expect(result.code).toContain('tag`${_exp()}`');
   });
 
@@ -201,8 +201,8 @@ describe('collectOxcTemplateDependencies', () => {
 
     const result = collectOxcTemplateDependencies(code, filename, true);
 
-    expect(result.code).toContain('let result = "result";');
-    expect(result.code).toContain('let { variable } = { variable: result };');
+    expect(result.code).toContain('let _result = "result";');
+    expect(result.code).toContain('let { variable } = { variable: _result };');
     expect(result.code).toContain('const _exp = () => (variable);');
   });
 

--- a/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.test.ts
+++ b/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.test.ts
@@ -29,6 +29,36 @@ describe('collectOxcTemplateDependencies', () => {
     expect(result.code).toContain(
       'tag`${_exp()}${_exp2()}${_exp3()}${_exp4()}`'
     );
+    expect(result.staticValues).toEqual(
+      expect.arrayContaining([
+        { name: '_exp', value: 42 },
+        { name: '_exp2', value: 'test' },
+      ])
+    );
+  });
+
+  it('records imported static candidates by generated helper name', () => {
+    const code = dedent`
+      import { color } from './tokens';
+
+      const template = tag\`${'${color}'}\`;
+    `;
+
+    const result = collectOxcTemplateDependencies(code, filename, true);
+
+    expect(result.staticValueCandidates).toEqual([
+      {
+        imports: [
+          {
+            imported: 'color',
+            local: 'color',
+            source: './tokens',
+          },
+        ],
+        name: '_exp',
+        source: 'color',
+      },
+    ]);
   });
 
   it('inserts hoisted expressions after imports and before the owner statement', () => {

--- a/packages/transform/src/utils/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors.ts
@@ -1091,7 +1091,8 @@ const collectUnusedImportRemovals = (
   code: string,
   program: Program,
   referencedNames: Set<string>,
-  removableNames: Set<string>
+  removableNames: Set<string>,
+  preserveSideEffectImportLocals: Set<string>
 ): Replacement[] => {
   const removals: Replacement[] = [];
 
@@ -1109,6 +1110,22 @@ const collectUnusedImportRemovals = (
       removableLocalNames.length === localNames.length &&
       removableLocalNames.every((localName) => !referencedNames.has(localName))
     ) {
+      if (
+        removableLocalNames.some((localName) =>
+          preserveSideEffectImportLocals.has(localName)
+        )
+      ) {
+        removals.push({
+          end: statement.end,
+          start: statement.start,
+          value: `import ${code.slice(
+            statement.source.start,
+            statement.source.end
+          )};`,
+        });
+        return;
+      }
+
       removals.push(
         expandImportRemovalRange(code, statement.start, statement.end)
       );
@@ -1270,7 +1287,8 @@ const removeUnusedAfterReplacement = (
   code: string,
   filename: string,
   initialRemovableNames: Set<string>,
-  removableExpressionRefs: Set<string>
+  removableExpressionRefs: Set<string>,
+  preserveSideEffectImportLocals: Set<string>
 ): string => {
   let current = code;
   const cumulativeRemovableNames = new Set(initialRemovableNames);
@@ -1316,7 +1334,8 @@ const removeUnusedAfterReplacement = (
         current,
         program,
         referencedNames,
-        cumulativeRemovableNames
+        cumulativeRemovableNames,
+        preserveSideEffectImportLocals
       ),
       ...collectTopLevelExpressionStatementRemovals(
         current,
@@ -2125,7 +2144,10 @@ export const applyOxcProcessors = (
   options: Pick<
     StrictOptions,
     'classNameSlug' | 'displayName' | 'extensions' | 'evaluate' | 'tagResolver'
-  > & { eventEmitter?: EventEmitter },
+  > & {
+    eventEmitter?: EventEmitter;
+    preserveSideEffectImportLocals?: Set<string>;
+  },
   callback: (processor: BaseProcessor) => void,
   cleanupUnused = false
 ): ApplyOxcProcessorsResult => {
@@ -2314,7 +2336,8 @@ export const applyOxcProcessors = (
             codeWithAddedImports,
             filename,
             removableImportLocals,
-            new Set([...removableExpressionRefs, ...extracted.dependencyNames])
+            new Set([...removableExpressionRefs, ...extracted.dependencyNames]),
+            options.preserveSideEffectImportLocals ?? new Set()
           )
         )
       : codeWithAddedImports,

--- a/packages/transform/src/utils/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors.ts
@@ -227,7 +227,8 @@ const insertAddedImports = (
   const prefix = code.slice(0, insertionPoint);
   const suffix = code.slice(insertionPoint);
   const leadingBreak = prefix.length > 0 && !prefix.endsWith('\n') ? '\n' : '';
-  const trailingBreak = suffix.length > 0 && !suffix.startsWith('\n') ? '\n' : '';
+  const trailingBreak =
+    suffix.length > 0 && !suffix.startsWith('\n') ? '\n' : '';
 
   return `${prefix}${leadingBreak}${importBlock}${trailingBreak}${suffix}`;
 };

--- a/packages/transform/src/utils/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors.ts
@@ -23,7 +23,11 @@ import type {
 
 import { collectOxcProcessorImportsFromProgram } from './collectOxcExportsAndImports';
 import { EventEmitter } from './EventEmitter';
-import { collectOxcExpressionDependencies } from './collectOxcTemplateDependencies';
+import {
+  collectOxcExpressionDependencies,
+  type OxcStaticValue,
+  type OxcStaticValueCandidate,
+} from './collectOxcTemplateDependencies';
 import { isNotNull } from './isNotNull';
 import {
   createOxcAstService,
@@ -45,6 +49,8 @@ type Replacement = {
 type ApplyOxcProcessorsResult = {
   code: string;
   processors: BaseProcessor[];
+  staticValueCandidates: OxcStaticValueCandidate[];
+  staticValues: OxcStaticValue[];
 };
 
 type AnyNode = Node & Record<string, unknown>;
@@ -2154,6 +2160,8 @@ export const applyOxcProcessors = (
     return {
       code: workingCode,
       processors: [],
+      staticValueCandidates: [],
+      staticValues: [],
     };
   }
 
@@ -2165,6 +2173,8 @@ export const applyOxcProcessors = (
     return {
       code: workingCode,
       processors: [],
+      staticValueCandidates: [],
+      staticValues: [],
     };
   }
 
@@ -2185,6 +2195,8 @@ export const applyOxcProcessors = (
           code: workingCode,
           dependencyNames: [],
           expressionValues: [],
+          staticValueCandidates: [],
+          staticValues: [],
         };
 
   if (extracted.code !== workingCode) {
@@ -2291,5 +2303,7 @@ export const applyOxcProcessors = (
         )
       : codeWithAddedImports,
     processors,
+    staticValueCandidates: extracted.staticValueCandidates,
+    staticValues: extracted.staticValues,
   };
 };

--- a/packages/transform/src/utils/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors.ts
@@ -426,14 +426,14 @@ const collectImportLocalNames = (node: Node): string[] => {
     return [];
   }
 
-  const specifiers = (node as AnyNode).specifiers;
+  const { specifiers } = node as AnyNode;
   if (!Array.isArray(specifiers)) {
     return [];
   }
 
   return specifiers
     .map((specifier) => {
-      const local = (specifier as AnyNode).local;
+      const { local } = specifier as AnyNode;
       return isNode(local) && 'name' in local && typeof local.name === 'string'
         ? local.name
         : null;
@@ -442,7 +442,7 @@ const collectImportLocalNames = (node: Node): string[] => {
 };
 
 const getImportSpecifierLocalName = (node: Node): string | null => {
-  const local = (node as AnyNode).local;
+  const { local } = node as AnyNode;
   return isNode(local) && 'name' in local && typeof local.name === 'string'
     ? local.name
     : null;
@@ -491,13 +491,13 @@ const collectTopLevelBindings = (statement: Node): Set<string> => {
   }
 
   if (statement.type === 'VariableDeclaration') {
-    const declarations = (statement as AnyNode).declarations;
+    const { declarations } = statement as AnyNode;
     if (!Array.isArray(declarations)) {
       return bindings;
     }
 
     declarations.forEach((declarator) => {
-      const id = (declarator as AnyNode).id;
+      const { id } = declarator as AnyNode;
       if (isNode(id)) {
         collectDeclaredNames(id).forEach((name) => bindings.add(name));
       }
@@ -511,7 +511,7 @@ const collectTopLevelBindings = (statement: Node): Set<string> => {
       statement.type === 'TSEnumDeclaration') &&
     'id' in statement
   ) {
-    const id = (statement as AnyNode).id;
+    const { id } = statement as AnyNode;
     if (isNode(id) && id.type === 'Identifier') {
       bindings.add(id.name);
     }
@@ -519,14 +519,18 @@ const collectTopLevelBindings = (statement: Node): Set<string> => {
   }
 
   if (statement.type === 'ExportNamedDeclaration') {
-    const declaration = (statement as AnyNode).declaration;
-    return isNode(declaration) ? collectTopLevelBindings(declaration) : bindings;
+    const { declaration } = statement as AnyNode;
+    return isNode(declaration)
+      ? collectTopLevelBindings(declaration)
+      : bindings;
   }
 
   return bindings;
 };
 
-const collectTopLevelStatementInfos = (program: Program): TopLevelStatementInfo[] =>
+const collectTopLevelStatementInfos = (
+  program: Program
+): TopLevelStatementInfo[] =>
   program.body.map((statement) => ({
     bindings: collectTopLevelBindings(statement),
     node: statement,
@@ -535,7 +539,8 @@ const collectTopLevelStatementInfos = (program: Program): TopLevelStatementInfo[
 
 const collectTopLevelBindingsFromStatements = (
   statements: TopLevelStatementInfo[]
-): Set<string> => new Set(statements.flatMap((statement) => [...statement.bindings]));
+): Set<string> =>
+  new Set(statements.flatMap((statement) => [...statement.bindings]));
 
 const collectRemovableNamesFromStatements = (
   statements: TopLevelStatementInfo[],
@@ -554,16 +559,14 @@ const collectRemovableNamesFromStatements = (
   while (queue.length > 0) {
     const name = queue.shift()!;
     const statement = bindingToStatement.get(name);
-    if (!statement) {
-      continue;
+    if (statement) {
+      statement.references.forEach((reference) => {
+        if (bindingToStatement.has(reference) && !removable.has(reference)) {
+          removable.add(reference);
+          queue.push(reference);
+        }
+      });
     }
-
-    statement.references.forEach((reference) => {
-      if (bindingToStatement.has(reference) && !removable.has(reference)) {
-        removable.add(reference);
-        queue.push(reference);
-      }
-    });
   }
 
   return removable;
@@ -656,11 +659,20 @@ const collectScopedBindingInfos = (
     target.externalReferences += 1;
   };
 
-  const walkPatternReferenceSubexpressions = (
+  type ScopedWalk = (
+    node: Node,
+    scope: ScopedCleanupScope,
+    parent?: Node | null,
+    ownerBindingId?: string | null
+  ) => void;
+
+  let walk: ScopedWalk;
+
+  function walkPatternReferenceSubexpressions(
     node: Node,
     scope: ScopedCleanupScope,
     ownerBindingId: string | null
-  ): void => {
+  ): void {
     if (node.type === 'Identifier') {
       return;
     }
@@ -712,19 +724,19 @@ const collectScopedBindingInfos = (
         }
       });
     }
-  };
+  }
 
-  const walk = (
+  walk = (
     node: Node,
     scope: ScopedCleanupScope,
     parent: Node | null = null,
     ownerBindingId: string | null = null
   ): void => {
     if (node.type === 'ImportDeclaration') {
-      const specifiers = (node as AnyNode).specifiers;
+      const { specifiers } = node as AnyNode;
       if (Array.isArray(specifiers)) {
         specifiers.forEach((specifier) => {
-          const local = (specifier as AnyNode).local;
+          const { local } = specifier as AnyNode;
           if (
             isNode(local) &&
             local.type === 'Identifier' &&
@@ -746,7 +758,7 @@ const collectScopedBindingInfos = (
     }
 
     if (node.type === 'ExportDefaultDeclaration') {
-      const declaration = (node as AnyNode).declaration;
+      const { declaration } = node as AnyNode;
       if (isNode(declaration)) {
         walk(declaration, scope, node, ownerBindingId);
         if (
@@ -761,21 +773,21 @@ const collectScopedBindingInfos = (
     }
 
     if (node.type === 'VariableDeclaration') {
-      const declarations = (node as AnyNode).declarations;
+      const { declarations } = node as AnyNode;
       if (!Array.isArray(declarations)) {
         return;
       }
 
       declarations.forEach((declarator) => {
-        const id = (declarator as AnyNode).id;
+        const { id } = declarator as AnyNode;
         if (isNode(id)) {
           addPatternBindings(scope, id, 'variable', node);
         }
       });
 
       declarations.forEach((declarator) => {
-        const id = (declarator as AnyNode).id;
-        const init = (declarator as AnyNode).init;
+        const { id } = declarator as AnyNode;
+        const { init } = declarator as AnyNode;
         if (!isNode(id) || !isNode(init)) {
           return;
         }
@@ -789,16 +801,17 @@ const collectScopedBindingInfos = (
     }
 
     if (node.type === 'FunctionDeclaration' && node.id) {
-      const functionBindingId = addBinding(scope, node.id.name, 'function', node);
+      const functionBindingId = addBinding(
+        scope,
+        node.id.name,
+        'function',
+        node
+      );
       const fnScope = createScopedCleanupScope(scope);
 
       node.params.forEach((param) => {
         addPatternBindings(fnScope, param, 'param', param);
-        walkPatternReferenceSubexpressions(
-          param,
-          fnScope,
-          functionBindingId
-        );
+        walkPatternReferenceSubexpressions(param, fnScope, functionBindingId);
       });
 
       if (node.body) {
@@ -829,7 +842,9 @@ const collectScopedBindingInfos = (
 
     if (node.type === 'BlockStatement') {
       const blockScope = createScopedCleanupScope(scope);
-      getChildren(node).forEach((child) => walk(child, blockScope, node, ownerBindingId));
+      getChildren(node).forEach((child) =>
+        walk(child, blockScope, node, ownerBindingId)
+      );
       return;
     }
 
@@ -841,7 +856,9 @@ const collectScopedBindingInfos = (
       recordReference(scope, node.name, ownerBindingId);
     }
 
-    getChildren(node).forEach((child) => walk(child, scope, node, ownerBindingId));
+    getChildren(node).forEach((child) =>
+      walk(child, scope, node, ownerBindingId)
+    );
   };
 
   walk(program, createScopedCleanupScope(null));
@@ -858,38 +875,74 @@ const collectScopedRemovableBindingIds = (
   while (changed) {
     changed = false;
 
-    bindings.forEach((binding) => {
+    for (const binding of bindings.values()) {
       if (
-        removable.has(binding.id) ||
-        binding.kind === 'import' ||
-        binding.kind === 'param' ||
-        binding.externalReferences > 0
+        !removable.has(binding.id) &&
+        binding.kind !== 'import' &&
+        binding.kind !== 'param' &&
+        binding.externalReferences === 0
       ) {
-        return;
-      }
+        const seededByName =
+          initialNames.has(binding.name) ||
+          (GENERATED_HELPER_NAME_RE.test(binding.name) &&
+            binding.incomingFromBindings.size === 0);
+        const allIncomingRemovable =
+          binding.incomingFromBindings.size > 0 &&
+          [...binding.incomingFromBindings].every((sourceId) =>
+            removable.has(sourceId)
+          );
 
-      const seededByName =
-        initialNames.has(binding.name) ||
-        (GENERATED_HELPER_NAME_RE.test(binding.name) &&
-          binding.incomingFromBindings.size === 0);
-      const allIncomingRemovable =
-        binding.incomingFromBindings.size > 0 &&
-        [...binding.incomingFromBindings].every((sourceId) =>
-          removable.has(sourceId)
-        );
-
-      if (
-        (seededByName && binding.incomingFromBindings.size === 0) ||
-        allIncomingRemovable
-      ) {
-        removable.add(binding.id);
-        changed = true;
+        if (
+          (seededByName && binding.incomingFromBindings.size === 0) ||
+          allIncomingRemovable
+        ) {
+          removable.add(binding.id);
+          changed = true;
+        }
       }
-    });
+    }
   }
 
   return removable;
 };
+
+function expandImportRemovalRange(
+  code: string,
+  start: number,
+  end: number
+): Replacement {
+  let removalStart = start;
+  while (
+    removalStart > 0 &&
+    (code[removalStart - 1] === ' ' || code[removalStart - 1] === '\t')
+  ) {
+    removalStart -= 1;
+  }
+
+  let removalEnd = end;
+  if (code[removalEnd] === ';') {
+    removalEnd += 1;
+  }
+
+  while (
+    removalEnd < code.length &&
+    (code[removalEnd] === ' ' || code[removalEnd] === '\t')
+  ) {
+    removalEnd += 1;
+  }
+
+  if (code[removalEnd] === '\r' && code[removalEnd + 1] === '\n') {
+    removalEnd += 2;
+  } else if (code[removalEnd] === '\n') {
+    removalEnd += 1;
+  }
+
+  return {
+    end: removalEnd,
+    start: removalStart,
+    value: '',
+  };
+}
 
 const collectUnusedScopedDeclarationRemovals = (
   code: string,
@@ -932,7 +985,7 @@ const collectUnusedScopedDeclarationRemovals = (
       return;
     }
 
-    const declarations = (binding.declaration as AnyNode).declarations;
+    const { declarations } = binding.declaration as AnyNode;
     if (!Array.isArray(declarations) || declarations.length !== 1) {
       return;
     }
@@ -946,44 +999,6 @@ const collectUnusedScopedDeclarationRemovals = (
   });
 
   return [...removals.values()];
-};
-
-const expandImportRemovalRange = (
-  code: string,
-  start: number,
-  end: number
-): Replacement => {
-  let removalStart = start;
-  while (
-    removalStart > 0 &&
-    (code[removalStart - 1] === ' ' || code[removalStart - 1] === '\t')
-  ) {
-    removalStart -= 1;
-  }
-
-  let removalEnd = end;
-  if (code[removalEnd] === ';') {
-    removalEnd += 1;
-  }
-
-  while (
-    removalEnd < code.length &&
-    (code[removalEnd] === ' ' || code[removalEnd] === '\t')
-  ) {
-    removalEnd += 1;
-  }
-
-  if (code[removalEnd] === '\r' && code[removalEnd + 1] === '\n') {
-    removalEnd += 2;
-  } else if (code[removalEnd] === '\n') {
-    removalEnd += 1;
-  }
-
-  return {
-    end: removalEnd,
-    start: removalStart,
-    value: '',
-  };
 };
 
 const expandImportSpecifierRemovalRange = (
@@ -1100,7 +1115,7 @@ const collectUnusedImportRemovals = (
       return;
     }
 
-    const specifiers = (statement as AnyNode).specifiers;
+    const { specifiers } = statement as AnyNode;
     if (!Array.isArray(specifiers) || specifiers.length <= 1) {
       return;
     }
@@ -1174,7 +1189,9 @@ const collectUnusedGeneratedHelperDeclarationRemovals = (
     const localNames = [...collectTopLevelBindings(statement)];
     if (
       localNames.length > 0 &&
-      localNames.every((localName) => GENERATED_HELPER_NAME_RE.test(localName)) &&
+      localNames.every((localName) =>
+        GENERATED_HELPER_NAME_RE.test(localName)
+      ) &&
       localNames.every((localName) => !referencedNames.has(localName))
     ) {
       removals.push(
@@ -1199,7 +1216,7 @@ const collectTopLevelExpressionStatementRemovals = (
       return;
     }
 
-    const expression = statement.node.expression;
+    const { expression } = statement.node;
     const isPureExpression =
       expression.type === 'Identifier' ||
       expression.type === 'Literal' ||
@@ -1222,11 +1239,7 @@ const collectTopLevelExpressionStatementRemovals = (
       localReferences.every((name) => removableExpressionRefs.has(name))
     ) {
       removals.push(
-        expandImportRemovalRange(
-          code,
-          statement.node.start,
-          statement.node.end
-        )
+        expandImportRemovalRange(code, statement.node.start, statement.node.end)
       );
     }
   });
@@ -1245,7 +1258,9 @@ const collectEmptyTopLevelBlockRemovals = (
       return;
     }
 
-    removals.push(expandImportRemovalRange(code, statement.start, statement.end));
+    removals.push(
+      expandImportRemovalRange(code, statement.start, statement.end)
+    );
   });
 
   return removals;
@@ -1444,18 +1459,14 @@ const expandReplacementTarget = (
       ancestor.expressions[ancestor.expressions.length - 1] === current
     ) {
       current = ancestor as Expression;
-      continue;
-    }
-
-    if (
+    } else if (
       ancestor.type === 'ParenthesizedExpression' &&
       ancestor.expression === current
     ) {
       current = ancestor as Expression;
-      continue;
+    } else {
+      break;
     }
-
-    break;
   }
 
   return current;
@@ -1648,19 +1659,23 @@ const expressionValue = (
       ? expression.callee.name
       : null;
 
+  let ex: ExpressionValue['ex'];
+  if (expression.type === 'Identifier') {
+    ex = { loc: location, name: expression.name, type: 'Identifier' };
+  } else if (helperCallName) {
+    ex = { loc: location, name: helperCallName, type: 'Identifier' };
+  } else {
+    ex = {
+      loc: location,
+      name: code.slice(expression.start, expression.end),
+      type: 'Identifier',
+    };
+  }
+
   return {
     buildCodeFrameError: (message: string) =>
       buildCodeFrameError(code, location, message),
-    ex:
-      expression.type === 'Identifier'
-        ? { loc: location, name: expression.name, type: 'Identifier' }
-        : helperCallName
-          ? { loc: location, name: helperCallName, type: 'Identifier' }
-        : {
-            loc: location,
-            name: code.slice(expression.start, expression.end),
-            type: 'Identifier',
-          },
+    ex,
     kind:
       expression.type === 'ArrowFunctionExpression' ||
       expression.type === 'FunctionExpression'
@@ -2037,12 +2052,12 @@ const createProcessor = (
         error instanceof Error &&
         error.message.startsWith("Couldn't determine a name for the component")
       ) {
-        const displayNameNode =
-          target.type === 'TaggedTemplateExpression'
-            ? target.tag
-            : target.type === 'CallExpression'
-              ? target.callee
-              : target;
+        let displayNameNode: Node = target;
+        if (target.type === 'TaggedTemplateExpression') {
+          displayNameNode = target.tag;
+        } else if (target.type === 'CallExpression') {
+          displayNameNode = target.callee;
+        }
         const pointerNode =
           displayNameNode.type === 'MemberExpression'
             ? getRootIdentifier(displayNameNode) ?? displayNameNode
@@ -2128,32 +2143,35 @@ export const applyOxcProcessors = (
       () => collectOxcProcessorImportsFromProgram(program, workingCode)
     );
 
-    eventEmitter.perf('transform:preeval:processTemplate:imports:lookup', () => {
-      imports.forEach((item) => {
-        const localName = item.local.name ?? item.local.code;
-        if (item.imported === 'side-effect' || !localName) {
-          return;
-        }
-
-        const [processor, tagSource] = getProcessorForImport(
-          {
-            imported: item.imported,
-            source: item.source,
-          },
-          filename,
-          options
-        );
-
-        if (processor) {
-          definedProcessors.set(localName, [processor, tagSource]);
-          removableImportLocals.add(localName);
-          const rootLocalName = localName.split('.')[0];
-          if (rootLocalName) {
-            removableImportLocals.add(rootLocalName);
+    eventEmitter.perf(
+      'transform:preeval:processTemplate:imports:lookup',
+      () => {
+        imports.forEach((item) => {
+          const localName = item.local.name ?? item.local.code;
+          if (item.imported === 'side-effect' || !localName) {
+            return;
           }
-        }
-      });
-    });
+
+          const [processor, tagSource] = getProcessorForImport(
+            {
+              imported: item.imported,
+              source: item.source,
+            },
+            filename,
+            options
+          );
+
+          if (processor) {
+            definedProcessors.set(localName, [processor, tagSource]);
+            removableImportLocals.add(localName);
+            const rootLocalName = localName.split('.')[0];
+            if (rootLocalName) {
+              removableImportLocals.add(rootLocalName);
+            }
+          }
+        });
+      }
+    );
   });
 
   if (definedProcessors.size === 0) {
@@ -2178,8 +2196,9 @@ export const applyOxcProcessors = (
     };
   }
 
-  const targetExpressionSpans =
-    processorUsages.flatMap(collectUsageExpressionSpans);
+  const targetExpressionSpans = processorUsages.flatMap(
+    collectUsageExpressionSpans
+  );
 
   const extracted =
     targetExpressionSpans.length > 0
@@ -2269,7 +2288,7 @@ export const applyOxcProcessors = (
 
       const owner = getTagOwner(usage.ancestors);
       if (owner?.type === 'VariableDeclarator') {
-        const id = owner.id;
+        const { id } = owner;
         if (isNode(id) && id.type === 'Identifier') {
           removableExpressionRefs.add(id.name);
         }
@@ -2295,10 +2314,7 @@ export const applyOxcProcessors = (
             codeWithAddedImports,
             filename,
             removableImportLocals,
-            new Set([
-              ...removableExpressionRefs,
-              ...extracted.dependencyNames,
-            ])
+            new Set([...removableExpressionRefs, ...extracted.dependencyNames])
           )
         )
       : codeWithAddedImports,

--- a/packages/transform/src/utils/collectOxcExportsAndImports.ts
+++ b/packages/transform/src/utils/collectOxcExportsAndImports.ts
@@ -1382,7 +1382,12 @@ export function collectOxcExportsAndImportsFromProgram(
   };
 
   precollectRequireSources(program, state);
-  visit(program, { key: 'program', parent: null, scope: rootScope }, state, 'all');
+  visit(
+    program,
+    { key: 'program', parent: null, scope: rootScope },
+    state,
+    'all'
+  );
   addUnusedNamespaceSideEffects(state);
 
   return state.result;

--- a/packages/transform/src/utils/collectOxcRuntime.ts
+++ b/packages/transform/src/utils/collectOxcRuntime.ts
@@ -89,10 +89,7 @@ const shouldTerminateWithSemicolon = (
   parent: Node | null,
   key: string | null
 ): boolean => {
-  if (
-    node.type === 'VariableDeclaration' &&
-    parent
-  ) {
+  if (node.type === 'VariableDeclaration' && parent) {
     if (
       (parent.type === 'ForStatement' ||
         parent.type === 'ForInStatement' ||
@@ -225,7 +222,10 @@ const printFormattedObjectExpression = (
   return `{\n${lines.join(',\n')}\n${baseIndent}}`;
 };
 
-const formatRuntimeObjectLiterals = (code: string, filename: string): string => {
+const formatRuntimeObjectLiterals = (
+  code: string,
+  filename: string
+): string => {
   const replacements: Replacement[] = [];
 
   const walk = (node: Node, parent: Node | null = null): void => {
@@ -263,33 +263,31 @@ const collapseRuntimeBlankLines = (code: string): string => {
     const line = lines[idx]!;
     if (line.trim() !== '') {
       result.push(line);
-      continue;
-    }
+    } else {
+      let nextIdx = idx;
+      while (nextIdx < lines.length && lines[nextIdx]?.trim() === '') {
+        nextIdx += 1;
+      }
 
-    let nextIdx = idx;
-    while (nextIdx < lines.length && lines[nextIdx]?.trim() === '') {
-      nextIdx += 1;
-    }
+      const previousNonEmpty = [...result]
+        .reverse()
+        .find((entry) => entry.trim() !== '');
+      const nextNonEmpty = lines
+        .slice(nextIdx)
+        .find((entry) => entry.trim() !== '');
 
-    const previousNonEmpty = [...result]
-      .reverse()
-      .find((entry) => entry.trim() !== '');
-    const nextNonEmpty = lines.slice(nextIdx).find((entry) => entry.trim() !== '');
+      if (previousNonEmpty && nextNonEmpty) {
+        const trimmedPrevious = previousNonEmpty.trim();
+        if (
+          trimmedPrevious.startsWith('//') ||
+          trimmedPrevious.endsWith('*/')
+        ) {
+          result.push('');
+        }
+      }
 
-    if (!previousNonEmpty || !nextNonEmpty) {
       idx = nextIdx - 1;
-      continue;
     }
-
-    const trimmedPrevious = previousNonEmpty.trim();
-    if (
-      trimmedPrevious.startsWith('//') ||
-      trimmedPrevious.endsWith('*/')
-    ) {
-      result.push('');
-    }
-
-    idx = nextIdx - 1;
   }
 
   return result.join('\n');

--- a/packages/transform/src/utils/collectOxcRuntime.ts
+++ b/packages/transform/src/utils/collectOxcRuntime.ts
@@ -18,7 +18,9 @@ type OxcCollectOptions = Pick<
   | 'extensions'
   | 'tagResolver'
   | 'variableNameConfig'
->;
+> & {
+  preserveSideEffectImportLocals?: Set<string>;
+};
 
 type OxcCollectResult = {
   code: string;

--- a/packages/transform/src/utils/collectOxcTemplateDependencies.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies.ts
@@ -5,6 +5,9 @@ import { ValueType } from '@wyw-in-js/shared';
 import type {
   AssignmentExpression,
   Expression,
+  ImportDeclaration,
+  ImportSpecifier,
+  ModuleExportName,
   Node,
   Program,
   TemplateLiteral,
@@ -31,6 +34,7 @@ type Binding = {
   declaration: VariableDeclaration | null;
   declarator: VariableDeclarator | null;
   functionNode?: OxcFunctionLikeNode | null;
+  imported?: 'default' | '*' | string;
   importedFrom?: string;
   isRoot: boolean;
   kind: BindingKind;
@@ -77,10 +81,29 @@ type ReferenceIdentifier = {
   start: number;
 };
 
+export type OxcStaticImportReference = {
+  imported: 'default' | string;
+  local: string;
+  source: string;
+};
+
+export type OxcStaticValue = {
+  name: string;
+  value: unknown;
+};
+
+export type OxcStaticValueCandidate = {
+  imports: OxcStaticImportReference[];
+  name: string;
+  source: string;
+};
+
 type TemplateExtractionResult = {
   code: string;
   dependencyNames: string[];
   expressionValues: Omit<ExpressionValue, 'buildCodeFrameError'>[];
+  staticValueCandidates: OxcStaticValueCandidate[];
+  staticValues: OxcStaticValue[];
 };
 
 type ExtractionContext = {
@@ -99,6 +122,8 @@ type ExtractionContext = {
   referencesByNode: WeakMap<Node, ReferenceIdentifier[]>;
   replacements: Replacement[];
   rootMutationsByBinding: Map<string, Array<AssignmentExpression | UpdateExpression>>;
+  staticValueCandidates: OxcStaticValueCandidate[];
+  staticValues: OxcStaticValue[];
   usedNames: Set<string>;
 };
 
@@ -106,6 +131,8 @@ type ExtractedExpression = {
   expressionCode: string;
   importedFrom: string[];
   kind: ValueType.FUNCTION | ValueType.LAZY;
+  staticImports: OxcStaticImportReference[];
+  staticValue?: unknown;
 };
 
 type ProgramAnalysis = {
@@ -244,6 +271,45 @@ const normalizeDeclarationKind = (
   }
 
   return 'const';
+};
+
+const moduleExportName = (node: ModuleExportName): string =>
+  node.type === 'Literal' ? String(node.value) : node.name;
+
+const getImportSpecifierInfo = (
+  statement: ImportDeclaration,
+  specifier: ImportDeclaration['specifiers'][number]
+): { imported: 'default' | '*' | string; local: string } | null => {
+  const local = specifier.local?.name;
+  if (!local) {
+    return null;
+  }
+
+  if (specifier.type === 'ImportDefaultSpecifier') {
+    return {
+      imported: 'default',
+      local,
+    };
+  }
+
+  if (specifier.type === 'ImportNamespaceSpecifier') {
+    return {
+      imported: '*',
+      local,
+    };
+  }
+
+  if (
+    statement.importKind === 'type' ||
+    (specifier as ImportSpecifier).importKind === 'type'
+  ) {
+    return null;
+  }
+
+  return {
+    imported: moduleExportName((specifier as ImportSpecifier).imported),
+    local,
+  };
 };
 
 const getDeclarationScope = (
@@ -494,15 +560,21 @@ const analyzeProgram = (
     if (node.type === 'ImportDeclaration') {
       const source = node.source.value;
       node.specifiers.forEach((specifier) => {
+        const importInfo = getImportSpecifierInfo(node, specifier);
+        if (!importInfo) {
+          return;
+        }
+
         addBinding(scope, {
           declaredAt: specifier.start,
           declaration: null,
           declarator: null,
           functionNode: null,
+          imported: importInfo.imported,
           importedFrom: source,
           isRoot: scope.root,
           kind: 'import',
-          name: specifier.local.name,
+          name: importInfo.local,
           scope,
         });
       });
@@ -771,6 +843,9 @@ const literalCode = (value: unknown): string | null => {
 
   return null;
 };
+
+const isStaticSerializableValue = (value: unknown): boolean =>
+  literalCode(value) !== null;
 
 const cloneStaticValue = (value: unknown): unknown => {
   if (Array.isArray(value)) {
@@ -1135,6 +1210,17 @@ const evaluateStatic = (
   env: EvalEnv = new Map(),
   stack: string[] = []
 ): unknown | undefined => {
+  if (
+    expression.type === 'TSAsExpression' ||
+    expression.type === 'TSSatisfiesExpression' ||
+    expression.type === 'TSNonNullExpression' ||
+    expression.type === 'TSInstantiationExpression' ||
+    expression.type === 'TSTypeAssertion' ||
+    expression.type === 'ParenthesizedExpression'
+  ) {
+    return evaluateStatic(expression.expression as Expression, ctx, env, stack);
+  }
+
   if (expression.type === 'Literal') {
     return expression.value;
   }
@@ -1279,8 +1365,18 @@ const evaluateStatic = (
     const result: unknown[] = [];
 
     for (const element of expression.elements) {
-      if (!element || element.type === 'SpreadElement') {
+      if (!element) {
         return undefined;
+      }
+
+      if (element.type === 'SpreadElement') {
+        const spreadValue = evaluateStatic(element.argument, ctx, env, stack);
+        if (!Array.isArray(spreadValue)) {
+          return undefined;
+        }
+
+        result.push(...spreadValue);
+        continue;
       }
 
       const value = evaluateStatic(element, ctx, env, stack);
@@ -1663,12 +1759,18 @@ const extractExpression = (
         expressionCode: literal,
         importedFrom: [],
         kind: isFunction ? ValueType.FUNCTION : ValueType.LAZY,
+        staticImports: [],
+        staticValue: isStaticSerializableValue(evaluated)
+          ? cloneStaticValue(evaluated)
+          : undefined,
       };
     }
   }
 
   const identifierReplacements = new Map<string, string>();
   const importedFrom: string[] = [];
+  const staticImports: OxcStaticImportReference[] = [];
+  let hasNonStaticLocalReference = false;
 
   findReferences(expression, ctx.referencesByNode).forEach(({ name, start }) => {
     const binding = resolveBindingAt(ctx, name, start);
@@ -1684,6 +1786,15 @@ const extractExpression = (
 
     if (binding.importedFrom) {
       importedFrom.push(binding.importedFrom);
+      if (binding.imported && binding.imported !== '*') {
+        staticImports.push({
+          imported: binding.imported,
+          local: binding.name,
+          source: binding.importedFrom,
+        });
+      } else {
+        hasNonStaticLocalReference = true;
+      }
       return;
     }
 
@@ -1693,6 +1804,7 @@ const extractExpression = (
       return;
     }
 
+    hasNonStaticLocalReference = true;
     assertHoistable(binding, ctx);
     addHoistedDeclaration(binding, ctx);
     if (!binding.isRoot && binding.declarator?.id.type === 'Identifier') {
@@ -1707,6 +1819,7 @@ const extractExpression = (
         : source,
     importedFrom,
     kind: isFunction ? ValueType.FUNCTION : ValueType.LAZY,
+    staticImports: hasNonStaticLocalReference ? [] : staticImports,
   };
 };
 
@@ -1797,7 +1910,13 @@ const extractExpressions = (
   expressions: Expression[]
 ): TemplateExtractionResult => {
   if (expressions.length === 0) {
-    return { code, dependencyNames: [], expressionValues: [] };
+    return {
+      code,
+      dependencyNames: [],
+      expressionValues: [],
+      staticValueCandidates: [],
+      staticValues: [],
+    };
   }
 
   const insertionPoints = getInsertionPoints(program, expressions);
@@ -1817,6 +1936,8 @@ const extractExpressions = (
     referencesByNode: new WeakMap(),
     replacements: [],
     rootMutationsByBinding: analysis.rootMutationsByBinding,
+    staticValueCandidates: [],
+    staticValues: [],
     usedNames: new Set(analysis.usedNames),
   };
 
@@ -1830,11 +1951,8 @@ const extractExpressions = (
       return;
     }
 
-    const { expressionCode, importedFrom, kind } = extractExpression(
-      expression,
-      ctx,
-      evaluate
-    );
+    const { expressionCode, importedFrom, kind, staticImports, staticValue } =
+      extractExpression(expression, ctx, evaluate);
     const expName = allocateExpressionName(ctx);
 
     addHoistedCode(
@@ -1842,6 +1960,25 @@ const extractExpressions = (
       `const ${expName} = () => (${expressionCode});`,
       ctx
     );
+    if (staticValue !== undefined && kind !== ValueType.FUNCTION) {
+      ctx.staticValues.push({
+        name: expName,
+        value: staticValue,
+      });
+    } else if (staticImports.length > 0 && kind !== ValueType.FUNCTION) {
+      const uniqueImports = new Map<string, OxcStaticImportReference>();
+      staticImports.forEach((item) => {
+        uniqueImports.set(
+          `${item.local}\0${item.source}\0${item.imported}`,
+          item
+        );
+      });
+      ctx.staticValueCandidates.push({
+        imports: [...uniqueImports.values()],
+        name: expName,
+        source: expressionCode,
+      });
+    }
     ctx.replacements.push({
       start: expression.start,
       end: expression.end,
@@ -1871,7 +2008,80 @@ const extractExpressions = (
     code: applyReplacements(code, ctx.replacements),
     dependencyNames: [...ctx.dependencyNames],
     expressionValues: ctx.expressionValues,
+    staticValueCandidates: ctx.staticValueCandidates,
+    staticValues: ctx.staticValues,
   };
+};
+
+export const isOxcStaticSerializableValue = (value: unknown): boolean =>
+  isStaticSerializableValue(value);
+
+export const evaluateOxcStaticExpressionAt = (
+  code: string,
+  filename: string,
+  expressionSpan: ExpressionSpan,
+  staticBindings: Map<string, unknown> = new Map()
+): unknown | undefined => {
+  const program = parseOxc(code, filename);
+  const analysis = analyzeProgram(program, {
+    collectTargetExpressions: true,
+    expressionSpanLookup: createSpanLookup([expressionSpan]),
+  });
+  const [expression] = analysis.targetExpressions;
+  if (!expression) {
+    return undefined;
+  }
+
+  const ctx: ExtractionContext = {
+    bindingResolutionCache: new Map(),
+    bindingsByName: analysis.bindingsByName,
+    code,
+    currentInsertionPoint: 0,
+    currentExpressionStart: expression.start,
+    dependencyNames: new Set(),
+    expressionValues: [],
+    filename,
+    hoistedBindingNames: new Map(),
+    hoistedDeclarations: new Map(),
+    hoistedDeclarationsByInsertionPoint: new Map(),
+    loc: createLocationLookup(code),
+    referencesByNode: new WeakMap(),
+    replacements: [],
+    rootMutationsByBinding: analysis.rootMutationsByBinding,
+    staticValueCandidates: [],
+    staticValues: [],
+    usedNames: new Set(analysis.usedNames),
+  };
+
+  return evaluateStatic(expression, ctx, new Map(staticBindings));
+};
+
+export const evaluateOxcStaticExpression = (
+  source: string,
+  filename: string,
+  staticBindings: Map<string, unknown> = new Map()
+): unknown | undefined => {
+  const code = `const __wyw_static_value = ${source};`;
+  const program = parseOxc(code, filename);
+  const declaration = program.body[0];
+  if (declaration?.type !== 'VariableDeclaration') {
+    return undefined;
+  }
+
+  const [declarator] = declaration.declarations;
+  if (!declarator?.init) {
+    return undefined;
+  }
+
+  return evaluateOxcStaticExpressionAt(
+    code,
+    filename,
+    {
+      end: declarator.init.end,
+      start: declarator.init.start,
+    },
+    staticBindings
+  );
 };
 
 export const collectOxcExpressionDependencies = (
@@ -1911,5 +2121,12 @@ export const collectOxcTemplateDependencies = (
     (template) => template.expressions
   );
 
-  return extractExpressions(code, filename, evaluate, program, analysis, expressions);
+  return extractExpressions(
+    code,
+    filename,
+    evaluate,
+    program,
+    analysis,
+    expressions
+  );
 };

--- a/packages/transform/src/utils/collectOxcTemplateDependencies.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies.ts
@@ -7,6 +7,7 @@ import type {
   Expression,
   ImportDeclaration,
   ImportSpecifier,
+  MemberExpression,
   ModuleExportName,
   Node,
   Program,
@@ -83,6 +84,7 @@ type ReferenceIdentifier = {
 
 export type OxcStaticImportReference = {
   imported: 'default' | string;
+  importLocal?: string;
   local: string;
   source: string;
 };
@@ -125,6 +127,7 @@ type ExtractionContext = {
     string,
     Array<AssignmentExpression | UpdateExpression>
   >;
+  staticImportAliases: Map<string, string>;
   staticValueCandidates: OxcStaticValueCandidate[];
   staticValues: OxcStaticValue[];
   usedNames: Set<string>;
@@ -134,6 +137,7 @@ type ExtractedExpression = {
   expressionCode: string;
   importedFrom: string[];
   kind: ValueType.FUNCTION | ValueType.LAZY;
+  staticExpressionCode?: string;
   staticImports: OxcStaticImportReference[];
   staticValue?: unknown;
 };
@@ -892,6 +896,28 @@ const getObjectMember = (
 
 type EvalEnv = Map<string, unknown>;
 
+const oxcStaticCallableValue = Symbol('wyw.oxc.staticCallableValue');
+
+type OxcStaticCallableValue = {
+  [oxcStaticCallableValue]: unknown;
+};
+
+const isOxcStaticCallableValue = (
+  value: unknown
+): value is OxcStaticCallableValue =>
+  typeof value === 'object' &&
+  value !== null &&
+  oxcStaticCallableValue in value;
+
+const unwrapOxcStaticCallableValue = (value: unknown): unknown =>
+  isOxcStaticCallableValue(value) ? value[oxcStaticCallableValue] : value;
+
+export const createOxcStaticCallableValue = (
+  value: unknown
+): OxcStaticCallableValue => ({
+  [oxcStaticCallableValue]: value,
+});
+
 const assignPatternValue = (
   pattern: Node,
   value: unknown,
@@ -1179,6 +1205,121 @@ const replaceIdentifierReferences = (
   return result;
 };
 
+const applyExpressionReplacements = (
+  expression: Expression,
+  replacements: Replacement[],
+  code: string
+): string => {
+  let result = code.slice(expression.start, expression.end);
+  replacements
+    .sort((a, b) => b.start - a.start)
+    .forEach((replacement) => {
+      const start = replacement.start - expression.start;
+      const end = replacement.end - expression.start;
+      result = result.slice(0, start) + replacement.value + result.slice(end);
+    });
+  return result;
+};
+
+const staticImportAliasPart = (value: string): string =>
+  value.replace(/[^A-Za-z0-9_$]/g, '_') || 'value';
+
+const allocateStaticImportAlias = (
+  binding: Binding,
+  imported: string,
+  ctx: ExtractionContext
+): string => {
+  const key = `${binding.importedFrom ?? ''}\0${binding.name}\0${imported}`;
+  const existing = ctx.staticImportAliases.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const namespacePart = staticImportAliasPart(binding.name);
+  const importedPart = staticImportAliasPart(imported);
+  let alias = `_wyw_static_${namespacePart}_${importedPart}`;
+  let idx = 1;
+  while (ctx.usedNames.has(alias)) {
+    idx += 1;
+    alias = `_wyw_static_${namespacePart}_${importedPart}_${idx}`;
+  }
+
+  ctx.usedNames.add(alias);
+  ctx.staticImportAliases.set(key, alias);
+  return alias;
+};
+
+const staticMemberPropertyName = (
+  expression: MemberExpression
+): string | null => {
+  if (!expression.computed && expression.property.type === 'Identifier') {
+    return expression.property.name;
+  }
+
+  if (
+    expression.computed &&
+    expression.property.type === 'Literal' &&
+    typeof expression.property.value === 'string'
+  ) {
+    return expression.property.value;
+  }
+
+  return null;
+};
+
+const collectStaticNamespaceMemberReferences = (
+  expression: Expression,
+  ctx: ExtractionContext
+): {
+  coveredReferenceStarts: Set<number>;
+  imports: OxcStaticImportReference[];
+  replacements: Replacement[];
+} => {
+  const coveredReferenceStarts = new Set<number>();
+  const imports = new Map<string, OxcStaticImportReference>();
+  const replacements: Replacement[] = [];
+
+  const walk = (node: Node): void => {
+    if (node.type === 'MemberExpression' && node.object.type === 'Identifier') {
+      const binding = resolveBindingAt(
+        ctx,
+        node.object.name,
+        node.object.start
+      );
+      const imported = staticMemberPropertyName(node);
+      if (
+        binding?.importedFrom &&
+        binding.imported === '*' &&
+        imported !== null
+      ) {
+        const alias = allocateStaticImportAlias(binding, imported, ctx);
+        imports.set(`${binding.importedFrom}\0${imported}\0${alias}`, {
+          imported,
+          importLocal: binding.name,
+          local: alias,
+          source: binding.importedFrom,
+        });
+        replacements.push({
+          end: node.end,
+          start: node.start,
+          value: alias,
+        });
+        coveredReferenceStarts.add(node.object.start);
+      }
+    }
+
+    getChildren(node).forEach(walk);
+  };
+
+  walk(expression);
+
+  return {
+    coveredReferenceStarts,
+    imports: [...imports.values()],
+    replacements,
+  };
+};
+
 const evaluateBinary = (
   expression: Expression,
   ctx: ExtractionContext
@@ -1265,7 +1406,7 @@ const evaluateStatic = (
 
   if (expression.type === 'Identifier') {
     if (env.has(expression.name)) {
-      return env.get(expression.name);
+      return unwrapOxcStaticCallableValue(env.get(expression.name));
     }
 
     const binding = resolveBindingAt(ctx, expression.name, expression.start);
@@ -1461,6 +1602,14 @@ const evaluateStatic = (
       );
       if (args.some((value) => value === undefined)) {
         return undefined;
+      }
+
+      const staticCallable = env.get(expression.callee.name);
+      if (
+        isOxcStaticCallableValue(staticCallable) &&
+        expression.arguments.length === 0
+      ) {
+        return unwrapOxcStaticCallableValue(staticCallable);
       }
 
       if (expression.callee.name === 'String' && args.length === 1) {
@@ -1794,7 +1943,13 @@ const extractExpression = (
 
   const identifierReplacements = new Map<string, string>();
   const importedFrom: string[] = [];
-  const staticImports: OxcStaticImportReference[] = [];
+  const namespaceStatic = collectStaticNamespaceMemberReferences(
+    expression,
+    ctx
+  );
+  const staticImports: OxcStaticImportReference[] = [
+    ...namespaceStatic.imports,
+  ];
   let hasNonStaticLocalReference = false;
 
   findReferences(expression, ctx.referencesByNode).forEach(
@@ -1818,6 +1973,12 @@ const extractExpression = (
             local: binding.name,
             source: binding.importedFrom,
           });
+        } else if (
+          binding.imported === '*' &&
+          namespaceStatic.coveredReferenceStarts.has(start)
+        ) {
+          // The static candidate source gets a synthetic named import alias,
+          // while the eval fallback keeps the original namespace expression.
         } else {
           hasNonStaticLocalReference = true;
         }
@@ -1842,10 +2003,22 @@ const extractExpression = (
   return {
     expressionCode:
       identifierReplacements.size > 0
-        ? replaceIdentifierReferences(expression, identifierReplacements, ctx.code)
+        ? replaceIdentifierReferences(
+            expression,
+            identifierReplacements,
+            ctx.code
+          )
         : source,
     importedFrom,
     kind: isFunction ? ValueType.FUNCTION : ValueType.LAZY,
+    staticExpressionCode:
+      namespaceStatic.replacements.length > 0
+        ? applyExpressionReplacements(
+            expression,
+            namespaceStatic.replacements,
+            ctx.code
+          )
+        : undefined,
     staticImports: hasNonStaticLocalReference ? [] : staticImports,
   };
 };
@@ -1946,6 +2119,7 @@ const extractExpressions = (
     referencesByNode: new WeakMap(),
     replacements: [],
     rootMutationsByBinding: analysis.rootMutationsByBinding,
+    staticImportAliases: new Map(),
     staticValueCandidates: [],
     staticValues: [],
     usedNames: new Set(analysis.usedNames),
@@ -1961,8 +2135,14 @@ const extractExpressions = (
       return;
     }
 
-    const { expressionCode, importedFrom, kind, staticImports, staticValue } =
-      extractExpression(expression, ctx, evaluate);
+    const {
+      expressionCode,
+      importedFrom,
+      kind,
+      staticExpressionCode,
+      staticImports,
+      staticValue,
+    } = extractExpression(expression, ctx, evaluate);
     const expName = allocateExpressionName(ctx);
 
     addHoistedCode(
@@ -1979,14 +2159,16 @@ const extractExpressions = (
       const uniqueImports = new Map<string, OxcStaticImportReference>();
       staticImports.forEach((item) => {
         uniqueImports.set(
-          `${item.local}\0${item.source}\0${item.imported}`,
+          `${item.local}\0${item.importLocal ?? ''}\0${item.source}\0${
+            item.imported
+          }`,
           item
         );
       });
       ctx.staticValueCandidates.push({
         imports: [...uniqueImports.values()],
         name: expName,
-        source: expressionCode,
+        source: staticExpressionCode ?? expressionCode,
       });
     }
     ctx.replacements.push({
@@ -2058,6 +2240,7 @@ export const evaluateOxcStaticExpressionAt = (
     referencesByNode: new WeakMap(),
     replacements: [],
     rootMutationsByBinding: analysis.rootMutationsByBinding,
+    staticImportAliases: new Map(),
     staticValueCandidates: [],
     staticValues: [],
     usedNames: new Set(analysis.usedNames),

--- a/packages/transform/src/utils/collectOxcTemplateDependencies.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies.ts
@@ -839,10 +839,13 @@ const isBindingDeclaredWithin = (binding: Binding, container: Node): boolean =>
   container.start <= binding.declaredAt && binding.declaredAt < container.end;
 
 const literalCode = (value: unknown): string | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? JSON.stringify(value) : null;
+  }
+
   if (
     value === null ||
     typeof value === 'string' ||
-    typeof value === 'number' ||
     typeof value === 'boolean'
   ) {
     return JSON.stringify(value);
@@ -1320,16 +1323,33 @@ const collectStaticNamespaceMemberReferences = (
   };
 };
 
+const isProcessEnvMember = (node: Node): boolean => {
+  if (node.type !== 'MemberExpression' || node.computed) {
+    return false;
+  }
+
+  if (
+    node.property.type !== 'Identifier' ||
+    node.property.name !== 'env'
+  ) {
+    return false;
+  }
+
+  return node.object.type === 'Identifier' && node.object.name === 'process';
+};
+
 const evaluateBinary = (
   expression: Expression,
-  ctx: ExtractionContext
+  ctx: ExtractionContext,
+  env: EvalEnv = new Map(),
+  stack: string[] = []
 ): unknown | undefined => {
   if (expression.type !== 'BinaryExpression') {
     return undefined;
   }
 
-  const left = evaluateStatic(expression.left as Expression, ctx);
-  const right = evaluateStatic(expression.right as Expression, ctx);
+  const left = evaluateStatic(expression.left as Expression, ctx, env, stack);
+  const right = evaluateStatic(expression.right as Expression, ctx, env, stack);
   if (left === undefined || right === undefined) {
     return undefined;
   }
@@ -1347,12 +1367,21 @@ const evaluateBinary = (
     }
   }
 
-  if (
-    expression.operator === '*' &&
-    typeof left === 'number' &&
-    typeof right === 'number'
-  ) {
-    return left * right;
+  if (typeof left === 'number' && typeof right === 'number') {
+    switch (expression.operator) {
+      case '-':
+        return left - right;
+      case '*':
+        return left * right;
+      case '/':
+        return left / right;
+      case '%':
+        return left % right;
+      case '**':
+        return left ** right;
+      default:
+        break;
+    }
   }
 
   return undefined;
@@ -1377,6 +1406,93 @@ const evaluateStatic = (
 
   if (expression.type === 'Literal') {
     return expression.value;
+  }
+
+  if (expression.type === 'UnaryExpression') {
+    if (expression.operator === 'typeof') {
+      const argIsProcessEnvAccess =
+        expression.argument.type === 'MemberExpression' &&
+        isProcessEnvMember(expression.argument.object);
+      const arg = evaluateStatic(
+        expression.argument as Expression,
+        ctx,
+        env,
+        stack
+      );
+      if (arg === undefined) {
+        return argIsProcessEnvAccess ? 'undefined' : undefined;
+      }
+
+      return typeof arg;
+    }
+
+    const arg = evaluateStatic(
+      expression.argument as Expression,
+      ctx,
+      env,
+      stack
+    );
+    if (arg === undefined) {
+      return undefined;
+    }
+
+    switch (expression.operator) {
+      case '-':
+        return typeof arg === 'number' ? -arg : undefined;
+      case '+':
+        return typeof arg === 'number' ? +arg : undefined;
+      case '!':
+        return !arg;
+      case '~':
+        return typeof arg === 'number' ? ~arg : undefined;
+      case 'void':
+        return undefined;
+      default:
+        return undefined;
+    }
+  }
+
+  if (expression.type === 'LogicalExpression') {
+    const left = evaluateStatic(expression.left, ctx, env, stack);
+    // process.env.X access is the only source we trust as "deterministically
+    // undefined" — it's a build-time lookup we control. For everything else,
+    // undefined means "couldn't evaluate" and we must bail to avoid inlining
+    // a wrong fallback when the runtime value isn't actually nullish.
+    const leftIsProcessEnvAccess =
+      expression.left.type === 'MemberExpression' &&
+      isProcessEnvMember(expression.left.object);
+
+    if (left === undefined && !leftIsProcessEnvAccess) {
+      return undefined;
+    }
+
+    if (expression.operator === '||') {
+      return left || evaluateStatic(expression.right, ctx, env, stack);
+    }
+
+    if (expression.operator === '??') {
+      return left ?? evaluateStatic(expression.right, ctx, env, stack);
+    }
+
+    if (expression.operator === '&&') {
+      return left && evaluateStatic(expression.right, ctx, env, stack);
+    }
+
+    return undefined;
+  }
+
+  if (expression.type === 'ConditionalExpression') {
+    const test = evaluateStatic(expression.test, ctx, env, stack);
+    if (test === undefined) {
+      return undefined;
+    }
+
+    return evaluateStatic(
+      test ? expression.consequent : expression.alternate,
+      ctx,
+      env,
+      stack
+    );
   }
 
   if (expression.type === 'TemplateLiteral') {
@@ -1541,7 +1657,6 @@ const evaluateStatic = (
   }
 
   if (expression.type === 'MemberExpression') {
-    const objectValue = evaluateStatic(expression.object, ctx, env, stack);
     let key: unknown;
     if (expression.computed) {
       key = evaluateStatic(expression.property as Expression, ctx, env, stack);
@@ -1549,11 +1664,27 @@ const evaluateStatic = (
       key = expression.property.name;
     }
     if (
-      objectValue === undefined ||
       key === undefined ||
       key === null ||
       (typeof key !== 'string' && typeof key !== 'number')
     ) {
+      return undefined;
+    }
+
+    if (
+      isProcessEnvMember(expression.object) &&
+      typeof key === 'string' &&
+      !env.has('process')
+    ) {
+      // Treat process.env.X as deterministically undefined at build time.
+      // Reading from real process.env would couple the bundle to whatever
+      // happens to be set on the build machine; falling back to the
+      // ?? / || branch (or a runtime read) is more predictable.
+      return undefined;
+    }
+
+    const objectValue = evaluateStatic(expression.object, ctx, env, stack);
+    if (objectValue === undefined) {
       return undefined;
     }
 
@@ -1673,7 +1804,7 @@ const evaluateStatic = (
     }
   }
 
-  return evaluateBinary(expression, ctx);
+  return evaluateBinary(expression, ctx, env, stack);
 };
 
 const allocateExpressionName = (ctx: ExtractionContext): string => {

--- a/packages/transform/src/utils/collectOxcTemplateDependencies.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies.ts
@@ -121,7 +121,10 @@ type ExtractionContext = {
   loc: LocationLookup;
   referencesByNode: WeakMap<Node, ReferenceIdentifier[]>;
   replacements: Replacement[];
-  rootMutationsByBinding: Map<string, Array<AssignmentExpression | UpdateExpression>>;
+  rootMutationsByBinding: Map<
+    string,
+    Array<AssignmentExpression | UpdateExpression>
+  >;
   staticValueCandidates: OxcStaticValueCandidate[];
   staticValues: OxcStaticValue[];
   usedNames: Set<string>;
@@ -137,7 +140,10 @@ type ExtractedExpression = {
 
 type ProgramAnalysis = {
   bindingsByName: Map<string, Binding[]>;
-  rootMutationsByBinding: Map<string, Array<AssignmentExpression | UpdateExpression>>;
+  rootMutationsByBinding: Map<
+    string,
+    Array<AssignmentExpression | UpdateExpression>
+  >;
   targetExpressions: Expression[];
   templateLiterals: TemplateLiteral[];
   usedNames: Set<string>;
@@ -676,7 +682,10 @@ const resolveBindingAt = (
 const collectRootMutations = (
   program: Program
 ): Map<string, Array<AssignmentExpression | UpdateExpression>> => {
-  const mutations = new Map<string, Array<AssignmentExpression | UpdateExpression>>();
+  const mutations = new Map<
+    string,
+    Array<AssignmentExpression | UpdateExpression>
+  >();
 
   const getRootMutationTarget = (
     node: Node
@@ -697,15 +706,17 @@ const collectRootMutations = (
       return null;
     }
 
-    const key = node.computed
-      ? node.property.type === 'Literal' &&
-        (typeof node.property.value === 'string' ||
-          typeof node.property.value === 'number')
-        ? node.property.value
-        : null
-      : node.property.type === 'Identifier'
-        ? node.property.name
-        : null;
+    let key: string | number | null = null;
+    if (
+      node.computed &&
+      node.property.type === 'Literal' &&
+      (typeof node.property.value === 'string' ||
+        typeof node.property.value === 'number')
+    ) {
+      key = node.property.value;
+    } else if (!node.computed && node.property.type === 'Identifier') {
+      key = node.property.name;
+    }
     if (key === null) {
       return null;
     }
@@ -721,7 +732,7 @@ const collectRootMutations = (
       return;
     }
 
-    const expression = statement.expression;
+    const { expression } = statement;
     if (expression.type === 'AssignmentExpression') {
       const target = getRootMutationTarget(expression.left);
       if (!target || target.path.length === 0) {
@@ -896,7 +907,9 @@ const assignPatternValue = (
   if (pattern.type === 'AssignmentPattern') {
     return assignPatternValue(
       pattern.left,
-      value === undefined ? evaluateStatic(pattern.right, ctx, env, stack) : value,
+      value === undefined
+        ? evaluateStatic(pattern.right, ctx, env, stack)
+        : value,
       ctx,
       env,
       stack
@@ -913,13 +926,14 @@ const assignPatternValue = (
         return false;
       }
 
-      const key = property.computed
-        ? evaluateStatic(property.key as Expression, ctx, env, stack)
-        : property.key.type === 'Identifier'
-          ? property.key.name
-          : property.key.type === 'Literal'
-            ? property.key.value
-            : undefined;
+      let key: unknown;
+      if (property.computed) {
+        key = evaluateStatic(property.key as Expression, ctx, env, stack);
+      } else if (property.key.type === 'Identifier') {
+        key = property.key.name;
+      } else if (property.key.type === 'Literal') {
+        key = property.key.value;
+      }
       if (key === undefined || key === null) {
         return false;
       }
@@ -957,9 +971,7 @@ const applyRootMutation = (
   env: EvalEnv,
   stack: string[]
 ): unknown | undefined => {
-  const resolvePath = (
-    node: Node
-  ): { path: Array<string | number> } | null => {
+  const resolvePath = (node: Node): { path: Array<string | number> } | null => {
     if (node.type === 'Identifier') {
       return node.name === bindingName ? { path: [] } : null;
     }
@@ -973,11 +985,12 @@ const applyRootMutation = (
       return null;
     }
 
-    const key = node.computed
-      ? evaluateStatic(node.property as Expression, ctx, env, stack)
-      : node.property.type === 'Identifier'
-        ? node.property.name
-        : undefined;
+    let key: unknown;
+    if (node.computed) {
+      key = evaluateStatic(node.property as Expression, ctx, env, stack);
+    } else if (node.property.type === 'Identifier') {
+      key = node.property.name;
+    }
     if (
       key === undefined ||
       key === null ||
@@ -1269,19 +1282,14 @@ const evaluateStatic = (
     }
 
     let value: unknown | undefined;
-    const declarator = binding.declarator;
+    const { declarator } = binding;
     const init = declarator?.init;
     if (init) {
       if (declarator.id.type !== 'Identifier') {
         return undefined;
       }
 
-      value = evaluateStatic(
-        init,
-        ctx,
-        env,
-        [...stack, binding.name]
-      );
+      value = evaluateStatic(init, ctx, env, [...stack, binding.name]);
     } else if (binding.functionNode) {
       value = binding.functionNode;
     }
@@ -1335,13 +1343,14 @@ const evaluateStatic = (
         continue;
       }
 
-      const key = property.computed
-        ? evaluateStatic(property.key as Expression, ctx, env, stack)
-        : property.key.type === 'Identifier'
-          ? property.key.name
-          : property.key.type === 'Literal'
-            ? property.key.value
-            : undefined;
+      let key: unknown;
+      if (property.computed) {
+        key = evaluateStatic(property.key as Expression, ctx, env, stack);
+      } else if (property.key.type === 'Identifier') {
+        key = property.key.name;
+      } else if (property.key.type === 'Literal') {
+        key = property.key.value;
+      }
       if (
         key === undefined ||
         key === null ||
@@ -1392,11 +1401,12 @@ const evaluateStatic = (
 
   if (expression.type === 'MemberExpression') {
     const objectValue = evaluateStatic(expression.object, ctx, env, stack);
-    const key = expression.computed
-      ? evaluateStatic(expression.property as Expression, ctx, env, stack)
-      : expression.property.type === 'Identifier'
-        ? expression.property.name
-        : undefined;
+    let key: unknown;
+    if (expression.computed) {
+      key = evaluateStatic(expression.property as Expression, ctx, env, stack);
+    } else if (expression.property.type === 'Identifier') {
+      key = expression.property.name;
+    }
     if (
       objectValue === undefined ||
       key === undefined ||
@@ -1410,7 +1420,10 @@ const evaluateStatic = (
   }
 
   if (expression.type === 'NewExpression') {
-    if (expression.callee.type !== 'Identifier' || expression.arguments.length !== 1) {
+    if (
+      expression.callee.type !== 'Identifier' ||
+      expression.arguments.length !== 1
+    ) {
       return undefined;
     }
 
@@ -1474,23 +1487,31 @@ const evaluateStatic = (
           fn.type === 'FunctionDeclaration' ||
           fn.type === 'FunctionExpression')
       ) {
-        return evaluateFunctionCall(
-          fn,
-          args,
-          ctx,
-          env,
-          [...stack, expression.callee.name]
-        );
+        return evaluateFunctionCall(fn, args, ctx, env, [
+          ...stack,
+          expression.callee.name,
+        ]);
       }
     }
 
     if (expression.callee.type === 'MemberExpression') {
-      const objectValue = evaluateStatic(expression.callee.object, ctx, env, stack);
-      const key = expression.callee.computed
-        ? evaluateStatic(expression.callee.property as Expression, ctx, env, stack)
-        : expression.callee.property.type === 'Identifier'
-          ? expression.callee.property.name
-          : undefined;
+      const objectValue = evaluateStatic(
+        expression.callee.object,
+        ctx,
+        env,
+        stack
+      );
+      let key: unknown;
+      if (expression.callee.computed) {
+        key = evaluateStatic(
+          expression.callee.property as Expression,
+          ctx,
+          env,
+          stack
+        );
+      } else if (expression.callee.property.type === 'Identifier') {
+        key = expression.callee.property.name;
+      }
       if (typeof objectValue === 'string') {
         if (key === 'toLowerCase' && expression.arguments.length === 0) {
           return objectValue.toLowerCase();
@@ -1511,15 +1532,17 @@ const substituteConstants = (
   ctx: ExtractionContext
 ): string => {
   const replacements = new Map<string, string>();
-  findReferences(expression, ctx.referencesByNode).forEach(({ name, start }) => {
-    const replacement = getConstantReplacement(
-      resolveBindingAt(ctx, name, start),
-      ctx
-    );
-    if (replacement) {
-      replacements.set(name, replacement);
+  findReferences(expression, ctx.referencesByNode).forEach(
+    ({ name, start }) => {
+      const replacement = getConstantReplacement(
+        resolveBindingAt(ctx, name, start),
+        ctx
+      );
+      if (replacement) {
+        replacements.set(name, replacement);
+      }
     }
-  });
+  );
 
   return replaceIdentifierReferences(expression, replacements, ctx.code);
 };
@@ -1672,12 +1695,14 @@ const addHoistedDeclaration = (
   }
 
   const hoistSource = binding.declarator.init ?? binding.declarator;
-  findReferences(hoistSource, ctx.referencesByNode).forEach(({ name, start }) => {
+  findReferences(hoistSource, ctx.referencesByNode).forEach(
+    ({ name, start }) => {
       const dependency = resolveBindingAt(ctx, name, start);
       if (dependency) {
         addHoistedDeclaration(dependency, ctx, [...stack, binding.name]);
       }
-    });
+    }
+  );
 
   if (!ctx.hoistedDeclarations.has(binding.name)) {
     addHoistedCode(
@@ -1772,45 +1797,47 @@ const extractExpression = (
   const staticImports: OxcStaticImportReference[] = [];
   let hasNonStaticLocalReference = false;
 
-  findReferences(expression, ctx.referencesByNode).forEach(({ name, start }) => {
-    const binding = resolveBindingAt(ctx, name, start);
-    if (!binding) {
-      return;
-    }
-
-    if (isFunction && isBindingDeclaredWithin(binding, expression)) {
-      return;
-    }
-
-    ctx.dependencyNames.add(name);
-
-    if (binding.importedFrom) {
-      importedFrom.push(binding.importedFrom);
-      if (binding.imported && binding.imported !== '*') {
-        staticImports.push({
-          imported: binding.imported,
-          local: binding.name,
-          source: binding.importedFrom,
-        });
-      } else {
-        hasNonStaticLocalReference = true;
+  findReferences(expression, ctx.referencesByNode).forEach(
+    ({ name, start }) => {
+      const binding = resolveBindingAt(ctx, name, start);
+      if (!binding) {
+        return;
       }
-      return;
-    }
 
-    const replacement = getConstantReplacement(binding, ctx);
-    if (evaluate && replacement) {
-      identifierReplacements.set(name, replacement);
-      return;
-    }
+      if (isFunction && isBindingDeclaredWithin(binding, expression)) {
+        return;
+      }
 
-    hasNonStaticLocalReference = true;
-    assertHoistable(binding, ctx);
-    addHoistedDeclaration(binding, ctx);
-    if (!binding.isRoot && binding.declarator?.id.type === 'Identifier') {
-      identifierReplacements.set(name, getHoistedBindingName(binding, ctx));
+      ctx.dependencyNames.add(name);
+
+      if (binding.importedFrom) {
+        importedFrom.push(binding.importedFrom);
+        if (binding.imported && binding.imported !== '*') {
+          staticImports.push({
+            imported: binding.imported,
+            local: binding.name,
+            source: binding.importedFrom,
+          });
+        } else {
+          hasNonStaticLocalReference = true;
+        }
+        return;
+      }
+
+      const replacement = getConstantReplacement(binding, ctx);
+      if (evaluate && replacement) {
+        identifierReplacements.set(name, replacement);
+        return;
+      }
+
+      hasNonStaticLocalReference = true;
+      assertHoistable(binding, ctx);
+      addHoistedDeclaration(binding, ctx);
+      if (!binding.isRoot && binding.declarator?.id.type === 'Identifier') {
+        identifierReplacements.set(name, getHoistedBindingName(binding, ctx));
+      }
     }
-  });
+  );
 
   return {
     expressionCode:
@@ -1821,23 +1848,6 @@ const extractExpression = (
     kind: isFunction ? ValueType.FUNCTION : ValueType.LAZY,
     staticImports: hasNonStaticLocalReference ? [] : staticImports,
   };
-};
-
-const getInsertionPoint = (
-  program: Program,
-  expression: Expression
-): number => {
-  const owner =
-    program.body.find(
-      (statement) =>
-        statement.start <= expression.start && statement.end >= expression.end
-    ) ?? program.body[0];
-
-  if (!owner) {
-    return 0;
-  }
-
-  return owner.start;
 };
 
 const getInsertionPoints = (

--- a/packages/transform/src/utils/collectOxcTemplateDependencies.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies.ts
@@ -1676,26 +1676,6 @@ const evaluateStatic = (
   return evaluateBinary(expression, ctx);
 };
 
-const substituteConstants = (
-  expression: Expression,
-  ctx: ExtractionContext
-): string => {
-  const replacements = new Map<string, string>();
-  findReferences(expression, ctx.referencesByNode).forEach(
-    ({ name, start }) => {
-      const replacement = getConstantReplacement(
-        resolveBindingAt(ctx, name, start),
-        ctx
-      );
-      if (replacement) {
-        replacements.set(name, replacement);
-      }
-    }
-  );
-
-  return replaceIdentifierReferences(expression, replacements, ctx.code);
-};
-
 const allocateExpressionName = (ctx: ExtractionContext): string => {
   let base = '_exp';
   let idx = 1;
@@ -1744,6 +1724,30 @@ const getHoistedBindingName = (
   return next;
 };
 
+const declarationInitCode = (
+  init: Expression,
+  ctx: ExtractionContext
+): string => {
+  const renamedDependencies = new Map<string, string>();
+  findReferences(init, ctx.referencesByNode).forEach(({ name, start }) => {
+    const dependency = resolveBindingAt(ctx, name, start);
+    if (
+      !dependency ||
+      dependency.importedFrom ||
+      dependency.isRoot ||
+      dependency.declarator?.id.type !== 'Identifier'
+    ) {
+      return;
+    }
+
+    renamedDependencies.set(name, getHoistedBindingName(dependency, ctx));
+  });
+
+  return renamedDependencies.size > 0
+    ? replaceIdentifierReferences(init, renamedDependencies, ctx.code)
+    : ctx.code.slice(init.start, init.end);
+};
+
 const addHoistedCode = (
   key: string,
   code: string,
@@ -1765,14 +1769,19 @@ const addHoistedCode = (
 };
 
 const declarationCode = (binding: Binding, ctx: ExtractionContext): string => {
-  const declarator = binding.declarator;
+  const { declarator } = binding;
   if (!declarator) {
     return '';
   }
 
-  if (declarator.id.type !== 'Identifier') {
-    const source = ctx.code.slice(declarator.start, declarator.end);
-    return `let ${source};`;
+  const { id } = declarator;
+  if (id.type !== 'Identifier') {
+    const idCode = ctx.code.slice(id.start, id.end);
+    if (!declarator.init) {
+      return `let ${idCode};`;
+    }
+
+    return `let ${idCode} = ${declarationInitCode(declarator.init, ctx)};`;
   }
 
   const hoistedName = getHoistedBindingName(binding, ctx);
@@ -1780,22 +1789,7 @@ const declarationCode = (binding: Binding, ctx: ExtractionContext): string => {
     return `let ${hoistedName};`;
   }
 
-  const renamedDependencies = new Map<string, string>();
-  findReferences(declarator.init, ctx.referencesByNode).forEach(({ name, start }) => {
-    const dependency = resolveBindingAt(ctx, name, start);
-    if (!dependency || dependency.importedFrom || dependency.isRoot) {
-      return;
-    }
-
-    renamedDependencies.set(name, getHoistedBindingName(dependency, ctx));
-  });
-
-  const initCode =
-    renamedDependencies.size > 0
-      ? replaceIdentifierReferences(declarator.init, renamedDependencies, ctx.code)
-      : ctx.code.slice(declarator.init.start, declarator.init.end);
-
-  return `let ${hoistedName} = ${initCode};`;
+  return `let ${hoistedName} = ${declarationInitCode(declarator.init, ctx)};`;
 };
 
 const assertHoistable = (
@@ -1854,11 +1848,7 @@ const addHoistedDeclaration = (
   );
 
   if (!ctx.hoistedDeclarations.has(binding.name)) {
-    addHoistedCode(
-      binding.name,
-      declarationCode(binding, ctx),
-      ctx
-    );
+    addHoistedCode(binding.name, declarationCode(binding, ctx), ctx);
   }
 };
 

--- a/packages/transform/src/utils/hasCachedWywPrevalExport.ts
+++ b/packages/transform/src/utils/hasCachedWywPrevalExport.ts
@@ -21,9 +21,7 @@ export const hasCachedWywPrevalExport = (
     | string[]
     | undefined;
   if (knownExports) {
-    return (
-      knownExports.includes('__wywPreval') || knownExports.includes('*')
-    );
+    return knownExports.includes('__wywPreval') || knownExports.includes('*');
   }
 
   const filename = stripQueryAndHash(resolved);

--- a/packages/transform/src/utils/oxcEmit.ts
+++ b/packages/transform/src/utils/oxcEmit.ts
@@ -64,7 +64,7 @@ const getCommonJsFilename = (): string | null =>
   typeof __filename === 'string' ? __filename : null;
 
 const getCurrentFilenameFromStack = (): string | null => {
-  const stack = new Error().stack;
+  const { stack } = new Error();
   const match = stack?.match(
     /(?:\(|\s)(file:\/\/[^)\s]+\/oxcEmit\.(?:js|ts)|\/[^)\s]+\/oxcEmit\.(?:js|ts)):\d+:\d+/
   );
@@ -173,7 +173,9 @@ const getNativeBindingCandidates = (): string[] => {
 const loadNativeOxcTransform = (
   requireFromHere: NodeRequire
 ): OxcTransformModule => {
-  const requireFromOxc = createRequire(requireFromHere.resolve('oxc-transform'));
+  const requireFromOxc = createRequire(
+    requireFromHere.resolve('oxc-transform')
+  );
   const errors: unknown[] = [];
 
   for (const candidate of [

--- a/packages/transform/src/utils/oxcPreevalStage.ts
+++ b/packages/transform/src/utils/oxcPreevalStage.ts
@@ -6,6 +6,7 @@ import { isFeatureEnabled } from '@wyw-in-js/shared';
 
 import { EventEmitter } from './EventEmitter';
 import type { WYWTransformMetadata } from './TransformMetadata';
+import type { OxcStaticValueCandidate } from './collectOxcTemplateDependencies';
 import { applyOxcProcessors } from './applyOxcProcessors';
 import {
   removeDangerousCodeWithOxc,
@@ -25,8 +26,13 @@ type OxcPreevalOptions = Pick<
 > & { eventEmitter?: EventEmitter };
 
 type OxcPreevalResult = {
+  baseCode: string;
   code: string;
+  dependencyNames: string[];
   metadata: WYWTransformMetadata | null;
+  staticDependencies: string[];
+  staticValueCache: Map<string, unknown>;
+  staticValueCandidates: OxcStaticValueCandidate[];
 };
 
 const DYNAMIC_IMPORT_RE = /\bimport(?:\s|\/\*[\s\S]*?\*\/)*\(/;
@@ -50,7 +56,7 @@ const parseSourceType = (
   return parsed.program.sourceType === 'script' ? 'script' : 'module';
 };
 
-const appendWywPreval = (
+export const appendOxcWywPreval = (
   code: string,
   filename: string,
   dependencyNames: string[]
@@ -86,6 +92,12 @@ export const runOxcPreevalStage = (
       processor.doEvaltimeReplacement();
     })
   );
+  const staticValueNames = new Set(
+    processed.staticValues.map((item) => item.name)
+  );
+  const evalDependencyNames = dependencyNames.filter(
+    (name) => !staticValueNames.has(name)
+  );
 
   let nextCode = eventEmitter.perf('transform:preeval:importMetaEnv', () =>
     replaceImportMetaEnvWithOxc(processed.code, filename)
@@ -100,27 +112,46 @@ export const runOxcPreevalStage = (
   const shouldRewriteDynamicImports = DYNAMIC_IMPORT_RE.test(nextCode);
   const shouldAddRequireFallback = REQUIRE_CALL_RE.test(nextCode);
   if (shouldRewriteDynamicImports || shouldAddRequireFallback) {
-    nextCode = rewriteDynamicImportsAndAddRequireFallbackWithOxc(nextCode, filename, {
-      addRequireFallback: shouldAddRequireFallback,
-      eventEmitter,
-      rewriteDynamicImports: shouldRewriteDynamicImports,
-    });
+    nextCode = rewriteDynamicImportsAndAddRequireFallbackWithOxc(
+      nextCode,
+      filename,
+      {
+        addRequireFallback: shouldAddRequireFallback,
+        eventEmitter,
+        rewriteDynamicImports: shouldRewriteDynamicImports,
+      }
+    );
   }
 
   if (processed.processors.length === 0) {
     return {
+      baseCode: nextCode,
       code: nextCode,
+      dependencyNames: [],
       metadata: null,
+      staticDependencies: [],
+      staticValueCandidates: [],
+      staticValueCache: new Map(),
     };
   }
 
+  const staticValueCache = new Map<string, unknown>();
+  processed.staticValues.forEach(({ name, value }) => {
+    staticValueCache.set(name, value);
+  });
+
   return {
-    code: appendWywPreval(nextCode, filename, dependencyNames),
+    baseCode: nextCode,
+    code: appendOxcWywPreval(nextCode, filename, evalDependencyNames),
+    dependencyNames: evalDependencyNames,
     metadata: {
       dependencies: [],
       processors: processed.processors,
       replacements: [],
       rules: {},
     },
+    staticDependencies: [],
+    staticValueCandidates: processed.staticValueCandidates,
+    staticValueCache,
   };
 };

--- a/packages/transform/src/utils/oxcPreevalStage.ts
+++ b/packages/transform/src/utils/oxcPreevalStage.ts
@@ -38,6 +38,21 @@ type OxcPreevalResult = {
 const DYNAMIC_IMPORT_RE = /\bimport(?:\s|\/\*[\s\S]*?\*\/)*\(/;
 const REQUIRE_CALL_RE = /\brequire(?:\s|\/\*[\s\S]*?\*\/)*\(/;
 
+const isEnvDisabled = (value: string): boolean =>
+  value === '0' || value === 'false' || value === 'no' || value === 'off';
+
+const isStaticImportValuesEnabled = (
+  features: StrictOptions['features'],
+  filename: string
+): boolean => {
+  const envValue = process.env.WYW_STATIC_IMPORT_VALUES?.trim().toLowerCase();
+  if (envValue) {
+    return !isEnvDisabled(envValue);
+  }
+
+  return isFeatureEnabled(features, 'staticImportValues', filename);
+};
+
 const parseSourceType = (
   code: string,
   filename: string
@@ -92,12 +107,16 @@ export const runOxcPreevalStage = (
       processor.doEvaltimeReplacement();
     })
   );
-  const staticValueNames = new Set(
-    processed.staticValues.map((item) => item.name)
+  const staticValuesEnabled = isStaticImportValuesEnabled(
+    options.features,
+    filename
   );
-  const evalDependencyNames = dependencyNames.filter(
-    (name) => !staticValueNames.has(name)
-  );
+  const staticValueNames = staticValuesEnabled
+    ? new Set(processed.staticValues.map((item) => item.name))
+    : null;
+  const evalDependencyNames = staticValuesEnabled
+    ? dependencyNames.filter((name) => !staticValueNames!.has(name))
+    : dependencyNames;
 
   let nextCode = eventEmitter.perf('transform:preeval:importMetaEnv', () =>
     replaceImportMetaEnvWithOxc(processed.code, filename)
@@ -136,9 +155,11 @@ export const runOxcPreevalStage = (
   }
 
   const staticValueCache = new Map<string, unknown>();
-  processed.staticValues.forEach(({ name, value }) => {
-    staticValueCache.set(name, value);
-  });
+  if (staticValuesEnabled) {
+    processed.staticValues.forEach(({ name, value }) => {
+      staticValueCache.set(name, value);
+    });
+  }
 
   return {
     baseCode: nextCode,
@@ -151,7 +172,9 @@ export const runOxcPreevalStage = (
       rules: {},
     },
     staticDependencies: [],
-    staticValueCandidates: processed.staticValueCandidates,
+    staticValueCandidates: staticValuesEnabled
+      ? processed.staticValueCandidates
+      : [],
     staticValueCache,
   };
 };

--- a/packages/transform/src/utils/oxcPreevalTransforms.ts
+++ b/packages/transform/src/utils/oxcPreevalTransforms.ts
@@ -831,10 +831,15 @@ const isBindingPosition = (node: Node, parent: Node | null): boolean => {
   }
 
   if (
-    (parent.type === 'ImportSpecifier' ||
-      parent.type === 'ImportDefaultSpecifier' ||
+    parent.type === 'ImportSpecifier' &&
+    (parent.local === node || parent.imported === node)
+  ) {
+    return true;
+  }
+
+  if (
+    (parent.type === 'ImportDefaultSpecifier' ||
       parent.type === 'ImportNamespaceSpecifier') &&
-    'local' in parent &&
     parent.local === node
   ) {
     return true;

--- a/packages/transform/src/utils/oxcPreevalTransforms.ts
+++ b/packages/transform/src/utils/oxcPreevalTransforms.ts
@@ -332,7 +332,11 @@ const evaluateStaticValue = (
       return undefined;
     }
 
-    return evaluateStaticValue(binding, scope, new Set([...seen, expression.name]));
+    return evaluateStaticValue(
+      binding,
+      scope,
+      new Set([...seen, expression.name])
+    );
   }
 
   if (expression.type === 'BinaryExpression' && expression.operator === '+') {
@@ -359,7 +363,11 @@ const evaluateStaticValue = (
     expression.type === 'CallExpression' &&
     expression.callee.type === 'MemberExpression'
   ) {
-    const objectValue = evaluateStaticValue(expression.callee.object, scope, seen);
+    const objectValue = evaluateStaticValue(
+      expression.callee.object,
+      scope,
+      seen
+    );
     const propertyName = getMemberPropertyName(expression.callee);
     if (!propertyName) {
       return undefined;
@@ -603,10 +611,7 @@ const visit = (
 ): void => {
   let currentScope = scope;
   if (createsScope(node)) {
-    currentScope = createScope(
-      scope,
-      `${node.type}:${node.start}:${node.end}`
-    );
+    currentScope = createScope(scope, `${node.type}:${node.start}:${node.end}`);
     predeclareScopeNames(node, currentScope);
   }
 
@@ -643,38 +648,6 @@ export const replaceImportMetaEnvWithOxc = (
   return applyReplacements(code, replacements);
 };
 
-export const rewriteDynamicImportsWithOxc = (
-  code: string,
-  filename: string
-): string => {
-  const replacements = collectDynamicImportAndRequireFallbackReplacements(
-    code,
-    filename,
-    {
-      addRequireFallback: false,
-      rewriteDynamicImports: true,
-    }
-  );
-
-  return applyReplacements(code, replacements);
-};
-
-export const addRequireFallbackWithOxc = (
-  code: string,
-  filename: string
-): string => {
-  const replacements = collectDynamicImportAndRequireFallbackReplacements(
-    code,
-    filename,
-    {
-      addRequireFallback: true,
-      rewriteDynamicImports: false,
-    }
-  );
-
-  return applyReplacements(code, replacements);
-};
-
 type CombinedSyntaxRewriteOptions = {
   addRequireFallback: boolean;
   eventEmitter?: EventEmitter;
@@ -686,49 +659,60 @@ type RequireFallbackCandidate = {
   scope: Scope;
 };
 
-const collectDynamicImportAndRequireFallbackReplacements = (
+function collectDynamicImportAndRequireFallbackReplacements(
   code: string,
   filename: string,
   options: CombinedSyntaxRewriteOptions
-): Replacement[] => {
+): Replacement[] {
   const eventEmitter = options.eventEmitter ?? EventEmitter.dummy;
   const dynamicImportCandidates: ImportExpression[] = [];
   const requireFallbackCandidates: RequireFallbackCandidate[] = [];
 
-  eventEmitter.perf('transform:preeval:dynamicImportRequireFallback:scan', () => {
-    visit(parseOxc(code, filename), createScope(null, 'root'), (node, scope) => {
-      if (options.rewriteDynamicImports && node.type === 'ImportExpression') {
-        dynamicImportCandidates.push(node as ImportExpression);
-      }
+  eventEmitter.perf(
+    'transform:preeval:dynamicImportRequireFallback:scan',
+    () => {
+      visit(
+        parseOxc(code, filename),
+        createScope(null, 'root'),
+        (node, scope) => {
+          if (
+            options.rewriteDynamicImports &&
+            node.type === 'ImportExpression'
+          ) {
+            dynamicImportCandidates.push(node as ImportExpression);
+          }
 
-      if (
-        !options.addRequireFallback ||
-        node.type !== 'CallExpression'
-      ) {
-        return;
-      }
+          if (!options.addRequireFallback || node.type !== 'CallExpression') {
+            return;
+          }
 
-      const call = node as CallExpression;
-      if (
-        call.callee.type !== 'Identifier' ||
-        call.callee.name !== 'require' ||
-        hasBinding(scope, 'require') ||
-        call.arguments.length !== 1
-      ) {
-        return;
-      }
+          const call = node as CallExpression;
+          if (
+            call.callee.type !== 'Identifier' ||
+            call.callee.name !== 'require' ||
+            hasBinding(scope, 'require') ||
+            call.arguments.length !== 1
+          ) {
+            return;
+          }
 
-      const [firstArg] = call.arguments;
-      if (!firstArg || firstArg.type === 'SpreadElement' || isLiteralRequireArg(firstArg)) {
-        return;
-      }
+          const [firstArg] = call.arguments;
+          if (
+            !firstArg ||
+            firstArg.type === 'SpreadElement' ||
+            isLiteralRequireArg(firstArg)
+          ) {
+            return;
+          }
 
-      requireFallbackCandidates.push({
-        call,
-        scope,
-      });
-    });
-  });
+          requireFallbackCandidates.push({
+            call,
+            scope,
+          });
+        }
+      );
+    }
+  );
 
   const replacements: Replacement[] = [];
 
@@ -779,6 +763,38 @@ const collectDynamicImportAndRequireFallbackReplacements = (
   });
 
   return replacements;
+}
+
+export const rewriteDynamicImportsWithOxc = (
+  code: string,
+  filename: string
+): string => {
+  const replacements = collectDynamicImportAndRequireFallbackReplacements(
+    code,
+    filename,
+    {
+      addRequireFallback: false,
+      rewriteDynamicImports: true,
+    }
+  );
+
+  return applyReplacements(code, replacements);
+};
+
+export const addRequireFallbackWithOxc = (
+  code: string,
+  filename: string
+): string => {
+  const replacements = collectDynamicImportAndRequireFallbackReplacements(
+    code,
+    filename,
+    {
+      addRequireFallback: true,
+      rewriteDynamicImports: false,
+    }
+  );
+
+  return applyReplacements(code, replacements);
 };
 
 export const rewriteDynamicImportsAndAddRequireFallbackWithOxc = (
@@ -912,7 +928,8 @@ const findRemovableOwner = (node: Node, ancestors: Node[]): Node => {
     }
   }
 
-  const parent = ownerAncestorIndex > 0 ? ancestors[ownerAncestorIndex - 1] : null;
+  const parent =
+    ownerAncestorIndex > 0 ? ancestors[ownerAncestorIndex - 1] : null;
   if (
     parent?.type === 'ExportNamedDeclaration' &&
     'declaration' in parent &&
@@ -941,10 +958,7 @@ const collectReExportedLocalNames = (program: Program): Set<string> => {
       continue;
     }
     for (const spec of stmt.specifiers) {
-      if (
-        spec.type === 'ExportSpecifier' &&
-        spec.local.type === 'Identifier'
-      ) {
+      if (spec.type === 'ExportSpecifier' && spec.local.type === 'Identifier') {
         names.add(spec.local.name);
       }
     }
@@ -1090,8 +1104,10 @@ const containsForbiddenReference = (
     const bindingKey = getBindingKey(childScope, child.name);
     if (
       alwaysForbiddenIdentifiers.has(child.name) ||
-      (forbiddenGlobals.has(child.name) && !hasBinding(childScope, child.name)) ||
-      (windowScopedNames.has(child.name) && !hasBinding(childScope, child.name)) ||
+      (forbiddenGlobals.has(child.name) &&
+        !hasBinding(childScope, child.name)) ||
+      (windowScopedNames.has(child.name) &&
+        !hasBinding(childScope, child.name)) ||
       (bindingKey !== null && derivedForbiddenBindings.has(bindingKey))
     ) {
       found = true;
@@ -1120,7 +1136,10 @@ const collectImportBindings = (
 ): ImportBinding[] => {
   const bindings = new Map<string, ImportBinding>();
   const addBinding = (binding: ImportBinding): void => {
-    bindings.set(`${binding.local}\0${binding.source}\0${binding.imported}`, binding);
+    bindings.set(
+      `${binding.local}\0${binding.source}\0${binding.imported}`,
+      binding
+    );
   };
 
   program.body.forEach((statement) => {
@@ -1193,6 +1212,19 @@ const getImportBinding = (
   local: string
 ): ImportBinding | undefined => imports.find((item) => item.local === local);
 
+function unwrapSequenceCallee(node: Expression): Expression {
+  if (
+    node.type === 'SequenceExpression' &&
+    node.expressions.length === 2 &&
+    node.expressions[0]?.type === 'Literal' &&
+    node.expressions[0].value === 0
+  ) {
+    return node.expressions[1] as Expression;
+  }
+
+  return node;
+}
+
 const getExpressionImportKey = (node: Expression): string | null => {
   const expression = unwrapSequenceCallee(node);
 
@@ -1214,19 +1246,6 @@ const getExpressionImportKey = (node: Expression): string | null => {
 
 const isHookOrCreateElement = (name: string): boolean =>
   name === 'createElement' || /use[A-Z]/.test(name);
-
-const unwrapSequenceCallee = (node: Expression): Expression => {
-  if (
-    node.type === 'SequenceExpression' &&
-    node.expressions.length === 2 &&
-    node.expressions[0]?.type === 'Literal' &&
-    node.expressions[0].value === 0
-  ) {
-    return node.expressions[1] as Expression;
-  }
-
-  return node;
-};
 
 const getInnermostCallee = (call: CallExpression): Expression => {
   let callee = unwrapSequenceCallee(call.callee);
@@ -1524,9 +1543,9 @@ export const removeDangerousCodeWithOxc = (
     : new Set<string>();
   const reExportedLocalNames = collectReExportedLocalNames(program);
 
-  let discoveredNewDerivedBinding = true;
-  while (discoveredNewDerivedBinding) {
-    discoveredNewDerivedBinding = false;
+  const derivedBindingDiscovery = { found: true };
+  while (derivedBindingDiscovery.found) {
+    derivedBindingDiscovery.found = false;
 
     visit(program, createScope(null, 'root'), (node, scope) => {
       if (
@@ -1552,187 +1571,194 @@ export const removeDangerousCodeWithOxc = (
         )
       ) {
         derivedForbiddenBindings.add(bindingKey);
-        discoveredNewDerivedBinding = true;
+        derivedBindingDiscovery.found = true;
       }
     });
   }
 
-  visit(program, createScope(null, 'root'), (node, scope, parent, ancestors) => {
-    if (node.type === 'JSXElement' || node.type === 'JSXFragment') {
-      replacements.push(
-        findFunctionReplacement(ancestors) ?? {
-          start: node.start,
-          end: node.end,
-          value: 'null',
-        }
-      );
-      return;
-    }
-
-    if (node.type === 'CallExpression') {
-      if (isReactRuntimeCall(node, imports)) {
-        const replacement = findFunctionReplacement(ancestors);
-        if (replacement) {
-          replacements.push(replacement);
-        }
-
+  visit(
+    program,
+    createScope(null, 'root'),
+    (node, scope, parent, ancestors) => {
+      if (node.type === 'JSXElement' || node.type === 'JSXFragment') {
+        replacements.push(
+          findFunctionReplacement(ancestors) ?? {
+            start: node.start,
+            end: node.end,
+            value: 'null',
+          }
+        );
         return;
       }
 
-      if (hasHocs && isHocCall(node, hocs, imports)) {
+      if (node.type === 'CallExpression') {
+        if (isReactRuntimeCall(node, imports)) {
+          const replacement = findFunctionReplacement(ancestors);
+          if (replacement) {
+            replacements.push(replacement);
+          }
+
+          return;
+        }
+
+        if (hasHocs && isHocCall(node, hocs, imports)) {
+          replacements.push({
+            start: node.start,
+            end: node.end,
+            value: '() => null',
+          });
+          return;
+        }
+      }
+
+      if (
+        node.type === 'VariableDeclarator' &&
+        node.id.type === 'Identifier' &&
+        node.init &&
+        isComponentTypeMatch(node.id, componentTypes, imports)
+      ) {
         replacements.push({
-          start: node.start,
-          end: node.end,
+          start: node.init.start,
+          end: node.init.end,
           value: '() => null',
         });
         return;
       }
-    }
 
-    if (
-      node.type === 'VariableDeclarator' &&
-      node.id.type === 'Identifier' &&
-      node.init &&
-      isComponentTypeMatch(node.id, componentTypes, imports)
-    ) {
-      replacements.push({
-        start: node.init.start,
-        end: node.init.end,
-        value: '() => null',
-      });
-      return;
-    }
+      if (
+        node.type === 'UnaryExpression' &&
+        node.operator === 'typeof' &&
+        node.argument.type === 'Identifier' &&
+        ssrCheckFields.has(node.argument.name) &&
+        !hasBinding(scope, node.argument.name)
+      ) {
+        replacements.push({
+          start: node.start,
+          end: node.end,
+          value: '"undefined"',
+        });
+        return;
+      }
 
-    if (
-      node.type === 'UnaryExpression' &&
-      node.operator === 'typeof' &&
-      node.argument.type === 'Identifier' &&
-      ssrCheckFields.has(node.argument.name) &&
-      !hasBinding(scope, node.argument.name)
-    ) {
-      replacements.push({
-        start: node.start,
-        end: node.end,
-        value: '"undefined"',
-      });
-      return;
-    }
+      if (node.type === 'MetaProperty') {
+        const owner = findRemovableOwner(node, ancestors);
+        replacements.push({ start: owner.start, end: owner.end, value: '' });
+        return;
+      }
 
-    if (node.type === 'MetaProperty') {
-      const owner = findRemovableOwner(node, ancestors);
+      if (
+        node.type !== 'Identifier' ||
+        isTypeContext(ancestors) ||
+        isInsideTypeof(ancestors) ||
+        isInsideImportDeclaration(ancestors)
+      ) {
+        return;
+      }
+
+      if (isPropertyOnlyIdentifier(node, parent)) {
+        return;
+      }
+
+      const isAlwaysForbidden = alwaysForbiddenIdentifiers.has(node.name);
+      const bindingKey = getBindingKey(scope, node.name);
+      const isDerivedForbidden =
+        bindingKey !== null && derivedForbiddenBindings.has(bindingKey);
+      const isWindowScoped =
+        windowScopedNames.has(node.name) && !hasBinding(scope, node.name);
+      const isForbiddenGlobal =
+        forbiddenGlobals.has(node.name) && !hasBinding(scope, node.name);
+
+      if (
+        !isAlwaysForbidden &&
+        !isDerivedForbidden &&
+        !isWindowScoped &&
+        !isForbiddenGlobal
+      ) {
+        return;
+      }
+
+      if (!isAlwaysForbidden && isInDeferredFunctionScope(ancestors)) {
+        return;
+      }
+
+      if (isBindingPosition(node, parent) && !isAlwaysForbidden) {
+        return;
+      }
+
+      if (
+        parent?.type === 'ExportDefaultDeclaration' &&
+        parent.declaration === node
+      ) {
+        return;
+      }
+
+      if (
+        generatedProcessorHelperNameRe.test(node.name) &&
+        hasBinding(scope, node.name)
+      ) {
+        return;
+      }
+
+      const generatedHelperDeclarator = findLastAncestor(
+        ancestors,
+        (ancestor) =>
+          ancestor.type === 'VariableDeclarator' &&
+          ancestor.id.type === 'Identifier' &&
+          generatedProcessorHelperNameRe.test(ancestor.id.name)
+      );
+      if (generatedHelperDeclarator) {
+        return;
+      }
+
+      if (
+        parent?.type === 'Property' &&
+        parent.value === node &&
+        hasBinding(scope, node.name)
+      ) {
+        return;
+      }
+
+      if (parent?.type === 'Property' && parent.value === node) {
+        replacements.push({
+          start: node.start,
+          end: node.end,
+          value: parent.shorthand ? `${node.name}: undefined` : 'undefined',
+        });
+        return;
+      }
+
+      const grandparent = ancestors[ancestors.length - 2] ?? null;
+      if (
+        parent?.type === 'MemberExpression' &&
+        parent.object === node &&
+        grandparent?.type === 'SpreadElement' &&
+        grandparent.argument === parent
+      ) {
+        replacements.push({
+          start: grandparent.start,
+          end: grandparent.end,
+          value: '...{}',
+        });
+        return;
+      }
+
+      const exportProtection = findExportedBindingProtection(
+        node,
+        ancestors,
+        reExportedLocalNames
+      );
+      if (exportProtection) {
+        replacements.push(exportProtection);
+        return;
+      }
+
+      const promiseOwner = findPromiseCallbackOwner(ancestors);
+      const owner = promiseOwner
+        ? findRemovableOwner(promiseOwner, ancestors)
+        : findRemovableOwner(node, ancestors);
       replacements.push({ start: owner.start, end: owner.end, value: '' });
-      return;
     }
-
-    if (
-      node.type !== 'Identifier' ||
-      isTypeContext(ancestors) ||
-      isInsideTypeof(ancestors) ||
-      isInsideImportDeclaration(ancestors)
-    ) {
-      return;
-    }
-
-    if (isPropertyOnlyIdentifier(node, parent)) {
-      return;
-    }
-
-    const isAlwaysForbidden = alwaysForbiddenIdentifiers.has(node.name);
-    const bindingKey = getBindingKey(scope, node.name);
-    const isDerivedForbidden =
-      bindingKey !== null && derivedForbiddenBindings.has(bindingKey);
-    const isWindowScoped =
-      windowScopedNames.has(node.name) && !hasBinding(scope, node.name);
-    const isForbiddenGlobal =
-      forbiddenGlobals.has(node.name) && !hasBinding(scope, node.name);
-
-    if (
-      !isAlwaysForbidden &&
-      !isDerivedForbidden &&
-      !isWindowScoped &&
-      !isForbiddenGlobal
-    ) {
-      return;
-    }
-
-    if (!isAlwaysForbidden && isInDeferredFunctionScope(ancestors)) {
-      return;
-    }
-
-    if (isBindingPosition(node, parent) && !isAlwaysForbidden) {
-      return;
-    }
-
-    if (
-      parent?.type === 'ExportDefaultDeclaration' &&
-      parent.declaration === node
-    ) {
-      return;
-    }
-
-    if (generatedProcessorHelperNameRe.test(node.name) && hasBinding(scope, node.name)) {
-      return;
-    }
-
-    const generatedHelperDeclarator = findLastAncestor(
-      ancestors,
-      (ancestor) =>
-        ancestor.type === 'VariableDeclarator' &&
-        ancestor.id.type === 'Identifier' &&
-        generatedProcessorHelperNameRe.test(ancestor.id.name)
-    );
-    if (generatedHelperDeclarator) {
-      return;
-    }
-
-    if (
-      parent?.type === 'Property' &&
-      parent.value === node &&
-      hasBinding(scope, node.name)
-    ) {
-      return;
-    }
-
-    if (parent?.type === 'Property' && parent.value === node) {
-      replacements.push({
-        start: node.start,
-        end: node.end,
-        value: parent.shorthand ? `${node.name}: undefined` : 'undefined',
-      });
-      return;
-    }
-
-    const grandparent = ancestors[ancestors.length - 2] ?? null;
-    if (
-      parent?.type === 'MemberExpression' &&
-      parent.object === node &&
-      grandparent?.type === 'SpreadElement' &&
-      grandparent.argument === parent
-    ) {
-      replacements.push({
-        start: grandparent.start,
-        end: grandparent.end,
-        value: '...{}',
-      });
-      return;
-    }
-
-    const exportProtection = findExportedBindingProtection(
-      node,
-      ancestors,
-      reExportedLocalNames
-    );
-    if (exportProtection) {
-      replacements.push(exportProtection);
-      return;
-    }
-
-    const promiseOwner = findPromiseCallbackOwner(ancestors);
-    const owner = promiseOwner
-      ? findRemovableOwner(promiseOwner, ancestors)
-      : findRemovableOwner(node, ancestors);
-    replacements.push({ start: owner.start, end: owner.end, value: '' });
-  });
+  );
 
   return applyReplacements(code, normalizeReplacements(replacements));
 };

--- a/packages/transform/src/utils/oxcShaker.ts
+++ b/packages/transform/src/utils/oxcShaker.ts
@@ -7,10 +7,10 @@ import type { Node, Program } from 'oxc-parser';
 
 import { syncResolve, type ImportOverrides } from '@wyw-in-js/shared';
 
-import {
+import { collectOxcExportsAndImportsFromProgram } from './collectOxcExportsAndImports';
+import type {
   collectOxcExportsAndImports,
-  collectOxcExportsAndImportsFromProgram,
-  type OxcCollectedImport,
+  OxcCollectedImport,
 } from './collectOxcExportsAndImports';
 import { getImportOverride, toImportKey } from './importOverrides';
 import { parseOxcCached } from './parseOxc';
@@ -100,11 +100,15 @@ const parseOxc = (
     if (process.env.WYW_DEBUG_SHAKER_DUMP) {
       const dumpFile = path.join(
         '/tmp',
-        `wyw-oxc-shaker-${path.basename(filename).replace(/[^a-z0-9_.-]/gi, '_')}-${Date.now()}.js`
+        `wyw-oxc-shaker-${path
+          .basename(filename)
+          .replace(/[^a-z0-9_.-]/gi, '_')}-${Date.now()}.js`
       );
       fs.writeFileSync(dumpFile, code);
       const message =
-        error instanceof Error ? error.message : 'Unknown Oxc shaker parse error';
+        error instanceof Error
+          ? error.message
+          : 'Unknown Oxc shaker parse error';
       throw new Error(`${message} [${filename}] [dump: ${dumpFile}]`);
     }
 
@@ -261,10 +265,7 @@ const isIdentifierReference = (
     return false;
   }
 
-  if (
-    parent.type === 'ExportSpecifier' &&
-    parentNode.exported === node
-  ) {
+  if (parent.type === 'ExportSpecifier' && parentNode.exported === node) {
     return false;
   }
 
@@ -486,7 +487,7 @@ const collectImportLocalNames = (node: Node): string[] => {
 };
 
 const getImportSpecifierLocalName = (node: Node): string | null => {
-  const local = (node as AnyNode).local;
+  const { local } = node as AnyNode;
   return isNode(local) && 'name' in local && typeof local.name === 'string'
     ? local.name
     : null;

--- a/packages/transform/src/utils/oxcShaker.ts
+++ b/packages/transform/src/utils/oxcShaker.ts
@@ -275,6 +275,12 @@ const isIdentifierReference = (
       : true;
   }
 
+  // The `imported` name of `import { X as Y }` is what to take from the source
+  // module — it does not reference a local binding `X` in the current module.
+  if (parent.type === 'ImportSpecifier' && parentNode.imported === node) {
+    return false;
+  }
+
   return true;
 };
 

--- a/packages/transform/src/utils/processorLookup.ts
+++ b/packages/transform/src/utils/processorLookup.ts
@@ -193,11 +193,13 @@ export const getProcessorForImport = (
 
     customFile = tagResolver(source, imported, tagResolverMeta);
   }
-  const processor = customFile
-    ? getProcessorFromFile(customFile)
-    : packageLookupCandidate
-      ? getProcessorFromPackage(source, imported, filename)
-      : null;
+  let processor: ProcessorClass | null = null;
+  if (customFile) {
+    processor = getProcessorFromFile(customFile);
+  } else if (packageLookupCandidate) {
+    processor = getProcessorFromPackage(source, imported, filename);
+  }
+
   lookupCache.set(cacheKey, processor);
   return [processor, { imported, source }];
 };


### PR DESCRIPTION
## Summary

- Add an opt-in Oxc static value resolver for template dependencies that can be proven static.
- Inline safe primitives, `null`, arrays, plain objects, compiled enum objects, zero-argument static helper returns, selector-only metadata, and static metadata helper chains without sending those bindings through build-time evaluation.
- Preserve fallback behavior for unresolved, mutable, cyclic, side-effectful, computed, callable, class-based, or otherwise non-serializable values.
- Keep `features.staticImportValues` disabled by default and document the benefits, costs, and limitations.

## Validation

- `bun run --filter @wyw-in-js/transform test -- transform.static-import-values.test.ts`
- `bun run --filter @wyw-in-js/transform build:types`