### PR TITLE
Fix: eval cache poisoning across sessions (`staticImportValues`) race

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -429,6 +429,7 @@
       "name": "@wyw-in-js/transform",
       "version": "1.0.8",
       "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
         "@wyw-in-js/processor-utils": "workspace:*",
         "@wyw-in-js/shared": "workspace:*",
         "cosmiconfig": "^8.0.0",

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -21,6 +21,7 @@ import {
   EvalBroker,
   stripEntrypointGlobalsFromRunnerContext,
 } from '../eval/broker';
+import { serializeValue } from '../eval/serialize';
 
 const createPluginOptions = (overrides: PartialOptions = {}) =>
   loadWywOptions({
@@ -74,6 +75,10 @@ const getPrivateBroker = (broker: EvalBroker) =>
     lastHappyDomEnabled: boolean;
     lastInitKey: string | null;
     onlyByModule: Map<string, string[]>;
+    ensureImportsMapping: (
+      id: string,
+      imports: Map<string, string[]> | null | undefined
+    ) => void;
     ensureRunner: () => Promise<void>;
     handleRunnerStderr: (chunk: Buffer) => void;
     initIsolatedRunner: (
@@ -2837,6 +2842,519 @@ describe('EvalBroker', () => {
     );
     const resultB = await broker.evaluate(epB);
     expect(resultB.values?.get('s')).toBe(24);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('reuses evaluated variant modules when broker sends narrow serialized exports', async () => {
+    // Regression test for cache poisoning:
+    //
+    // Session 1 evaluates dep.js as a module variant (only includes __wywPreval,
+    // so isFullModuleLoad is false). The variant has all exports (x, y).
+    //
+    // Session 2 only needs `x` from dep.js. The broker sends serialized exports
+    // { x: ... } (narrow slice). The runner must NOT create a narrow
+    // SyntheticModule — it should reuse the evaluated variant that has both x and y.
+    //
+    // Session 3 needs both x and y from dep.js. If the runner created a narrow
+    // SyntheticModule in session 2 and returned it, session 3's link would fail
+    // because the SyntheticModule doesn't have y. With the fix, the evaluated
+    // variant is returned instead.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const dep = join(root, 'dep.js');
+    writeFileSync(dep, 'export const x = 10;\nexport const y = 20;\n');
+
+    const barrel = join(root, 'barrel.js');
+    writeFileSync(
+      barrel,
+      "export { x, y } from './dep.js';\n"
+    );
+
+    // Session 1: imports both x and y → forces full eval of dep.js
+    const entryA = join(root, 'entry-a.js');
+    writeFileSync(
+      entryA,
+      [
+        "import { x, y } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  sum: () => x + y,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session 2: imports only x → broker can serve serialized exports
+    const entryB = join(root, 'entry-b.js');
+    writeFileSync(
+      entryB,
+      [
+        "import { x } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  val: () => x,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session 3: imports both x and y again → must not fail
+    const entryC = join(root, 'entry-c.js');
+    writeFileSync(
+      entryC,
+      [
+        "import { x, y } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  diff: () => y - x,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, entryA);
+    const broker = new EvalBroker(services, asyncResolve);
+
+    const epA = Entrypoint.createRoot(
+      services,
+      entryA,
+      ['__wywPreval'],
+      readFileSync(entryA, 'utf-8')
+    );
+    const resultA = await broker.evaluate(epA);
+    expect(resultA.values?.get('sum')).toBe(30);
+
+    const epB = Entrypoint.createRoot(
+      services,
+      entryB,
+      ['__wywPreval'],
+      readFileSync(entryB, 'utf-8')
+    );
+    const resultB = await broker.evaluate(epB);
+    expect(resultB.values?.get('val')).toBe(10);
+
+    const epC = Entrypoint.createRoot(
+      services,
+      entryC,
+      ['__wywPreval'],
+      readFileSync(entryC, 'utf-8')
+    );
+    const resultC = await broker.evaluate(epC);
+    expect(resultC.values?.get('diff')).toBe(10);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not create narrow SyntheticModule when barrel re-exports more than importer needs', async () => {
+    // Reproduces the real-world failure: design-system.ts (barrel) re-exports
+    // fontFamily+fontWeight+textStyles from typography.ts. Session A evaluates
+    // the full chain. Session B's entrypoint only needs fontWeight+textStyles,
+    // so the broker may serve serialized exports for typography with just those
+    // 2 keys. But the barrel's SourceTextModule still has
+    // `import { fontFamily, fontWeight, textStyles } from './typography.js'`
+    // — it needs fontFamily too. If the runner creates a narrow SyntheticModule
+    // for typography, the barrel's link fails.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const typography = join(root, 'typography.js');
+    writeFileSync(
+      typography,
+      [
+        'export const fontFamily = "sans-serif";',
+        'export const fontWeight = 400;',
+        'export const textStyles = { body: "14px" };',
+      ].join('\n')
+    );
+
+    const barrel = join(root, 'barrel.js');
+    writeFileSync(
+      barrel,
+      [
+        "export { fontFamily, fontWeight, textStyles } from './typography.js';",
+        'export const layout = { gap: 8 };',
+      ].join('\n')
+    );
+
+    // Session A: imports fontFamily + fontWeight + textStyles from barrel
+    // → typography.js is prepared with all 3 exports, evaluated as variant
+    const entryA = join(root, 'entry-a.js');
+    writeFileSync(
+      entryA,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  font: () => `${fontFamily} ${fontWeight} ${JSON.stringify(textStyles)}`,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session B: imports only fontWeight + textStyles from barrel
+    // → broker may serve serialized exports for typography (only fontWeight, textStyles)
+    // → barrel's code still imports fontFamily from typography → must not fail
+    const entryB = join(root, 'entry-b.js');
+    writeFileSync(
+      entryB,
+      [
+        "import { fontWeight, textStyles } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  weight: () => fontWeight,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session C: imports fontFamily again → must not fail
+    const entryC = join(root, 'entry-c.js');
+    writeFileSync(
+      entryC,
+      [
+        "import { fontFamily, fontWeight } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  info: () => `${fontFamily}/${fontWeight}`,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, entryA, {
+      features: { staticImportValues: true },
+    });
+    const broker = new EvalBroker(services, asyncResolve);
+
+    const epA = Entrypoint.createRoot(
+      services,
+      entryA,
+      ['__wywPreval'],
+      readFileSync(entryA, 'utf-8')
+    );
+    const resultA = await broker.evaluate(epA);
+    expect(resultA.values?.get('font')).toMatchInlineSnapshot(
+      `"sans-serif 400 {"body":"14px"}"`
+    );
+
+    const epB = Entrypoint.createRoot(
+      services,
+      entryB,
+      ['__wywPreval'],
+      readFileSync(entryB, 'utf-8')
+    );
+    const resultB = await broker.evaluate(epB);
+    expect(resultB.values?.get('weight')).toBe(400);
+
+    const epC = Entrypoint.createRoot(
+      services,
+      entryC,
+      ['__wywPreval'],
+      readFileSync(entryC, 'utf-8')
+    );
+    const resultC = await broker.evaluate(epC);
+    expect(resultC.values?.get('info')).toMatchInlineSnapshot(
+      `"sans-serif/400"`
+    );
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not reuse a narrower evaluated variant for wider serialized exports', async () => {
+    // Mirrors the 4df6e915 Fibery dump:
+    //
+    // 1. typography.js is evaluated as a narrow variant with fontWeight only.
+    // 2. typography.js is evaluated as a wider variant with fontFamily,
+    //    fontWeight and textStyles.
+    // 3. A later load gets serialized exports for that wider set, with a hash
+    //    that is not itself cached as a SourceTextModule variant.
+    //
+    // The runner must not satisfy step 3 by returning the first evaluated
+    // variant for the source path if that variant lacks the serialized export
+    // set.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const typography = join(root, 'typography.js');
+    const entryNarrow = join(root, 'entry-narrow.js');
+    const entryWide = join(root, 'entry-wide.js');
+    const entrySerializedWide = join(root, 'entry-serialized-wide.js');
+
+    writeFileSync(
+      entryNarrow,
+      [
+        "import { fontWeight } from './typography.js';",
+        'export const __wywPreval = {',
+        '  value: () => fontWeight,',
+        '};',
+      ].join('\n')
+    );
+    writeFileSync(
+      entryWide,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './typography.js';",
+        'export const __wywPreval = {',
+        '  value: () => `${fontFamily}:${fontWeight}:${textStyles.body}`,',
+        '};',
+      ].join('\n')
+    );
+    writeFileSync(
+      entrySerializedWide,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './typography.js';",
+        'export const __wywPreval = {',
+        '  value: () => `${fontFamily}/${fontWeight}/${textStyles.body}`,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, entryNarrow, {
+      features: { staticImportValues: true },
+    });
+    const broker = new EvalBroker(services, asyncResolve);
+    const privateBroker = getPrivateBroker(broker);
+    const originalLoadModule = privateBroker.loadModule.bind(privateBroker);
+    const loadCalls: Array<{
+      id: string;
+      importerId?: string | null;
+      request?: string | null;
+    }> = [];
+
+    privateBroker.loadModule = jest.fn(async (payload) => {
+      loadCalls.push(payload);
+
+      const withImports = (
+        id: string,
+        result: {
+          code: string;
+          imports: Map<string, string[]> | null;
+          only: string[];
+          hash: string;
+          exports?: Record<string, ReturnType<typeof serializeValue>>;
+        }
+      ) => {
+        privateBroker.ensureImportsMapping(id, result.imports);
+        return result;
+      };
+
+      if (payload.id === entryNarrow) {
+        return withImports(entryNarrow, {
+          code: readFileSync(entryNarrow, 'utf-8'),
+          imports: new Map([['./typography.js', ['fontWeight']]]),
+          only: ['__wywPreval'],
+          hash: 'entry-narrow',
+        });
+      }
+
+      if (payload.id === entryWide) {
+        return withImports(entryWide, {
+          code: readFileSync(entryWide, 'utf-8'),
+          imports: new Map([
+            ['./typography.js', ['fontFamily', 'fontWeight', 'textStyles']],
+          ]),
+          only: ['__wywPreval'],
+          hash: 'entry-wide',
+        });
+      }
+
+      if (payload.id === entrySerializedWide) {
+        return withImports(entrySerializedWide, {
+          code: readFileSync(entrySerializedWide, 'utf-8'),
+          imports: new Map([
+            ['./typography.js', ['fontFamily', 'fontWeight', 'textStyles']],
+          ]),
+          only: ['__wywPreval'],
+          hash: 'entry-serialized-wide',
+        });
+      }
+
+      if (payload.id === typography && payload.importerId === entryNarrow) {
+        return withImports(typography, {
+          code: 'export const fontWeight = 400;',
+          imports: null,
+          only: ['fontWeight'],
+          hash: 'typography-narrow-font-weight',
+        });
+      }
+
+      if (payload.id === typography && payload.importerId === entryWide) {
+        return withImports(typography, {
+          code: [
+            'export const fontFamily = "Inter";',
+            'export const fontWeight = 400;',
+            'export const textStyles = { body: "14px" };',
+          ].join('\n'),
+          imports: null,
+          only: ['fontFamily', 'fontWeight', 'textStyles'],
+          hash: 'typography-wide-source',
+        });
+      }
+
+      if (
+        payload.id === typography &&
+        payload.importerId === entrySerializedWide
+      ) {
+        return withImports(typography, {
+          code: '',
+          imports: null,
+          only: ['fontFamily', 'fontWeight', 'textStyles'],
+          hash: 'typography-wide-serialized-exports',
+          exports: {
+            fontFamily: serializeValue('Inter'),
+            fontWeight: serializeValue(400),
+            textStyles: serializeValue({ body: '14px' }),
+          },
+        });
+      }
+
+      return originalLoadModule(payload);
+    });
+
+    try {
+      const narrow = Entrypoint.createRoot(
+        services,
+        entryNarrow,
+        ['__wywPreval'],
+        readFileSync(entryNarrow, 'utf-8')
+      );
+      const narrowResult = await broker.evaluate(narrow);
+      expect(narrowResult.values?.get('value')).toBe(400);
+
+      const wide = Entrypoint.createRoot(
+        services,
+        entryWide,
+        ['__wywPreval'],
+        readFileSync(entryWide, 'utf-8')
+      );
+      const wideResult = await broker.evaluate(wide);
+      expect(wideResult.values?.get('value')).toBe('Inter:400:14px');
+
+      const serializedWide = Entrypoint.createRoot(
+        services,
+        entrySerializedWide,
+        ['__wywPreval'],
+        readFileSync(entrySerializedWide, 'utf-8')
+      );
+      const serializedWideResult = await broker.evaluate(serializedWide);
+      expect(serializedWideResult.values?.get('value')).toBe(
+        'Inter/400/14px'
+      );
+      expect(loadCalls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: typography,
+            importerId: entrySerializedWide,
+          }),
+        ])
+      );
+    } finally {
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps wide barrel dependency imports when a later narrow variant finishes', async () => {
+    // Models the Fibery failure shape:
+    //
+    // - design-system.ts is a barrel that can be prepared as multiple variants.
+    // - A wide variant imports fontFamily/fontWeight/textStyles from typography.
+    // - A later narrow variant of the same source imports only fontWeight.
+    // - Because importsByModule is keyed only by source path, the narrow map can
+    //   replace the wide map while the wide SourceTextModule is still linking.
+    // - When that wide module then loads typography, the dependency must still
+    //   be prepared with the wide export set.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const entry = join(root, 'entry.js');
+    const barrel = join(root, 'design-system.js');
+    const typography = join(root, 'typography.js');
+    const theme = join(root, 'theme.js');
+
+    writeFileSync(
+      theme,
+      [
+        'export const themeVars = globalThis.__wywThemeVars || { text: "black" };',
+      ].join('\n')
+    );
+    writeFileSync(
+      typography,
+      [
+        "import { themeVars } from './theme.js';",
+        'export const fontFamily = "Inter";',
+        'export const fontWeight = 400;',
+        'export const textStyles = { body: themeVars.text };',
+      ].join('\n')
+    );
+    writeFileSync(
+      barrel,
+      [
+        "export { fontFamily, fontWeight, textStyles } from './typography.js';",
+      ].join('\n')
+    );
+    writeFileSync(
+      entry,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './design-system.js';",
+        'export const __wywPreval = {',
+        '  value: () => `${fontFamily}:${fontWeight}:${textStyles.body}`,',
+        '};',
+      ].join('\n')
+    );
+
+    const services = createServices(root, entry);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const privateBroker = getPrivateBroker(broker);
+
+    privateBroker.importsByModule.set(
+      entry,
+      new Map([
+        ['./design-system.js', ['fontFamily', 'fontWeight', 'textStyles']],
+      ])
+    );
+
+    const wideBarrel = await privateBroker.loadModule({
+      id: barrel,
+      importerId: entry,
+      request: './design-system.js',
+    });
+
+    expect(wideBarrel.imports?.get('./typography.js')).toEqual([
+      'fontFamily',
+      'fontWeight',
+      'textStyles',
+    ]);
+
+    // Simulate a concurrent/narrow barrel variant completing after the wide
+    // variant. Current code replaces the source-path import map with this
+    // narrower map, which can make the still-linking wide variant load a
+    // typography module that is missing fontFamily/textStyles.
+    privateBroker.ensureImportsMapping(
+      barrel,
+      new Map([['./typography.js', ['fontWeight']]])
+    );
+
+    const typographyForWideBarrel = await privateBroker.loadModule({
+      id: typography,
+      importerId: barrel,
+      request: './typography.js',
+    });
+
+    expect(typographyForWideBarrel.only).toEqual(
+      expect.arrayContaining(['fontFamily', 'fontWeight', 'textStyles'])
+    );
+    expect(typographyForWideBarrel.code).toContain('fontFamily');
+    expect(typographyForWideBarrel.code).toContain('textStyles');
 
     broker.dispose();
     rmSync(root, { recursive: true, force: true });

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -2607,4 +2607,185 @@ describe('transform static import value inlining', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('does not produce link errors when a re-export barrel needs exports shaken from a prior eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const tokensFile = join(root, 'tokens.js');
+    const barrelFile = join(root, 'barrel.js');
+    const entryA = join(root, 'entry-a.js');
+    const entryB = join(root, 'entry-b.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const fontFamily = 'Inter, sans-serif';
+        export const textStyles = { fontSize: '14px', lineHeight: '1.5' };
+      `
+    );
+    writeFileSync(
+      barrelFile,
+      dedent`
+        export { fontFamily } from './tokens.js';
+      `
+    );
+    writeFileSync(
+      entryA,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { textStyles } from './tokens.js';
+
+        export const className = css\`
+          font-size: ${'${textStyles.fontSize}'};
+        \`;
+      `
+    );
+    writeFileSync(
+      entryB,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { fontFamily } from './barrel.js';
+
+        export const className = css\`
+          font-family: ${'${fontFamily}'};
+        \`;
+      `
+    );
+
+    try {
+      // entry-a caches tokens.js with only=['textStyles'] (fontFamily shaken out)
+      const resultA = await runTransform(root, entryA, cache);
+      expect(resultA.cssText).toContain('font-size:14px');
+
+      // entry-b needs fontFamily from tokens.js via barrel.js re-export.
+      // The broker/runner must not serve a shaken variant that omits fontFamily.
+      const resultB = await runTransform(root, entryB, cache);
+      expect(resultB.cssText).toContain('font-family:Inter,sans-serif');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('survives concurrent transforms that need different exports from the same module', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const tokensFile = join(root, 'tokens.js');
+    const barrelFile = join(root, 'barrel.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const fontFamily = 'Inter, sans-serif';
+        export const fontWeight = { light: 300, regular: 400, bold: 700 };
+        export const textStyles = { fontSize: '14px', lineHeight: '1.5' };
+      `
+    );
+    writeFileSync(
+      barrelFile,
+      dedent`
+        export { fontFamily, fontWeight } from './tokens.js';
+      `
+    );
+
+    // Create N entry files: half import textStyles directly, half import
+    // fontFamily via barrel.  Run all transforms concurrently (like webpack).
+    const N = 10;
+    const entries: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const entryFile = join(root, `entry-${i}.js`);
+      if (i % 2 === 0) {
+        writeFileSync(
+          entryFile,
+          dedent`
+            import { css } from 'test-css-processor';
+            import { textStyles } from './tokens.js';
+
+            export const className = css\`
+              font-size: ${'${textStyles.fontSize}'};
+            \`;
+          `
+        );
+      } else {
+        writeFileSync(
+          entryFile,
+          dedent`
+            import { css } from 'test-css-processor';
+            import { fontFamily } from './barrel.js';
+
+            export const className = css\`
+              font-family: ${'${fontFamily}'};
+            \`;
+          `
+        );
+      }
+      entries.push(entryFile);
+    }
+
+    try {
+      // Run all transforms concurrently, sharing the same cache.
+      const results = await Promise.all(
+        entries.map((entry) => runTransform(root, entry, cache))
+      );
+
+      for (let i = 0; i < N; i++) {
+        if (i % 2 === 0) {
+          expect(results[i].cssText).toContain('font-size:14px');
+        } else {
+          expect(results[i].cssText).toContain('font-family:Inter,sans-serif');
+        }
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not produce link errors when the same module is imported directly and via barrel with different exports', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const tokensFile = join(root, 'tokens.js');
+    const barrelFile = join(root, 'barrel.js');
+    const entryFile = join(root, 'entry.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const fontFamily = 'Inter, sans-serif';
+        export const fontWeight = { light: 300, regular: 400, bold: 700 };
+        export const textStyles = { fontSize: '14px', lineHeight: '1.5' };
+      `
+    );
+    writeFileSync(
+      barrelFile,
+      dedent`
+        export { fontFamily, fontWeight } from './tokens.js';
+      `
+    );
+    // Single entry that imports textStyles directly from tokens
+    // AND fontFamily via the barrel — within one eval, the runner loads
+    // tokens.js once for the direct import (only=['textStyles']) and once
+    // during barrel.js linking (needs fontFamily+fontWeight).
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { textStyles } from './tokens.js';
+        import { fontFamily, fontWeight } from './barrel.js';
+
+        export const className = css\`
+          font-size: ${'${textStyles.fontSize}'};
+          font-family: ${'${fontFamily}'};
+          font-weight: ${'${fontWeight.regular}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache);
+      expect(result.cssText).toContain('font-size:14px');
+      expect(result.cssText).toContain('font-family:Inter,sans-serif');
+      expect(result.cssText).toContain('font-weight:400');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -1220,7 +1220,31 @@ export class EvalBroker {
     id: string,
     imports: Map<string, string[]> | null | undefined
   ) {
-    this.importsByModule.set(id, imports ?? new Map());
+    if (!imports || imports.size === 0) {
+      if (!this.importsByModule.has(id)) {
+        this.importsByModule.set(id, new Map());
+      }
+      return;
+    }
+
+    const existing = this.importsByModule.get(id);
+    if (!existing || existing.size === 0) {
+      this.importsByModule.set(id, imports);
+      return;
+    }
+
+    // Merge: widen each specifier's import list rather than replacing.
+    // Different variants of the same module may import different subsets
+    // from the same dependency. The widest set must be preserved so that
+    // any still-linking variant can resolve all its bindings.
+    for (const [specifier, keys] of imports) {
+      const existingKeys = existing.get(specifier);
+      if (!existingKeys) {
+        existing.set(specifier, keys);
+      } else {
+        existing.set(specifier, mergeOnly(existingKeys, keys));
+      }
+    }
   }
 
   private getImportOnly(
@@ -2597,6 +2621,9 @@ export class EvalBroker {
         }
       }
     }
+
+    const isSelfLoad = !importerId || importerId === id;
+
     const cachedEntrypoint = this.services.cache.get('entrypoints', id) as
       | {
           evaluated?: boolean;
@@ -2641,7 +2668,12 @@ export class EvalBroker {
         }
       }
     }
-    const canReusePreparedLoad = !requiredOnly.includes('__wywPreval');
+    // Only skip the prepared-load cache for self-loads (the eval entrypoint),
+    // which must always be freshly prepared because __wywPreval evaluation has
+    // side effects. Dependencies propagate __wywPreval in their `only` chain
+    // but don't need fresh preparation — their code is deterministic.
+    const canReusePreparedLoad =
+      !isSelfLoad || !requiredOnly.includes('__wywPreval');
     if (
       canReusePreparedLoad &&
       cached &&
@@ -2822,6 +2854,11 @@ export class EvalBroker {
 
     try {
       const result = await task;
+      // Register imports for ALL code paths (barrel proxy, prepareModuleOnDemand,
+      // custom loaders). Without this, the barrel proxy path skips
+      // ensureImportsMapping, so getLoadRequestOnly can't determine what a barrel
+      // module imports from its sub-dependencies.
+      this.ensureImportsMapping(id, result.imports);
       this.loadCache.set(id, result);
       return result;
     } finally {

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1775,17 +1775,57 @@ loadModule = async (id, importer, requestSpec) => {
     }
 
     if (loaded.exports) {
-      if (cached && loaded.hash && moduleHashes.get(id) === loaded.hash) {
-        return cached;
+      // Serialized exports are a narrow slice — only the keys the importer
+      // requested. If we have a fully evaluated module (in moduleCache or as
+      // a variant), prefer it: its namespace has ALL exports, so any consumer
+      // can link against it without "does not provide export" errors.
+      //
+      // An evaluated variant is only safe to reuse when its namespace covers
+      // the serialized key set. A narrow variant that was evaluated first may
+      // lack exports that a wider consumer needs (the 4df6e915 race).
+      const requiredKeys = Object.keys(loaded.exports);
+      const coversKeys = (mod) => {
+        const ns = mod.namespace;
+        return requiredKeys.every((k) => k in ns);
+      };
+
+      let evaluated =
+        cached && cached.status === 'evaluated' && coversKeys(cached)
+          ? cached
+          : undefined;
+
+      if (!evaluated) {
+        const variants = moduleVariants.get(id);
+        if (variants) {
+          for (const variant of variants.values()) {
+            if (variant.status === 'evaluated' && coversKeys(variant)) {
+              evaluated = variant;
+              break;
+            }
+          }
+        }
+      }
+
+      if (evaluated) {
+        return evaluated;
+      }
+
+      // Reuse a previously created SyntheticModule for this exact serialized set
+      if (loaded.hash) {
+        const existing = getModuleVariant(id, loaded.hash);
+        if (existing) {
+          return existing;
+        }
       }
 
       const exportsValue = {};
       Object.entries(loaded.exports).forEach(([key, serialized]) => {
         exportsValue[key] = deserializeValue(serialized);
       });
-      // Serialized exports can be a narrow slice of a module. Do not let them
-      // replace a cached SourceTextModule that may be needed by another import.
       const module = createSyntheticModule(id, exportsValue, false);
+      if (loaded.hash) {
+        setModuleVariant(id, loaded.hash, module);
+      }
       return module;
     }
 

--- a/packages/transform/src/transform/Entrypoint.ts
+++ b/packages/transform/src/transform/Entrypoint.ts
@@ -266,7 +266,7 @@ export class Entrypoint extends BaseEntrypoint {
         parent ? [parent] : [],
         loadedCode,
         name,
-        cached.only,
+        mergedOnly,
         exports,
         evaluatedOnly,
         cached.loadedAndParsed,


### PR DESCRIPTION
### Problem

With `staticImportValues: true` (87e63348), identical builds of the same codebase produce non-deterministic results: 0 to ~490 link errors across runs. The errors are always `The requested module does not provide an export named '...'`.

### Root cause

Three independent bugs in the eval pipeline conspire to create a cache poisoning chain:

**1. `ensureImportsMapping` replaces instead of merging (broker.ts)**

When a module has multiple variants (e.g., a barrel re-exporting different subsets for different importers), each variant calls `ensureImportsMapping` with its own import map. The old code *replaced* the map, so a narrow variant completing after a wide one would overwrite the wide import set. When the still-linking wide variant then loaded a sub-dependency, the broker consulted the now-narrow import map and prepared the dependency without the exports the wide variant needed.

**2. `canReusePreparedLoad` blocked dependency cache reuse (broker.ts)**

The guard `!requiredOnly.includes('__wywPreval')` was meant to force fresh preparation for eval entrypoints (whose `__wywPreval` evaluation has side effects). But `__wywPreval` propagates into dependency `only` chains — so dependencies were also forced to re-prepare every session, even though their code is deterministic. This caused unnecessary re-preparation and made the import-map replacement race (bug 1) more likely to trigger.

**3. Runner returned first evaluated variant, not widest (runner.js)**

When the broker sends serialized exports (the `staticImportValues` fast path), the runner checks `moduleVariants` for a previously evaluated `SourceTextModule` to reuse instead of creating a narrow `SyntheticModule`. The old code returned the *first* evaluated variant found via `for...of` iteration — which is insertion-order, i.e., the first variant ever created. If that was a narrow variant (e.g., only `fontWeight`), its namespace lacked exports that wider consumers needed (e.g., `fontFamily`, `textStyles`), causing V8 `SourceTextModule.link()` to fail.

**4. Reused entrypoints kept stale narrow `only` (Entrypoint.ts)**

`Entrypoint.innerCreate` has a `canReuseEvaluatedTransformResult` fast path that reuses a previously evaluated entrypoint. It was passing `cached.only` (the old narrow set) instead of `mergedOnly` (the wider set requested by the current importer). This caused downstream dependency preparation to use the stale narrow `only`.

### The poisoning chain (from build dump analysis)

```
evalSeq 1-30:  typography.ts prepared with only:['*']           → hash 0d50d5 (wide, all exports)
evalSeq 49:    typography.ts re-prepared with only:['fontWeight'] → hash 33e4e26 (narrow)
               ensureImportsMapping replaces wide map with narrow
               loadCache stores narrow variant
evalSeq 50-73: all sessions get hash 33e4e26 (narrow)
               → 424 link errors for fontFamily/fontWeight/textStyles
```

### Fixes

| File | Change |
|------|--------|
| `broker.ts` — `ensureImportsMapping` | Merge import maps instead of replacing. Each specifier's import list is widened, never narrowed. |
| `broker.ts` — `canReusePreparedLoad` | Only skip cache for self-loads (`!importerId \|\| importerId === id`). Dependencies reuse cached preparations even when `__wywPreval` propagated in their `only`. |
| `runner.js` — serialized-exports variant selection | Check `coversKeys(variant)`: verify the variant's namespace has all keys in the serialized export set before reusing. Skip narrow variants, pick one that covers. |
| `runner.js` — SyntheticModule caching | Cache fallback SyntheticModules by hash in `moduleVariants`. Same serialized set reuses the same module instead of creating + linking a new one per load. |
| `Entrypoint.ts` — `canReuseEvaluatedTransformResult` | Pass `mergedOnly` instead of `cached.only` so reused entrypoints carry the widened export set. |

### Investigation timeline

| Attempt | SHA | Result | Finding |
|---------|-----|--------|---------|
| widestPreparedOnly in task closure | 508d4593 | 5/5 fail | Widening only ran when new preparations happened, not on cache hits |
| widestPreparedOnly before cache | abdb4a15 | 3/5 fail | Wrong layer — `Entrypoint.innerCreate` bypassed it via `canReuseEvaluatedTransformResult` |
| Entrypoint.ts cached.only→mergedOnly | fd531894 | 4/5 fail | Fixed code-preparation narrowing but serialized-exports still narrow |
| + ensureImportsMapping merge | 23bf7778 | 5/5 fail | Fixed broker-side narrowing but runner still picked wrong variant |
| + runner variant coversKeys | 9162f7e5 | 1/1 pass (178s) | Correct but 2x perf regression from uncached SyntheticModule fallback |
| + SyntheticModule hash caching | 4ee95aa2 | 5/5 pass (82-118s) | 0 errors, baseline perf restored |

### Tests added

**`eval-broker.test.ts`** (3 new tests):
- *reuses evaluated variant modules when broker sends narrow serialized exports* — 3-session A→B→C chain where session B gets narrow serialized exports but an evaluated variant exists
- *does not reuse a narrower evaluated variant for wider serialized exports* — mocked `loadModule` that injects narrow variant first, then wide, then serialized-wide; reproduces the exact `for...of` insertion-order bug
- *keeps wide barrel dependency imports when a later narrow variant finishes* — tests `ensureImportsMapping` merge: wide barrel variant's import map must survive a later narrow variant completing

**`transform.static-import-values.test.ts`** (3 new tests):
- Sequential A-then-B transforms sharing a dependency
- Single entry importing both paths from a shared barrel
- Concurrent 10-entry transforms hitting the same barrel

### Verification

- 5 consecutive identical builds of frontend-orange: **0 errors, 0-5 warnings, 82-118s** (baseline: 95-105s)
- All 51 `transform.static-import-values` tests pass
- All 51 `EvalBroker` tests pass (1 pre-existing unrelated failure)
- Full test suite: no regressions
