### PR TITLE
fix(transform): prevent eval cache poisoning across sessions (MR1)

### DIFF
--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -21,6 +21,7 @@ import {
   EvalBroker,
   stripEntrypointGlobalsFromRunnerContext,
 } from '../eval/broker';
+import { serializeValue } from '../eval/serialize';
 
 const createPluginOptions = (overrides: PartialOptions = {}) =>
   loadWywOptions({
@@ -74,6 +75,10 @@ const getPrivateBroker = (broker: EvalBroker) =>
     lastHappyDomEnabled: boolean;
     lastInitKey: string | null;
     onlyByModule: Map<string, string[]>;
+    ensureImportsMapping: (
+      id: string,
+      imports: Map<string, string[]> | null | undefined
+    ) => void;
     ensureRunner: () => Promise<void>;
     handleRunnerStderr: (chunk: Buffer) => void;
     initIsolatedRunner: (
@@ -2837,6 +2842,519 @@ describe('EvalBroker', () => {
     );
     const resultB = await broker.evaluate(epB);
     expect(resultB.values?.get('s')).toBe(24);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('reuses evaluated variant modules when broker sends narrow serialized exports', async () => {
+    // Regression test for cache poisoning:
+    //
+    // Session 1 evaluates dep.js as a module variant (only includes __wywPreval,
+    // so isFullModuleLoad is false). The variant has all exports (x, y).
+    //
+    // Session 2 only needs `x` from dep.js. The broker sends serialized exports
+    // { x: ... } (narrow slice). The runner must NOT create a narrow
+    // SyntheticModule — it should reuse the evaluated variant that has both x and y.
+    //
+    // Session 3 needs both x and y from dep.js. If the runner created a narrow
+    // SyntheticModule in session 2 and returned it, session 3's link would fail
+    // because the SyntheticModule doesn't have y. With the fix, the evaluated
+    // variant is returned instead.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const dep = join(root, 'dep.js');
+    writeFileSync(dep, 'export const x = 10;\nexport const y = 20;\n');
+
+    const barrel = join(root, 'barrel.js');
+    writeFileSync(
+      barrel,
+      "export { x, y } from './dep.js';\n"
+    );
+
+    // Session 1: imports both x and y → forces full eval of dep.js
+    const entryA = join(root, 'entry-a.js');
+    writeFileSync(
+      entryA,
+      [
+        "import { x, y } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  sum: () => x + y,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session 2: imports only x → broker can serve serialized exports
+    const entryB = join(root, 'entry-b.js');
+    writeFileSync(
+      entryB,
+      [
+        "import { x } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  val: () => x,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session 3: imports both x and y again → must not fail
+    const entryC = join(root, 'entry-c.js');
+    writeFileSync(
+      entryC,
+      [
+        "import { x, y } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  diff: () => y - x,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, entryA);
+    const broker = new EvalBroker(services, asyncResolve);
+
+    const epA = Entrypoint.createRoot(
+      services,
+      entryA,
+      ['__wywPreval'],
+      readFileSync(entryA, 'utf-8')
+    );
+    const resultA = await broker.evaluate(epA);
+    expect(resultA.values?.get('sum')).toBe(30);
+
+    const epB = Entrypoint.createRoot(
+      services,
+      entryB,
+      ['__wywPreval'],
+      readFileSync(entryB, 'utf-8')
+    );
+    const resultB = await broker.evaluate(epB);
+    expect(resultB.values?.get('val')).toBe(10);
+
+    const epC = Entrypoint.createRoot(
+      services,
+      entryC,
+      ['__wywPreval'],
+      readFileSync(entryC, 'utf-8')
+    );
+    const resultC = await broker.evaluate(epC);
+    expect(resultC.values?.get('diff')).toBe(10);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not create narrow SyntheticModule when barrel re-exports more than importer needs', async () => {
+    // Reproduces the real-world failure: design-system.ts (barrel) re-exports
+    // fontFamily+fontWeight+textStyles from typography.ts. Session A evaluates
+    // the full chain. Session B's entrypoint only needs fontWeight+textStyles,
+    // so the broker may serve serialized exports for typography with just those
+    // 2 keys. But the barrel's SourceTextModule still has
+    // `import { fontFamily, fontWeight, textStyles } from './typography.js'`
+    // — it needs fontFamily too. If the runner creates a narrow SyntheticModule
+    // for typography, the barrel's link fails.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const typography = join(root, 'typography.js');
+    writeFileSync(
+      typography,
+      [
+        'export const fontFamily = "sans-serif";',
+        'export const fontWeight = 400;',
+        'export const textStyles = { body: "14px" };',
+      ].join('\n')
+    );
+
+    const barrel = join(root, 'barrel.js');
+    writeFileSync(
+      barrel,
+      [
+        "export { fontFamily, fontWeight, textStyles } from './typography.js';",
+        'export const layout = { gap: 8 };',
+      ].join('\n')
+    );
+
+    // Session A: imports fontFamily + fontWeight + textStyles from barrel
+    // → typography.js is prepared with all 3 exports, evaluated as variant
+    const entryA = join(root, 'entry-a.js');
+    writeFileSync(
+      entryA,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  font: () => `${fontFamily} ${fontWeight} ${JSON.stringify(textStyles)}`,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session B: imports only fontWeight + textStyles from barrel
+    // → broker may serve serialized exports for typography (only fontWeight, textStyles)
+    // → barrel's code still imports fontFamily from typography → must not fail
+    const entryB = join(root, 'entry-b.js');
+    writeFileSync(
+      entryB,
+      [
+        "import { fontWeight, textStyles } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  weight: () => fontWeight,',
+        '};',
+      ].join('\n')
+    );
+
+    // Session C: imports fontFamily again → must not fail
+    const entryC = join(root, 'entry-c.js');
+    writeFileSync(
+      entryC,
+      [
+        "import { fontFamily, fontWeight } from './barrel.js';",
+        'export const __wywPreval = {',
+        '  info: () => `${fontFamily}/${fontWeight}`,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, entryA, {
+      features: { staticImportValues: true },
+    });
+    const broker = new EvalBroker(services, asyncResolve);
+
+    const epA = Entrypoint.createRoot(
+      services,
+      entryA,
+      ['__wywPreval'],
+      readFileSync(entryA, 'utf-8')
+    );
+    const resultA = await broker.evaluate(epA);
+    expect(resultA.values?.get('font')).toMatchInlineSnapshot(
+      `"sans-serif 400 {"body":"14px"}"`
+    );
+
+    const epB = Entrypoint.createRoot(
+      services,
+      entryB,
+      ['__wywPreval'],
+      readFileSync(entryB, 'utf-8')
+    );
+    const resultB = await broker.evaluate(epB);
+    expect(resultB.values?.get('weight')).toBe(400);
+
+    const epC = Entrypoint.createRoot(
+      services,
+      entryC,
+      ['__wywPreval'],
+      readFileSync(entryC, 'utf-8')
+    );
+    const resultC = await broker.evaluate(epC);
+    expect(resultC.values?.get('info')).toMatchInlineSnapshot(
+      `"sans-serif/400"`
+    );
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not reuse a narrower evaluated variant for wider serialized exports', async () => {
+    // Mirrors the 4df6e915 Fibery dump:
+    //
+    // 1. typography.js is evaluated as a narrow variant with fontWeight only.
+    // 2. typography.js is evaluated as a wider variant with fontFamily,
+    //    fontWeight and textStyles.
+    // 3. A later load gets serialized exports for that wider set, with a hash
+    //    that is not itself cached as a SourceTextModule variant.
+    //
+    // The runner must not satisfy step 3 by returning the first evaluated
+    // variant for the source path if that variant lacks the serialized export
+    // set.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const typography = join(root, 'typography.js');
+    const entryNarrow = join(root, 'entry-narrow.js');
+    const entryWide = join(root, 'entry-wide.js');
+    const entrySerializedWide = join(root, 'entry-serialized-wide.js');
+
+    writeFileSync(
+      entryNarrow,
+      [
+        "import { fontWeight } from './typography.js';",
+        'export const __wywPreval = {',
+        '  value: () => fontWeight,',
+        '};',
+      ].join('\n')
+    );
+    writeFileSync(
+      entryWide,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './typography.js';",
+        'export const __wywPreval = {',
+        '  value: () => `${fontFamily}:${fontWeight}:${textStyles.body}`,',
+        '};',
+      ].join('\n')
+    );
+    writeFileSync(
+      entrySerializedWide,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './typography.js';",
+        'export const __wywPreval = {',
+        '  value: () => `${fontFamily}/${fontWeight}/${textStyles.body}`,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, entryNarrow, {
+      features: { staticImportValues: true },
+    });
+    const broker = new EvalBroker(services, asyncResolve);
+    const privateBroker = getPrivateBroker(broker);
+    const originalLoadModule = privateBroker.loadModule.bind(privateBroker);
+    const loadCalls: Array<{
+      id: string;
+      importerId?: string | null;
+      request?: string | null;
+    }> = [];
+
+    privateBroker.loadModule = jest.fn(async (payload) => {
+      loadCalls.push(payload);
+
+      const withImports = (
+        id: string,
+        result: {
+          code: string;
+          imports: Map<string, string[]> | null;
+          only: string[];
+          hash: string;
+          exports?: Record<string, ReturnType<typeof serializeValue>>;
+        }
+      ) => {
+        privateBroker.ensureImportsMapping(id, result.imports);
+        return result;
+      };
+
+      if (payload.id === entryNarrow) {
+        return withImports(entryNarrow, {
+          code: readFileSync(entryNarrow, 'utf-8'),
+          imports: new Map([['./typography.js', ['fontWeight']]]),
+          only: ['__wywPreval'],
+          hash: 'entry-narrow',
+        });
+      }
+
+      if (payload.id === entryWide) {
+        return withImports(entryWide, {
+          code: readFileSync(entryWide, 'utf-8'),
+          imports: new Map([
+            ['./typography.js', ['fontFamily', 'fontWeight', 'textStyles']],
+          ]),
+          only: ['__wywPreval'],
+          hash: 'entry-wide',
+        });
+      }
+
+      if (payload.id === entrySerializedWide) {
+        return withImports(entrySerializedWide, {
+          code: readFileSync(entrySerializedWide, 'utf-8'),
+          imports: new Map([
+            ['./typography.js', ['fontFamily', 'fontWeight', 'textStyles']],
+          ]),
+          only: ['__wywPreval'],
+          hash: 'entry-serialized-wide',
+        });
+      }
+
+      if (payload.id === typography && payload.importerId === entryNarrow) {
+        return withImports(typography, {
+          code: 'export const fontWeight = 400;',
+          imports: null,
+          only: ['fontWeight'],
+          hash: 'typography-narrow-font-weight',
+        });
+      }
+
+      if (payload.id === typography && payload.importerId === entryWide) {
+        return withImports(typography, {
+          code: [
+            'export const fontFamily = "Inter";',
+            'export const fontWeight = 400;',
+            'export const textStyles = { body: "14px" };',
+          ].join('\n'),
+          imports: null,
+          only: ['fontFamily', 'fontWeight', 'textStyles'],
+          hash: 'typography-wide-source',
+        });
+      }
+
+      if (
+        payload.id === typography &&
+        payload.importerId === entrySerializedWide
+      ) {
+        return withImports(typography, {
+          code: '',
+          imports: null,
+          only: ['fontFamily', 'fontWeight', 'textStyles'],
+          hash: 'typography-wide-serialized-exports',
+          exports: {
+            fontFamily: serializeValue('Inter'),
+            fontWeight: serializeValue(400),
+            textStyles: serializeValue({ body: '14px' }),
+          },
+        });
+      }
+
+      return originalLoadModule(payload);
+    });
+
+    try {
+      const narrow = Entrypoint.createRoot(
+        services,
+        entryNarrow,
+        ['__wywPreval'],
+        readFileSync(entryNarrow, 'utf-8')
+      );
+      const narrowResult = await broker.evaluate(narrow);
+      expect(narrowResult.values?.get('value')).toBe(400);
+
+      const wide = Entrypoint.createRoot(
+        services,
+        entryWide,
+        ['__wywPreval'],
+        readFileSync(entryWide, 'utf-8')
+      );
+      const wideResult = await broker.evaluate(wide);
+      expect(wideResult.values?.get('value')).toBe('Inter:400:14px');
+
+      const serializedWide = Entrypoint.createRoot(
+        services,
+        entrySerializedWide,
+        ['__wywPreval'],
+        readFileSync(entrySerializedWide, 'utf-8')
+      );
+      const serializedWideResult = await broker.evaluate(serializedWide);
+      expect(serializedWideResult.values?.get('value')).toBe(
+        'Inter/400/14px'
+      );
+      expect(loadCalls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: typography,
+            importerId: entrySerializedWide,
+          }),
+        ])
+      );
+    } finally {
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps wide barrel dependency imports when a later narrow variant finishes', async () => {
+    // Models the Fibery failure shape:
+    //
+    // - design-system.ts is a barrel that can be prepared as multiple variants.
+    // - A wide variant imports fontFamily/fontWeight/textStyles from typography.
+    // - A later narrow variant of the same source imports only fontWeight.
+    // - Because importsByModule is keyed only by source path, the narrow map can
+    //   replace the wide map while the wide SourceTextModule is still linking.
+    // - When that wide module then loads typography, the dependency must still
+    //   be prepared with the wide export set.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    const entry = join(root, 'entry.js');
+    const barrel = join(root, 'design-system.js');
+    const typography = join(root, 'typography.js');
+    const theme = join(root, 'theme.js');
+
+    writeFileSync(
+      theme,
+      [
+        'export const themeVars = globalThis.__wywThemeVars || { text: "black" };',
+      ].join('\n')
+    );
+    writeFileSync(
+      typography,
+      [
+        "import { themeVars } from './theme.js';",
+        'export const fontFamily = "Inter";',
+        'export const fontWeight = 400;',
+        'export const textStyles = { body: themeVars.text };',
+      ].join('\n')
+    );
+    writeFileSync(
+      barrel,
+      [
+        "export { fontFamily, fontWeight, textStyles } from './typography.js';",
+      ].join('\n')
+    );
+    writeFileSync(
+      entry,
+      [
+        "import { fontFamily, fontWeight, textStyles } from './design-system.js';",
+        'export const __wywPreval = {',
+        '  value: () => `${fontFamily}:${fontWeight}:${textStyles.body}`,',
+        '};',
+      ].join('\n')
+    );
+
+    const services = createServices(root, entry);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => null)
+    );
+    const privateBroker = getPrivateBroker(broker);
+
+    privateBroker.importsByModule.set(
+      entry,
+      new Map([
+        ['./design-system.js', ['fontFamily', 'fontWeight', 'textStyles']],
+      ])
+    );
+
+    const wideBarrel = await privateBroker.loadModule({
+      id: barrel,
+      importerId: entry,
+      request: './design-system.js',
+    });
+
+    expect(wideBarrel.imports?.get('./typography.js')).toEqual([
+      'fontFamily',
+      'fontWeight',
+      'textStyles',
+    ]);
+
+    // Simulate a concurrent/narrow barrel variant completing after the wide
+    // variant. Current code replaces the source-path import map with this
+    // narrower map, which can make the still-linking wide variant load a
+    // typography module that is missing fontFamily/textStyles.
+    privateBroker.ensureImportsMapping(
+      barrel,
+      new Map([['./typography.js', ['fontWeight']]])
+    );
+
+    const typographyForWideBarrel = await privateBroker.loadModule({
+      id: typography,
+      importerId: barrel,
+      request: './typography.js',
+    });
+
+    expect(typographyForWideBarrel.only).toEqual(
+      expect.arrayContaining(['fontFamily', 'fontWeight', 'textStyles'])
+    );
+    expect(typographyForWideBarrel.code).toContain('fontFamily');
+    expect(typographyForWideBarrel.code).toContain('textStyles');
 
     broker.dispose();
     rmSync(root, { recursive: true, force: true });

--- a/packages/transform/src/__tests__/resolveImports.boundedRetry.test.ts
+++ b/packages/transform/src/__tests__/resolveImports.boundedRetry.test.ts
@@ -1,0 +1,194 @@
+import * as babel from '@babel/core';
+
+import type { StrictOptions } from '@wyw-in-js/shared';
+import { logger } from '@wyw-in-js/shared';
+
+import { TransformCacheCollection } from '../cache';
+import { Entrypoint } from '../transform/Entrypoint';
+import type { LoadAndParseFn } from '../transform/Entrypoint.types';
+import { asyncResolveImports } from '../transform/generators/resolveImports';
+import type { IResolveImportsAction, Services } from '../transform/types';
+import { EventEmitter } from '../utils/EventEmitter';
+
+const createPluginOptions = (): StrictOptions => ({
+  babelOptions: {},
+  displayName: false,
+  evaluate: true,
+  extensions: ['.cjs', '.js', '.jsx', '.ts', '.tsx'],
+  features: {
+    dangerousCodeRemover: true,
+    globalCache: true,
+    happyDOM: true,
+    softErrors: false,
+    useBabelConfigs: true,
+    useWeakRefInEval: true,
+  },
+  highPriorityPlugins: [],
+  importOverrides: undefined,
+  rules: [],
+});
+
+const createServices = (filename: string): Services => {
+  const loadAndParseFn: LoadAndParseFn = (services, _name, loadedCode) => ({
+    get ast() {
+      return services.babel.parseSync(loadedCode ?? '')!;
+    },
+    code: loadedCode ?? '',
+    evaluator: jest.fn(),
+    evalConfig: {},
+  });
+
+  return {
+    babel,
+    cache: new TransformCacheCollection(),
+    loadAndParseFn,
+    log: logger,
+    eventEmitter: EventEmitter.dummy,
+    options: {
+      filename,
+      root: '/project',
+      pluginOptions: createPluginOptions(),
+    },
+  };
+};
+
+const drainAsync = async <T>(gen: AsyncGenerator<unknown, T>): Promise<T> => {
+  while (true) {
+    const next = await gen.next();
+    if (next.done) {
+      return next.value;
+    }
+  }
+};
+
+describe('asyncResolveImports — bounded retry on null resolutions', () => {
+  it('retries a transient null resolution exactly once, then succeeds', async () => {
+    const services = createServices('/project/src/a.js');
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      '/project/src/a.js',
+      ['*'],
+      ''
+    );
+
+    let attempt = 0;
+    const resolve = jest.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error('transient resolver failure');
+      }
+      return '/project/src/foo.js';
+    });
+
+    const callResolve = () =>
+      drainAsync(
+        asyncResolveImports.call(
+          {
+            data: { imports: new Map([['./foo', ['default']]]) },
+            entrypoint,
+            services,
+          } as IResolveImportsAction,
+          resolve
+        )
+      );
+
+    const first = await callResolve();
+    expect(first).toEqual([]); // null filtered out
+    expect(resolve).toHaveBeenCalledTimes(1);
+
+    const second = await callResolve();
+    expect(second).toEqual([
+      {
+        source: './foo',
+        only: ['default'],
+        resolved: '/project/src/foo.js',
+      },
+    ]);
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('caps retries at MAX_NULL_ATTEMPTS — persistent failures stop calling the resolver', async () => {
+    const services = createServices('/project/src/a.js');
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      '/project/src/a.js',
+      ['*'],
+      ''
+    );
+
+    const resolve = jest.fn(async () => {
+      throw new Error('persistent failure');
+    });
+
+    const callResolve = () =>
+      drainAsync(
+        asyncResolveImports.call(
+          {
+            data: { imports: new Map([['./foo', ['default']]]) },
+            entrypoint,
+            services,
+          } as IResolveImportsAction,
+          resolve
+        )
+      );
+
+    // Many consumers hit the same failing source. Resolver must be called at
+    // most MAX_NULL_ATTEMPTS times (currently 2), not once per consumer.
+    for (let i = 0; i < 50; i += 1) {
+      const result = await callResolve();
+      expect(result).toEqual([]);
+    }
+
+    // Exactly 2 attempts: first call, then one bounded retry.
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('still dedupes concurrent in-flight requests for the same source', async () => {
+    const services = createServices('/project/src/a.js');
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      '/project/src/a.js',
+      ['*'],
+      ''
+    );
+
+    let releaseResolver: ((value: string) => void) | null = null;
+    const resolve = jest.fn(
+      () =>
+        new Promise<string>((resolve_) => {
+          releaseResolver = resolve_;
+        })
+    );
+
+    const callResolve = () =>
+      drainAsync(
+        asyncResolveImports.call(
+          {
+            data: { imports: new Map([['./foo', ['default']]]) },
+            entrypoint,
+            services,
+          } as IResolveImportsAction,
+          resolve
+        )
+      );
+
+    const a = callResolve();
+    const b = callResolve();
+
+    await new Promise((r) => setImmediate(r));
+    expect(resolve).toHaveBeenCalledTimes(1);
+
+    releaseResolver!('/project/src/foo.js');
+
+    const [resolvedA, resolvedB] = await Promise.all([a, b]);
+    expect(resolvedA).toEqual([
+      {
+        source: './foo',
+        only: ['default'],
+        resolved: '/project/src/foo.js',
+      },
+    ]);
+    expect(resolvedB).toEqual(resolvedA);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -2607,4 +2607,185 @@ describe('transform static import value inlining', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('does not produce link errors when a re-export barrel needs exports shaken from a prior eval', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const tokensFile = join(root, 'tokens.js');
+    const barrelFile = join(root, 'barrel.js');
+    const entryA = join(root, 'entry-a.js');
+    const entryB = join(root, 'entry-b.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const fontFamily = 'Inter, sans-serif';
+        export const textStyles = { fontSize: '14px', lineHeight: '1.5' };
+      `
+    );
+    writeFileSync(
+      barrelFile,
+      dedent`
+        export { fontFamily } from './tokens.js';
+      `
+    );
+    writeFileSync(
+      entryA,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { textStyles } from './tokens.js';
+
+        export const className = css\`
+          font-size: ${'${textStyles.fontSize}'};
+        \`;
+      `
+    );
+    writeFileSync(
+      entryB,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { fontFamily } from './barrel.js';
+
+        export const className = css\`
+          font-family: ${'${fontFamily}'};
+        \`;
+      `
+    );
+
+    try {
+      // entry-a caches tokens.js with only=['textStyles'] (fontFamily shaken out)
+      const resultA = await runTransform(root, entryA, cache);
+      expect(resultA.cssText).toContain('font-size:14px');
+
+      // entry-b needs fontFamily from tokens.js via barrel.js re-export.
+      // The broker/runner must not serve a shaken variant that omits fontFamily.
+      const resultB = await runTransform(root, entryB, cache);
+      expect(resultB.cssText).toContain('font-family:Inter,sans-serif');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('survives concurrent transforms that need different exports from the same module', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const tokensFile = join(root, 'tokens.js');
+    const barrelFile = join(root, 'barrel.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const fontFamily = 'Inter, sans-serif';
+        export const fontWeight = { light: 300, regular: 400, bold: 700 };
+        export const textStyles = { fontSize: '14px', lineHeight: '1.5' };
+      `
+    );
+    writeFileSync(
+      barrelFile,
+      dedent`
+        export { fontFamily, fontWeight } from './tokens.js';
+      `
+    );
+
+    // Create N entry files: half import textStyles directly, half import
+    // fontFamily via barrel.  Run all transforms concurrently (like webpack).
+    const N = 10;
+    const entries: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const entryFile = join(root, `entry-${i}.js`);
+      if (i % 2 === 0) {
+        writeFileSync(
+          entryFile,
+          dedent`
+            import { css } from 'test-css-processor';
+            import { textStyles } from './tokens.js';
+
+            export const className = css\`
+              font-size: ${'${textStyles.fontSize}'};
+            \`;
+          `
+        );
+      } else {
+        writeFileSync(
+          entryFile,
+          dedent`
+            import { css } from 'test-css-processor';
+            import { fontFamily } from './barrel.js';
+
+            export const className = css\`
+              font-family: ${'${fontFamily}'};
+            \`;
+          `
+        );
+      }
+      entries.push(entryFile);
+    }
+
+    try {
+      // Run all transforms concurrently, sharing the same cache.
+      const results = await Promise.all(
+        entries.map((entry) => runTransform(root, entry, cache))
+      );
+
+      for (let i = 0; i < N; i++) {
+        if (i % 2 === 0) {
+          expect(results[i].cssText).toContain('font-size:14px');
+        } else {
+          expect(results[i].cssText).toContain('font-family:Inter,sans-serif');
+        }
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not produce link errors when the same module is imported directly and via barrel with different exports', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const tokensFile = join(root, 'tokens.js');
+    const barrelFile = join(root, 'barrel.js');
+    const entryFile = join(root, 'entry.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const fontFamily = 'Inter, sans-serif';
+        export const fontWeight = { light: 300, regular: 400, bold: 700 };
+        export const textStyles = { fontSize: '14px', lineHeight: '1.5' };
+      `
+    );
+    writeFileSync(
+      barrelFile,
+      dedent`
+        export { fontFamily, fontWeight } from './tokens.js';
+      `
+    );
+    // Single entry that imports textStyles directly from tokens
+    // AND fontFamily via the barrel — within one eval, the runner loads
+    // tokens.js once for the direct import (only=['textStyles']) and once
+    // during barrel.js linking (needs fontFamily+fontWeight).
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { textStyles } from './tokens.js';
+        import { fontFamily, fontWeight } from './barrel.js';
+
+        export const className = css\`
+          font-size: ${'${textStyles.fontSize}'};
+          font-family: ${'${fontFamily}'};
+          font-weight: ${'${fontWeight.regular}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache);
+      expect(result.cssText).toContain('font-size:14px');
+      expect(result.cssText).toContain('font-family:Inter,sans-serif');
+      expect(result.cssText).toContain('font-weight:400');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -1220,7 +1220,31 @@ export class EvalBroker {
     id: string,
     imports: Map<string, string[]> | null | undefined
   ) {
-    this.importsByModule.set(id, imports ?? new Map());
+    if (!imports || imports.size === 0) {
+      if (!this.importsByModule.has(id)) {
+        this.importsByModule.set(id, new Map());
+      }
+      return;
+    }
+
+    const existing = this.importsByModule.get(id);
+    if (!existing || existing.size === 0) {
+      this.importsByModule.set(id, imports);
+      return;
+    }
+
+    // Merge: widen each specifier's import list rather than replacing.
+    // Different variants of the same module may import different subsets
+    // from the same dependency. The widest set must be preserved so that
+    // any still-linking variant can resolve all its bindings.
+    for (const [specifier, keys] of imports) {
+      const existingKeys = existing.get(specifier);
+      if (!existingKeys) {
+        existing.set(specifier, keys);
+      } else {
+        existing.set(specifier, mergeOnly(existingKeys, keys));
+      }
+    }
   }
 
   private getImportOnly(
@@ -2597,6 +2621,9 @@ export class EvalBroker {
         }
       }
     }
+
+    const isSelfLoad = !importerId || importerId === id;
+
     const cachedEntrypoint = this.services.cache.get('entrypoints', id) as
       | {
           evaluated?: boolean;
@@ -2641,7 +2668,12 @@ export class EvalBroker {
         }
       }
     }
-    const canReusePreparedLoad = !requiredOnly.includes('__wywPreval');
+    // Only skip the prepared-load cache for self-loads (the eval entrypoint),
+    // which must always be freshly prepared because __wywPreval evaluation has
+    // side effects. Dependencies propagate __wywPreval in their `only` chain
+    // but don't need fresh preparation — their code is deterministic.
+    const canReusePreparedLoad =
+      !isSelfLoad || !requiredOnly.includes('__wywPreval');
     if (
       canReusePreparedLoad &&
       cached &&
@@ -2822,6 +2854,11 @@ export class EvalBroker {
 
     try {
       const result = await task;
+      // Register imports for ALL code paths (barrel proxy, prepareModuleOnDemand,
+      // custom loaders). Without this, the barrel proxy path skips
+      // ensureImportsMapping, so getLoadRequestOnly can't determine what a barrel
+      // module imports from its sub-dependencies.
+      this.ensureImportsMapping(id, result.imports);
       this.loadCache.set(id, result);
       return result;
     } finally {

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1775,17 +1775,57 @@ loadModule = async (id, importer, requestSpec) => {
     }
 
     if (loaded.exports) {
-      if (cached && loaded.hash && moduleHashes.get(id) === loaded.hash) {
-        return cached;
+      // Serialized exports are a narrow slice — only the keys the importer
+      // requested. If we have a fully evaluated module (in moduleCache or as
+      // a variant), prefer it: its namespace has ALL exports, so any consumer
+      // can link against it without "does not provide export" errors.
+      //
+      // An evaluated variant is only safe to reuse when its namespace covers
+      // the serialized key set. A narrow variant that was evaluated first may
+      // lack exports that a wider consumer needs (the 4df6e915 race).
+      const requiredKeys = Object.keys(loaded.exports);
+      const coversKeys = (mod) => {
+        const ns = mod.namespace;
+        return requiredKeys.every((k) => k in ns);
+      };
+
+      let evaluated =
+        cached && cached.status === 'evaluated' && coversKeys(cached)
+          ? cached
+          : undefined;
+
+      if (!evaluated) {
+        const variants = moduleVariants.get(id);
+        if (variants) {
+          for (const variant of variants.values()) {
+            if (variant.status === 'evaluated' && coversKeys(variant)) {
+              evaluated = variant;
+              break;
+            }
+          }
+        }
+      }
+
+      if (evaluated) {
+        return evaluated;
+      }
+
+      // Reuse a previously created SyntheticModule for this exact serialized set
+      if (loaded.hash) {
+        const existing = getModuleVariant(id, loaded.hash);
+        if (existing) {
+          return existing;
+        }
       }
 
       const exportsValue = {};
       Object.entries(loaded.exports).forEach(([key, serialized]) => {
         exportsValue[key] = deserializeValue(serialized);
       });
-      // Serialized exports can be a narrow slice of a module. Do not let them
-      // replace a cached SourceTextModule that may be needed by another import.
       const module = createSyntheticModule(id, exportsValue, false);
+      if (loaded.hash) {
+        setModuleVariant(id, loaded.hash, module);
+      }
       return module;
     }
 

--- a/packages/transform/src/transform/Entrypoint.ts
+++ b/packages/transform/src/transform/Entrypoint.ts
@@ -266,7 +266,7 @@ export class Entrypoint extends BaseEntrypoint {
         parent ? [parent] : [],
         loadedCode,
         name,
-        cached.only,
+        mergedOnly,
         exports,
         evaluatedOnly,
         cached.loadedAndParsed,

--- a/packages/transform/src/transform/Entrypoint.ts
+++ b/packages/transform/src/transform/Entrypoint.ts
@@ -54,6 +54,14 @@ export class Entrypoint extends BaseEntrypoint {
     Map<unknown, Map<unknown, BaseAction<ActionQueueItem>>>
   > = new Map();
 
+  // Tracks how many times resolveImports has settled with `resolved: null`
+  // for a given source. Bundler resolvers can return null transiently early
+  // in a build (loader context for that file isn't registered yet); after a
+  // bounded number of retries we accept the null as authoritative.
+  #resolveTaskNullAttempts = new Map<string, number>();
+
+  private static readonly RESOLVE_TASK_MAX_NULL_ATTEMPTS = 2;
+
   #hasWywMetadata: boolean = false;
 
   #hasTransformResult = false;
@@ -387,7 +395,28 @@ export class Entrypoint extends BaseEntrypoint {
     name: string,
     dependency: Promise<IEntrypointDependency>
   ): void {
-    this.resolveTasks.set(name, dependency);
+    // Bounded retry of transient null resolutions. The first time a
+    // resolveTask settles to null, evict it from the cache so the next
+    // consumer re-attempts the resolver. After RESOLVE_TASK_MAX_NULL_ATTEMPTS
+    // failures the entry stays cached so we don't thrash. Successful (non-null)
+    // resolutions remain cached normally; this branch only ever fires for null.
+    const tracked = dependency.then((resolved) => {
+      if (resolved.resolved !== null) {
+        return resolved;
+      }
+
+      const attempts = (this.#resolveTaskNullAttempts.get(name) ?? 0) + 1;
+      this.#resolveTaskNullAttempts.set(name, attempts);
+      if (
+        attempts < Entrypoint.RESOLVE_TASK_MAX_NULL_ATTEMPTS &&
+        this.resolveTasks.get(name) === tracked
+      ) {
+        this.resolveTasks.delete(name);
+      }
+
+      return resolved;
+    });
+    this.resolveTasks.set(name, tracked);
   }
 
   public applyDeferredSupersede() {

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -88,14 +88,21 @@ type StaticMetadataPreevalCacheEntry =
       result: ReturnType<typeof runOxcPreevalStage>;
     };
 
+// Null entries carry an attempt counter so we can retry a bounded number of
+// times before accepting the failure as stable. This avoids both:
+// (a) poisoning the cache forever from a transient resolver failure
+// (b) thundering-herd retries where every consumer re-walks a stable miss
 type StaticExportCacheEntry =
   | {
+      attempts: number;
       result: null;
     }
   | {
       dependencyHashes: Map<string, string>;
       result: StaticExportResult;
     };
+
+const STATIC_EXPORT_MAX_NULL_ATTEMPTS = 2;
 
 type StaticImportValueFeatures = {
   staticImportValues?: FeatureFlag;
@@ -382,6 +389,12 @@ const getStaticExportCachedResult = (
   }
 
   if (cached.result === null) {
+    // Bounded retry: until the attempt counter has been bumped enough times
+    // that we accept the null as stable, treat it as a cache miss so the
+    // caller re-walks. The counter is updated in setStaticExportCachedResult.
+    if (cached.attempts < STATIC_EXPORT_MAX_NULL_ATTEMPTS) {
+      return undefined;
+    }
     return null;
   }
 
@@ -404,6 +417,7 @@ const setStaticExportCachedResult = (
     return;
   }
 
+  const cache = staticExportResultCache(action);
   const cacheKey = staticExportCacheKey(
     action,
     filename,
@@ -411,7 +425,10 @@ const setStaticExportCachedResult = (
     codeHash
   );
   if (!result) {
-    staticExportResultCache(action).set(cacheKey, { result: null });
+    const existing = cache.get(cacheKey);
+    const attempts =
+      existing && existing.result === null ? existing.attempts + 1 : 1;
+    cache.set(cacheKey, { attempts, result: null });
     return;
   }
 
@@ -423,7 +440,7 @@ const setStaticExportCachedResult = (
     return;
   }
 
-  staticExportResultCache(action).set(cacheKey, {
+  cache.set(cacheKey, {
     dependencyHashes,
     result,
   });


### PR DESCRIPTION
## Summary

- Prevent eval cache poisoning: when an evaluated module variant has full exports, the runner returns the variant instead of building a narrow `SyntheticModule` from a session's serialized slice — so a later session asking for additional exports still finds them.
- Bound retries on `null` static-resolve results: `resolveStaticOxcValues` now tracks an `attempts` counter on null cache entries and re-walks up to 2 times before treating the miss as stable, avoiding permanent poisoning from a transient resolver failure.

## Test plan

- [ ] `pnpm --filter @wyw-in-js/transform test -- --testPathPattern='(eval-broker|resolveImports.boundedRetry|transform.static-import-values)'`
- [ ] Bisect resolver-failure scenario: confirm second attempt resolves once the resolver recovers, third attempt accepts the null as stable.

## Notes for reviewer

Both commits address the same failure mode (stale negative cache state surviving across eval sessions). Recommend **squash on merge**.

Lands cleanly on `anber/static-import-constant-inlining`. MR2 + MR3 touch adjacent regions of `broker.ts` / `Entrypoint.ts` — landing this first gives them a stable base.
