### PR TITLE
perf(transform): reduce eval broker work across sessions (MR3)

### DIFF
--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -3424,4 +3424,93 @@ describe('EvalBroker', () => {
     broker.dispose();
     rmSync(root, { recursive: true, force: true });
   });
+
+  it('skips re-shipping LoadResult code when runner already has matching hash', async () => {
+    // Multiple importers asking for the same dependency in one runner session
+    // produce identical prepared variants (same hash, same `only`). The first
+    // LOAD must ship code; subsequent LOADs must ship `code: ''` so the
+    // runner's hash-match short-circuit (runner.js:1834) reuses its cached
+    // SourceTextModule instead of re-parsing identical bytes.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const importerA = join(root, 'a.js');
+    const importerB = join(root, 'b.js');
+    const dep = join(root, 'dep.js');
+
+    const customLoader = jest.fn(async () => ({
+      code: 'export const value = 1;',
+    }));
+    const services = createServices(root, importerA, {
+      eval: { customLoader },
+    });
+
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => dep)
+    );
+    const privateBroker = broker as unknown as {
+      handleLoad: (
+        id: string,
+        payload: { id: string; importerId: string | null; request: string | null }
+      ) => Promise<void>;
+      onlyByModule: Map<string, string[]>;
+      runnerInputQueue: unknown;
+      sendMessage: (message: unknown) => Promise<void>;
+    };
+
+    type CapturedLoadResult = {
+      id: string;
+      payload: { code?: string; hash?: string; only?: string[] };
+    };
+    const captured: CapturedLoadResult[] = [];
+    privateBroker.runnerInputQueue = {
+      write: () => Promise.resolve(),
+    };
+    privateBroker.sendMessage = async (message: unknown) => {
+      const m = message as { type: string } & CapturedLoadResult;
+      if (m.type === 'LOAD_RESULT') {
+        captured.push({ id: m.id, payload: m.payload });
+      }
+    };
+
+    privateBroker.onlyByModule.set(dep, ['*']);
+
+    await privateBroker.handleLoad('msg-1', {
+      id: dep,
+      importerId: importerA,
+      request: null,
+    });
+    await privateBroker.handleLoad('msg-2', {
+      id: dep,
+      importerId: importerB,
+      request: null,
+    });
+
+    expect(captured).toHaveLength(2);
+    const [first, second] = captured;
+    expect(first.payload.code).toBe('export const value = 1;');
+    expect(first.payload.hash).toBeTruthy();
+    expect(second.payload.code).toBe('');
+    expect(second.payload.hash).toBe(first.payload.hash);
+
+    // Third LOAD with a wider `only` (forces a new prepared variant via the
+    // loadCache miss path) must ship code again.
+    const widerLoader = jest.fn(async () => ({
+      code: 'export const value = 1;\nexport const extra = 2;',
+    }));
+    services.options.pluginOptions.eval = { customLoader: widerLoader };
+    privateBroker.onlyByModule.set(dep, ['*', 'extra']);
+
+    await privateBroker.handleLoad('msg-3', {
+      id: dep,
+      importerId: importerA,
+      request: null,
+    });
+
+    expect(captured).toHaveLength(3);
+    expect(captured[2].payload.code).toContain('extra');
+    expect(captured[2].payload.hash).not.toBe(first.payload.hash);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
 });

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -3450,7 +3450,11 @@ describe('EvalBroker', () => {
     const privateBroker = broker as unknown as {
       handleLoad: (
         id: string,
-        payload: { id: string; importerId: string | null; request: string | null }
+        payload: {
+          id: string;
+          importerId: string | null;
+          request: string | null;
+        }
       ) => Promise<void>;
       onlyByModule: Map<string, string[]>;
       runnerInputQueue: unknown;
@@ -3509,6 +3513,95 @@ describe('EvalBroker', () => {
     expect(captured).toHaveLength(3);
     expect(captured[2].payload.code).toContain('extra');
     expect(captured[2].payload.hash).not.toBe(first.payload.hash);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not carry shipped-code coverage across different load hashes', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entry = join(root, 'entry.js');
+    const dep = join(root, 'dep.js');
+    writeFileSync(entry, 'export const __wywPreval = {};');
+
+    const services = createServices(root, entry);
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => dep)
+    );
+    const privateBroker = broker as unknown as {
+      handleLoad: (
+        id: string,
+        payload: {
+          id: string;
+          importerId: string | null;
+          request: string | null;
+        }
+      ) => Promise<void>;
+      loadModule: jest.Mock;
+      runnerInputQueue: unknown;
+      sendMessage: (message: unknown) => Promise<void>;
+    };
+
+    type CapturedLoadResult = {
+      id: string;
+      payload: { code?: string; hash?: string; only?: string[] };
+    };
+    const captured: CapturedLoadResult[] = [];
+    privateBroker.runnerInputQueue = {
+      write: () => Promise.resolve(),
+    };
+    privateBroker.sendMessage = async (message: unknown) => {
+      const m = message as { type: string } & CapturedLoadResult;
+      if (m.type === 'LOAD_RESULT') {
+        captured.push({ id: m.id, payload: m.payload });
+      }
+    };
+
+    privateBroker.loadModule = jest
+      .fn()
+      .mockResolvedValueOnce({
+        code: 'export const first = 1;',
+        imports: null,
+        only: ['*'],
+        hash: 'hash-a',
+      })
+      .mockResolvedValueOnce({
+        code: 'export const value = 1;',
+        imports: null,
+        only: ['value'],
+        hash: 'hash-b',
+      })
+      .mockResolvedValueOnce({
+        code: 'export const value = 1;',
+        imports: null,
+        only: ['*'],
+        hash: 'hash-b',
+      });
+
+    await privateBroker.handleLoad('msg-1', {
+      id: dep,
+      importerId: entry,
+      request: null,
+    });
+    await privateBroker.handleLoad('msg-2', {
+      id: dep,
+      importerId: entry,
+      request: null,
+    });
+    await privateBroker.handleLoad('msg-3', {
+      id: dep,
+      importerId: entry,
+      request: null,
+    });
+
+    expect(captured).toHaveLength(3);
+    expect(captured[0].payload.code).toContain('first');
+    expect(captured[1].payload.code).toContain('value');
+    // The second load stored hash-b as a module variant. The prior wildcard
+    // coverage from hash-a must not make the broker believe hash-b also exists
+    // in the runner's primary module cache.
+    expect(captured[2].payload.code).toContain('value');
 
     broker.dispose();
     rmSync(root, { recursive: true, force: true });

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -3615,4 +3615,150 @@ describe('EvalBroker', () => {
     broker.dispose();
     rmSync(root, { recursive: true, force: true });
   });
+
+  describe('evaluate batching', () => {
+    type BatchPrivateBroker = {
+      ensureRunner: () => Promise<void>;
+      initRunner: (entrypoint: Entrypoint) => Promise<void>;
+      onlyByModule: Map<string, string[]>;
+      pendingEvals: unknown[];
+      request: (
+        type: string,
+        payload: unknown,
+        timeoutMs?: number
+      ) => Promise<unknown>;
+    };
+
+    const stubBatchInternals = (
+      broker: EvalBroker,
+      onEval: (id: string) => Promise<{
+        values: Record<string, unknown> | null;
+        modules?: Record<string, unknown>;
+      }>
+    ) => {
+      const pb = broker as unknown as BatchPrivateBroker;
+      pb.ensureRunner = jest.fn(async () => {});
+      pb.initRunner = jest.fn(async () => {});
+      pb.request = jest.fn(async (type, payload) => {
+        if (type !== 'EVAL') {
+          throw new Error(`unexpected request type: ${type}`);
+        }
+        const { id } = payload as { id: string };
+        return onEval(id);
+      });
+      return pb;
+    };
+
+    it('coalesces concurrent evaluate() calls into one runner pass', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+      const entries = ['a', 'b', 'c'].map((n) => join(root, `${n}.js`));
+      entries.forEach((p) => writeFileSync(p, 'export const __wywPreval = {};'));
+
+      const services = createServices(root, entries[0]);
+      const broker = new EvalBroker(
+        services,
+        jest.fn(async () => null)
+      );
+      const entrypoints = entries.map((p) =>
+        Entrypoint.createRoot(services, p, ['__wywPreval'], readFileSync(p, 'utf-8'))
+      );
+
+      const evalOrder: string[] = [];
+      const onlySnapshots: Record<string, string[] | undefined> = {};
+      const pb = stubBatchInternals(broker, async (id) => {
+        evalOrder.push(id);
+        // Capture the broker's onlyByModule for this entrypoint at the moment
+        // EVAL is sent — proves per-entrypoint state-clear runs between
+        // members of the batch.
+        onlySnapshots[id] = pb.onlyByModule.get(id);
+        return {
+          values: { v: serializeValue(`from-${id}`, { allowFunctions: true }) },
+        };
+      });
+
+      const initSpy = pb.initRunner as jest.Mock;
+      const ensureSpy = pb.ensureRunner as jest.Mock;
+
+      const promises = entrypoints.map((ep) => broker.evaluate(ep));
+      const results = await Promise.all(promises);
+
+      expect(evalOrder).toEqual(entries);
+      results.forEach((r, i) => {
+        expect(r.values?.get('v')).toBe(`from-${entries[i]}`);
+      });
+      entries.forEach((p) => {
+        expect(onlySnapshots[p]).toEqual(['__wywPreval']);
+      });
+      // One ensureRunner across the batch; initRunner still per-member
+      // (cheap on the runner side via canReuseContext).
+      expect(ensureSpy).toHaveBeenCalledTimes(1);
+      expect(initSpy).toHaveBeenCalledTimes(3);
+
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    it('isolates batch-member failures', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+      const entries = ['a', 'b', 'c'].map((n) => join(root, `${n}.js`));
+      entries.forEach((p) => writeFileSync(p, 'export const __wywPreval = {};'));
+
+      const services = createServices(root, entries[0]);
+      const broker = new EvalBroker(
+        services,
+        jest.fn(async () => null)
+      );
+      const entrypoints = entries.map((p) =>
+        Entrypoint.createRoot(services, p, ['__wywPreval'], readFileSync(p, 'utf-8'))
+      );
+
+      stubBatchInternals(broker, async (id) => {
+        if (id === entries[1]) {
+          throw new Error('middle-fail');
+        }
+        return { values: { v: serializeValue(id, { allowFunctions: true }) } };
+      });
+
+      const settled = await Promise.allSettled(
+        entrypoints.map((ep) => broker.evaluate(ep))
+      );
+      expect(settled[0].status).toBe('fulfilled');
+      expect(settled[1].status).toBe('rejected');
+      expect(settled[2].status).toBe('fulfilled');
+      if (settled[1].status === 'rejected') {
+        expect(String(settled[1].reason)).toContain('middle-fail');
+      }
+
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    it('single evaluate() call still runs (batch of one is a no-op)', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+      const entry = join(root, 'a.js');
+      writeFileSync(entry, 'export const __wywPreval = {};');
+
+      const services = createServices(root, entry);
+      const broker = new EvalBroker(
+        services,
+        jest.fn(async () => null)
+      );
+      const entrypoint = Entrypoint.createRoot(
+        services,
+        entry,
+        ['__wywPreval'],
+        readFileSync(entry, 'utf-8')
+      );
+
+      stubBatchInternals(broker, async (id) => ({
+        values: { v: serializeValue(id, { allowFunctions: true }) },
+      }));
+
+      const result = await broker.evaluate(entrypoint);
+      expect(result.values?.get('v')).toBe(entry);
+
+      broker.dispose();
+      rmSync(root, { recursive: true, force: true });
+    });
+  });
 });

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -3513,4 +3513,106 @@ describe('EvalBroker', () => {
     broker.dispose();
     rmSync(root, { recursive: true, force: true });
   });
+
+  it('keeps shipped-code mirror across evaluate() boundaries with stable globals/happyDOM', async () => {
+    // Real workflows reuse the runner across many entrypoints. The runner
+    // only resets its moduleCache when globals or happyDOM change
+    // (runner.js:2116). When those are stable, INIT just rebinds entrypoint
+    // metadata and the runner keeps every cached module — so the broker's
+    // shipped-code mirror must survive cross-entrypoint INITs.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entryA = join(root, 'a.js');
+    const entryB = join(root, 'b.js');
+    const dep = join(root, 'dep.js');
+    writeFileSync(entryA, 'export const __wywPreval = {};');
+    writeFileSync(entryB, 'export const __wywPreval = {};');
+
+    const customLoader = jest.fn(async () => ({
+      code: 'export const value = 1;',
+    }));
+    const services = createServices(root, entryA, {
+      eval: { customLoader },
+    });
+    const broker = new EvalBroker(
+      services,
+      jest.fn(async () => dep)
+    );
+    const privateBroker = broker as unknown as {
+      ensureRunner: () => Promise<void>;
+      handleLoad: (
+        id: string,
+        payload: { id: string; importerId: string | null; request: string | null }
+      ) => Promise<void>;
+      initRunner: (entrypoint: Entrypoint) => Promise<void>;
+      lastInitKey: string | null;
+      lastHappyDomEnabled: boolean;
+      lastSentLoadByModule: Map<string, { hash: string; only: string[] }>;
+      onlyByModule: Map<string, string[]>;
+      request: (
+        type: string,
+        payload: unknown,
+        timeoutMs?: number
+      ) => Promise<unknown>;
+      runnerInputQueue: unknown;
+      sendMessage: (message: unknown) => Promise<void>;
+    };
+    privateBroker.ensureRunner = jest.fn(async () => {});
+    privateBroker.request = jest.fn(async () => ({}));
+
+    type CapturedLoadResult = {
+      id: string;
+      payload: { code?: string; hash?: string };
+    };
+    const captured: CapturedLoadResult[] = [];
+    privateBroker.runnerInputQueue = {
+      write: () => Promise.resolve(),
+    };
+    privateBroker.sendMessage = async (message: unknown) => {
+      const m = message as { type: string } & CapturedLoadResult;
+      if (m.type === 'LOAD_RESULT') {
+        captured.push({ id: m.id, payload: m.payload });
+      }
+    };
+
+    privateBroker.onlyByModule.set(dep, ['*']);
+
+    const entrypointA = Entrypoint.createRoot(
+      services,
+      entryA,
+      ['__wywPreval'],
+      readFileSync(entryA, 'utf-8')
+    );
+    const entrypointB = Entrypoint.createRoot(
+      services,
+      entryB,
+      ['__wywPreval'],
+      readFileSync(entryB, 'utf-8')
+    );
+
+    await privateBroker.initRunner(entrypointA);
+    await privateBroker.handleLoad('msg-1', {
+      id: dep,
+      importerId: entryA,
+      request: null,
+    });
+
+    // Switch to a different entrypoint — initKey changes but globals/happyDOM
+    // are identical, so the runner keeps moduleCache and our mirror must too.
+    await privateBroker.initRunner(entrypointB);
+    expect(privateBroker.lastSentLoadByModule.size).toBeGreaterThan(0);
+
+    await privateBroker.handleLoad('msg-2', {
+      id: dep,
+      importerId: entryB,
+      request: null,
+    });
+
+    expect(captured).toHaveLength(2);
+    expect(captured[0].payload.code).toBe('export const value = 1;');
+    expect(captured[1].payload.code).toBe('');
+    expect(captured[1].payload.hash).toBe(captured[0].payload.hash);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
 });

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -665,7 +665,7 @@ const buildRunnerInitPayload = (
 
   return {
     evalOptions: {
-      globals: encodeGlobals(sanitizedGlobals) as Record<string, unknown>,
+      globals: encodeGlobalsCached(sanitizedGlobals),
       importOverrides,
       mode: evalOptions.mode ?? 'strict',
       require: evalOptions.require ?? 'warn-and-run',
@@ -1152,6 +1152,38 @@ const getInitPayloadKey = (payload: EvalRunnerInitPayload): string =>
     .update(JSON.stringify(canonicalizeForHash(payload)))
     .digest('hex');
 
+// Hash everything in the init payload that affects whether the runner needs
+// a fresh INIT — i.e. everything except `entrypoint` (which only affects
+// __filename/__dirname rebinding, not context reuse). The broker memoizes
+// this per-services so we replace per-evaluate SHA-256 of the full payload
+// with one SHA-256 of the stable bits + a cheap string concat per
+// entrypoint.
+const getStableInitPayloadHash = (
+  payload: EvalRunnerInitPayload
+): string => {
+  const { entrypoint: _entrypoint, ...stable } = payload;
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalizeForHash(stable)))
+    .digest('hex');
+};
+
+// Memoize encodeGlobals on input reference. The user's globals object is
+// stable across a build, so we can encode it once instead of per evaluate.
+// If the input ref changes, fall through to a fresh encode (and reset the
+// cache).
+const encodeGlobalsMemo = new WeakMap<object, Record<string, unknown>>();
+const encodeGlobalsCached = (input: unknown): Record<string, unknown> => {
+  if (input !== null && typeof input === 'object') {
+    const obj = input as object;
+    const cached = encodeGlobalsMemo.get(obj);
+    if (cached) return cached;
+    const encoded = encodeGlobals(input) as Record<string, unknown>;
+    encodeGlobalsMemo.set(obj, encoded);
+    return encoded;
+  }
+  return encodeGlobals(input) as Record<string, unknown>;
+};
+
 const formatLoaderResult = (code: string, loader?: string | null) => {
   if (loader === 'json') {
     return `export default ${JSON.stringify(JSON.parse(code))};`;
@@ -1233,6 +1265,19 @@ export class EvalBroker {
   private pendingEvals: PendingEval[] = [];
 
   private evalFlushScheduled = false;
+
+  // Cached stable init payload hash. Keyed on the refs that feed the stable
+  // bits (pluginOptions.eval and pluginOptions itself). Any reference change
+  // invalidates the cache. The full per-entrypoint init key is
+  // `${stableHash}::${entrypoint.name}` — cheap string concat instead of
+  // re-canonicalizing+stringifying+SHA-256ing the whole payload per call.
+  private stableInitHashCache: {
+    pluginOptionsRef: unknown;
+    evalOptionsRef: unknown;
+    featuresRef: FeatureFlags<'happyDOM'>;
+    rootRef: string | undefined;
+    hash: string;
+  } | null = null;
 
   private evalSeq = 0;
 
@@ -1511,6 +1556,7 @@ export class EvalBroker {
     this.lastInitKey = null;
     this.lastHappyDomEnabled = false;
     this.lastSentLoadByModule.clear();
+    this.stableInitHashCache = null;
     flushDebugStreams();
   }
 
@@ -1715,19 +1761,57 @@ export class EvalBroker {
     this.lastSentLoadByModule.clear();
   }
 
+  private getStableInitHash(
+    services: Services,
+    features: FeatureFlags<'happyDOM'>
+  ): string {
+    const pluginOptionsRef = services.options.pluginOptions;
+    const evalOptionsRef = pluginOptionsRef.eval;
+    const rootRef = services.options.root;
+    if (
+      this.stableInitHashCache !== null &&
+      this.stableInitHashCache.pluginOptionsRef === pluginOptionsRef &&
+      this.stableInitHashCache.evalOptionsRef === evalOptionsRef &&
+      this.stableInitHashCache.featuresRef === features &&
+      this.stableInitHashCache.rootRef === rootRef
+    ) {
+      return this.stableInitHashCache.hash;
+    }
+    // Build a sample payload (entrypoint name doesn't affect stable hash; we
+    // pass any name and strip it inside getStableInitPayloadHash).
+    // encodeGlobals is memoized so this is the only place it actually runs
+    // per config change.
+    const samplePayload = buildRunnerInitPayload(
+      services,
+      { name: '\0stable-init-sample\0' } as Entrypoint,
+      features
+    );
+    samplePayload.reuseModules = true;
+    const hash = getStableInitPayloadHash(samplePayload);
+    this.stableInitHashCache = {
+      pluginOptionsRef,
+      evalOptionsRef,
+      featuresRef: features,
+      rootRef,
+      hash,
+    };
+    return hash;
+  }
+
   private async initRunner(entrypoint: Entrypoint) {
     const features = this.getRunnerFeatures();
-    const payload = buildRunnerInitPayload(this.services, entrypoint, features);
-    payload.reuseModules = true;
-    const initKey = getInitPayloadKey(payload);
+    const stableHash = this.getStableInitHash(this.currentServices, features);
+    const initKey = `${stableHash}::${entrypoint.name}`;
+    if (this.lastInitKey === initKey) {
+      return;
+    }
     const nextHappyDomEnabled = isFeatureEnabled(
       features,
       'happyDOM',
       entrypoint.name
     );
-    if (this.lastInitKey === initKey) {
-      return;
-    }
+    const payload = buildRunnerInitPayload(this.services, entrypoint, features);
+    payload.reuseModules = true;
     const timeoutMs = this.getInitTimeoutMs(entrypoint, features);
 
     if (
@@ -1755,7 +1839,7 @@ export class EvalBroker {
           );
           fallbackPayload.reuseModules = true;
           await this.request('INIT', fallbackPayload, INIT_TIMEOUT_MS);
-          this.lastInitKey = getInitPayloadKey(fallbackPayload);
+          this.lastInitKey = `${this.getStableInitHash(this.currentServices, fallbackFeatures)}::${entrypoint.name}`;
           this.lastHappyDomEnabled = false;
           return;
         }

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -445,6 +445,13 @@ type PendingRequest = {
   timeout: ReturnType<typeof setTimeout>;
 };
 
+// Mirrors runner.js `isFullModuleLoad`: wildcard `['*']` (or empty) is the
+// only shape stored in the runner's moduleCache; everything else lands in
+// moduleVariants. The shipped-code dedup must respect this shape because the
+// runner picks its lookup map based on the LoadResult's `only`.
+const isWildcardOnly = (only: string[] | undefined | null): boolean =>
+  !only || only.length === 0 || (only.length === 1 && only[0] === '*');
+
 const isEvalTimeoutError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') return false;
   if ('code' in error && (error as { code?: string }).code) {
@@ -1669,13 +1676,6 @@ export class EvalBroker {
     if (this.lastInitKey === initKey) {
       return;
     }
-    // We're about to send a fresh INIT. The runner may reset its moduleCache
-    // when its context is rebuilt (globals/happyDOM changes). We can't tell
-    // from here whether it actually will, so conservatively drop our
-    // "what runner already has" mirror — at most one redundant retransmission
-    // per init boundary, vs. the alternative of shipping `code: ''` to a
-    // runner that just cleared its cache (which would crash with empty code).
-    this.lastSentLoadByModule.clear();
     const timeoutMs = this.getInitTimeoutMs(entrypoint, features);
 
     if (
@@ -1812,6 +1812,12 @@ export class EvalBroker {
           this.rejectPending(message.id, message.error);
           this.runner?.kill();
           return;
+        }
+        if (message.modulesReset) {
+          // Runner just cleared its moduleCache during this INIT (full
+          // context rebuild or reuseModules:false). Drop our shipped-code
+          // mirror so handleLoad ships fresh code on the next LOAD.
+          this.lastSentLoadByModule.clear();
         }
         this.resolvePending(message.id, {});
         return;
@@ -2565,10 +2571,21 @@ export class EvalBroker {
     const previouslySent = prepared.hash
       ? this.lastSentLoadByModule.get(payload.id)
       : undefined;
+    // Runner stores by hash but classifies storage by `only` shape: wildcard
+    // (`['*']`) ⇒ moduleCache, anything else ⇒ moduleVariants (runner.js
+    // isFullModuleLoad / runner.js:1832-1842). Reusing across shapes would
+    // hit the wrong map and miss. Require the same shape AND the prepared
+    // `only` to be a subset of what we already shipped — same hash already
+    // implies identical bytes.
+    const sameStorageShape = Boolean(
+      previouslySent &&
+        isWildcardOnly(previouslySent.only) === isWildcardOnly(prepared.only)
+    );
     const runnerHasCachedVariant = Boolean(
       prepared.hash &&
         previouslySent &&
         previouslySent.hash === prepared.hash &&
+        sameStorageShape &&
         isSuperSet(previouslySent.only, prepared.only)
     );
     const shouldShipCode = Boolean(

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -1442,12 +1442,14 @@ export class EvalBroker {
     this.resetPerEntrypointState(entrypoint);
     this.evalSeq += 1;
 
-    debugAction({
-      type: 'eval:start',
-      evalSeq: this.evalSeq,
-      entrypoint: entrypoint.name,
-      ts: performance.now(),
-    });
+    if (debugEvalDir) {
+      debugAction({
+        type: 'eval:start',
+        evalSeq: this.evalSeq,
+        entrypoint: entrypoint.name,
+        ts: performance.now(),
+      });
+    }
 
     try {
       await this.initRunner(entrypoint);
@@ -1458,13 +1460,15 @@ export class EvalBroker {
         EVAL_TIMEOUT_MS
       );
 
-      debugAction({
-        type: 'eval:finish',
-        evalSeq: this.evalSeq,
-        entrypoint: entrypoint.name,
-        hasValues: Boolean(payload.values),
-        ts: performance.now(),
-      });
+      if (debugEvalDir) {
+        debugAction({
+          type: 'eval:finish',
+          evalSeq: this.evalSeq,
+          entrypoint: entrypoint.name,
+          hasValues: Boolean(payload.values),
+          ts: performance.now(),
+        });
+      }
 
       if (payload.modules) {
         this.applyModuleExports(payload.modules);
@@ -2022,16 +2026,18 @@ export class EvalBroker {
   private async handleResolve(id: string, payload: ResolveRequestPayload) {
     const result = await this.resolveImport(payload);
 
-    debugAction({
-      type: 'resolve',
-      evalSeq: this.evalSeq,
-      specifier: payload.specifier,
-      importer: payload.importerId,
-      kind: payload.kind,
-      resolvedId: result.resolvedId ?? null,
-      external: result.external ?? false,
-      ts: performance.now(),
-    });
+    if (debugEvalDir) {
+      debugAction({
+        type: 'resolve',
+        evalSeq: this.evalSeq,
+        specifier: payload.specifier,
+        importer: payload.importerId,
+        kind: payload.kind,
+        resolvedId: result.resolvedId ?? null,
+        external: result.external ?? false,
+        ts: performance.now(),
+      });
+    }
 
     await this.sendMessage({
       type: 'RESOLVE_RESULT',
@@ -2728,28 +2734,30 @@ export class EvalBroker {
       prepared.code && !prepared.exports && !runnerHasCachedVariant
     );
 
-    if (shouldShipCode && debugEvalDir) {
-      dumpEvalCode(
-        payload.id,
-        prepared.code!,
-        prepared.only,
-        prepared.hash ? `cache:${prepared.hash}` : 'fresh',
-        this.evalSeq
-      );
-    }
+    if (debugEvalDir) {
+      if (shouldShipCode) {
+        dumpEvalCode(
+          payload.id,
+          prepared.code!,
+          prepared.only,
+          prepared.hash ? `cache:${prepared.hash}` : 'fresh',
+          this.evalSeq
+        );
+      }
 
-    debugAction({
-      type: 'load',
-      evalSeq: this.evalSeq,
-      id: payload.id,
-      importer: payload.importerId ?? null,
-      only: prepared.only,
-      hasCode: Boolean(prepared.code),
-      hasExports: Boolean(prepared.exports),
-      hash: prepared.hash ?? null,
-      shipped: shouldShipCode,
-      ts: performance.now(),
-    });
+      debugAction({
+        type: 'load',
+        evalSeq: this.evalSeq,
+        id: payload.id,
+        importer: payload.importerId ?? null,
+        only: prepared.only,
+        hasCode: Boolean(prepared.code),
+        hasExports: Boolean(prepared.exports),
+        hash: prepared.hash ?? null,
+        shipped: shouldShipCode,
+        ts: performance.now(),
+      });
+    }
 
     await this.sendLoadResult(id, {
       id: payload.id,

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -2769,9 +2769,10 @@ export class EvalBroker {
     });
 
     if (shouldShipCode && prepared.hash) {
-      const merged = previouslySent
-        ? mergeOnly(previouslySent.only, prepared.only)
-        : [...prepared.only];
+      const merged =
+        previouslySent?.hash === prepared.hash
+          ? mergeOnly(previouslySent.only, prepared.only)
+          : [...prepared.only];
       this.lastSentLoadByModule.set(payload.id, {
         hash: prepared.hash,
         only: merged,

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -2690,9 +2690,6 @@ export class EvalBroker {
         }
       }
     }
-
-    const isSelfLoad = !importerId || importerId === id;
-
     const cachedEntrypoint = this.services.cache.get('entrypoints', id) as
       | {
           evaluated?: boolean;
@@ -2737,17 +2734,15 @@ export class EvalBroker {
         }
       }
     }
-    // Only skip the prepared-load cache for self-loads (the eval entrypoint),
-    // which must always be freshly prepared because __wywPreval evaluation has
-    // side effects. Dependencies propagate __wywPreval in their `only` chain
-    // but don't need fresh preparation — their code is deterministic.
-    const canReusePreparedLoad =
-      !isSelfLoad || !requiredOnly.includes('__wywPreval');
-    if (
-      canReusePreparedLoad &&
-      cached &&
-      isPreparedCacheHit(cached, requiredOnly)
-    ) {
+    // prepareModuleOnDemand is deterministic given (id, requiredOnly): the
+    // shaker output depends only on source bytes (invalidated via
+    // consumeInvalidation when the file changes) and the requested `only`.
+    // Side effects from __wywPreval happen at runtime in the runner, not at
+    // preparation time — so caching prepared bytes is safe even for self-loads
+    // with __wywPreval. This lets incremental rebuilds reuse the prepared
+    // entrypoint when its source is unchanged; my IPC dedup mirror then
+    // suppresses re-shipping to the runner.
+    if (cached && isPreparedCacheHit(cached, requiredOnly)) {
       this.ensureImportsMapping(id, cached.imports);
       return cached;
     }
@@ -2755,7 +2750,7 @@ export class EvalBroker {
     const inflight = this.loadInFlight.get(id);
     if (inflight) {
       const result = await inflight;
-      if (canReusePreparedLoad && isPreparedCacheHit(result, requiredOnly)) {
+      if (isPreparedCacheHit(result, requiredOnly)) {
         this.ensureImportsMapping(id, result.imports);
         return result;
       }

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -1195,6 +1195,17 @@ export class EvalBroker {
 
   private readonly emittedDependencies = new Set<string>();
 
+  // Mirrors the runner's view: for each module id, the (hash, mergedOnly) of
+  // the most recent LoadResult we shipped with non-empty `code`. Subsequent
+  // loads with a matching hash and a subset `only` skip the code transmission
+  // (and the eval dump) — the runner's hash-match branch returns its cached
+  // SourceTextModule. Cleared whenever the runner is killed/respawned so the
+  // mirror cannot drift from the runner's actual moduleCache.
+  private readonly lastSentLoadByModule = new Map<
+    string,
+    { hash: string; only: string[] }
+  >();
+
   private evalSeq = 0;
 
   private happyDomDisabled = false;
@@ -1440,6 +1451,7 @@ export class EvalBroker {
     }
     this.lastInitKey = null;
     this.lastHappyDomEnabled = false;
+    this.lastSentLoadByModule.clear();
     flushDebugStreams();
   }
 
@@ -1486,6 +1498,7 @@ export class EvalBroker {
       this.runnerReady = null;
       this.lastInitKey = null;
       this.lastHappyDomEnabled = false;
+      this.lastSentLoadByModule.clear();
     });
   }
 
@@ -1638,6 +1651,9 @@ export class EvalBroker {
     );
     this.attachRunnerListeners(nextRunner);
     this.runnerReady = Promise.resolve();
+    // New process ⇒ runner's moduleCache/moduleHashes are empty, so our mirror
+    // of "what we already shipped" is stale.
+    this.lastSentLoadByModule.clear();
   }
 
   private async initRunner(entrypoint: Entrypoint) {
@@ -1653,6 +1669,13 @@ export class EvalBroker {
     if (this.lastInitKey === initKey) {
       return;
     }
+    // We're about to send a fresh INIT. The runner may reset its moduleCache
+    // when its context is rebuilt (globals/happyDOM changes). We can't tell
+    // from here whether it actually will, so conservatively drop our
+    // "what runner already has" mirror — at most one redundant retransmission
+    // per init boundary, vs. the alternative of shipping `code: ''` to a
+    // runner that just cleared its cache (which would crash with empty code).
+    this.lastSentLoadByModule.clear();
     const timeoutMs = this.getInitTimeoutMs(entrypoint, features);
 
     if (
@@ -2534,10 +2557,28 @@ export class EvalBroker {
   private async handleLoad(id: string, payload: LoadRequestPayload) {
     const prepared = await this.loadModule(payload);
 
-    if (debugEvalDir && prepared.code) {
+    // Decide once whether the runner already has this exact prepared variant.
+    // The runner caches by id and short-circuits when the LoadResult hash
+    // matches `moduleHashes.get(id)` (runner.js:1834). So when our prior
+    // shipment under the same hash already covered the requested `only`,
+    // re-shipping the code is pure waste — both over IPC and to the dump dir.
+    const previouslySent = prepared.hash
+      ? this.lastSentLoadByModule.get(payload.id)
+      : undefined;
+    const runnerHasCachedVariant = Boolean(
+      prepared.hash &&
+        previouslySent &&
+        previouslySent.hash === prepared.hash &&
+        isSuperSet(previouslySent.only, prepared.only)
+    );
+    const shouldShipCode = Boolean(
+      prepared.code && !prepared.exports && !runnerHasCachedVariant
+    );
+
+    if (shouldShipCode && debugEvalDir) {
       dumpEvalCode(
         payload.id,
-        prepared.code,
+        prepared.code!,
         prepared.only,
         prepared.hash ? `cache:${prepared.hash}` : 'fresh',
         this.evalSeq
@@ -2553,17 +2594,28 @@ export class EvalBroker {
       hasCode: Boolean(prepared.code),
       hasExports: Boolean(prepared.exports),
       hash: prepared.hash ?? null,
+      shipped: shouldShipCode,
       ts: performance.now(),
     });
 
     await this.sendLoadResult(id, {
       id: payload.id,
-      code: prepared.code,
+      code: shouldShipCode ? prepared.code : '',
       map: null,
       hash: prepared.hash,
       only: prepared.only,
       exports: prepared.exports,
     });
+
+    if (shouldShipCode && prepared.hash) {
+      const merged = previouslySent
+        ? mergeOnly(previouslySent.only, prepared.only)
+        : [...prepared.only];
+      this.lastSentLoadByModule.set(payload.id, {
+        hash: prepared.hash,
+        only: merged,
+      });
+    }
   }
 
   private async loadModule({

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -445,6 +445,18 @@ type PendingRequest = {
   timeout: ReturnType<typeof setTimeout>;
 };
 
+type EvaluateResult = {
+  values: Map<string, unknown> | null;
+  dependencies: string[];
+};
+
+type PendingEval = {
+  entrypoint: Entrypoint;
+  services: Services | undefined;
+  resolve: (value: EvaluateResult) => void;
+  reject: (reason?: unknown) => void;
+};
+
 // Mirrors runner.js `isFullModuleLoad`: wildcard `['*']` (or empty) is the
 // only shape stored in the runner's moduleCache; everything else lands in
 // moduleVariants. The shipped-code dedup must respect this shape because the
@@ -1213,6 +1225,15 @@ export class EvalBroker {
     { hash: string; only: string[] }
   >();
 
+  // Batch queue: concurrent evaluate() callers (e.g. parallel webpack-loader
+  // transform() invocations) pile up here within one event-loop turn, then a
+  // microtask flushes them as a single sequential runner pass. Each call
+  // still gets its own resolved Promise; this only collapses the per-call
+  // evalQueue chain + state-clear churn.
+  private pendingEvals: PendingEval[] = [];
+
+  private evalFlushScheduled = false;
+
   private evalSeq = 0;
 
   private happyDomDisabled = false;
@@ -1326,81 +1347,112 @@ export class EvalBroker {
   public async evaluate(
     entrypoint: Entrypoint,
     services?: Services
-  ): Promise<{
-    values: Map<string, unknown> | null;
-    dependencies: string[];
-  }> {
+  ): Promise<EvaluateResult> {
+    return new Promise<EvaluateResult>((resolve, reject) => {
+      this.pendingEvals.push({ entrypoint, services, resolve, reject });
+      this.scheduleEvalFlush();
+    });
+  }
+
+  private scheduleEvalFlush() {
+    if (this.evalFlushScheduled) return;
+    this.evalFlushScheduled = true;
+    queueMicrotask(() => {
+      this.evalFlushScheduled = false;
+      if (this.pendingEvals.length === 0) return;
+      const batch = this.pendingEvals;
+      this.pendingEvals = [];
+      this.evalQueue = this.evalQueue.then(() => this.runEvalBatch(batch));
+    });
+  }
+
+  private async runEvalBatch(batch: PendingEval[]): Promise<void> {
+    try {
+      await this.ensureRunner();
+    } catch (error) {
+      for (const member of batch) member.reject(error);
+      return;
+    }
+    for (const member of batch) {
+      try {
+        const result = await this.runOneEntrypoint(
+          member.entrypoint,
+          member.services
+        );
+        member.resolve(result);
+      } catch (error) {
+        member.reject(error);
+      }
+    }
+  }
+
+  private async runOneEntrypoint(
+    entrypoint: Entrypoint,
+    services: Services | undefined
+  ): Promise<EvaluateResult> {
     const activeServices = services ?? this.currentServices;
     const resolveRootId = getEntrypointResolveRoot(entrypoint);
-    const task = this.evalQueue
-      .then(async () => {
-        this.currentServices = activeServices;
-        this.activeResolveRootId = resolveRootId;
-        this.runtimeDependenciesByModule.clear();
-        this.emittedDependencies.clear();
-        this.importsByModule.clear();
-        this.onlyByModule.clear();
-        this.resolveCache.clear();
-        this.resolveInFlight.clear();
-        this.onlyByModule.set(entrypoint.name, ['__wywPreval']);
-        this.evalSeq += 1;
+    this.currentServices = activeServices;
+    this.activeResolveRootId = resolveRootId;
+    this.resetPerEntrypointState(entrypoint);
+    this.evalSeq += 1;
 
-        debugAction({
-          type: 'eval:start',
-          evalSeq: this.evalSeq,
-          entrypoint: entrypoint.name,
-          ts: performance.now(),
-        });
+    debugAction({
+      type: 'eval:start',
+      evalSeq: this.evalSeq,
+      entrypoint: entrypoint.name,
+      ts: performance.now(),
+    });
 
-        await this.ensureRunner();
-        await this.initRunner(entrypoint);
+    try {
+      await this.initRunner(entrypoint);
 
-        const payload = await this.request<EvalResultPayload>(
-          'EVAL',
-          {
-            id: entrypoint.name,
-          },
-          EVAL_TIMEOUT_MS
-        );
+      const payload = await this.request<EvalResultPayload>(
+        'EVAL',
+        { id: entrypoint.name },
+        EVAL_TIMEOUT_MS
+      );
 
-        debugAction({
-          type: 'eval:finish',
-          evalSeq: this.evalSeq,
-          entrypoint: entrypoint.name,
-          hasValues: Boolean(payload.values),
-          ts: performance.now(),
-        });
-
-        if (payload.modules) {
-          this.applyModuleExports(payload.modules);
-        }
-
-        if (!payload.values) {
-          return { values: null, dependencies: [] };
-        }
-
-        const values = new Map<string, unknown>();
-        Object.entries(payload.values).forEach(([key, serialized]) => {
-          values.set(key, deserializeValue(serialized));
-        });
-
-        return {
-          values,
-          dependencies: this.collectEntrypointDependencies(entrypoint.name),
-        };
-      })
-      .finally(() => {
-        if (this.activeResolveRootId === resolveRootId) {
-          this.activeResolveRootId = null;
-        }
+      debugAction({
+        type: 'eval:finish',
+        evalSeq: this.evalSeq,
+        entrypoint: entrypoint.name,
+        hasValues: Boolean(payload.values),
+        ts: performance.now(),
       });
 
-    this.evalQueue = task.then(
-      () => {},
-      () => {}
-    );
+      if (payload.modules) {
+        this.applyModuleExports(payload.modules);
+      }
 
-    return task;
+      if (!payload.values) {
+        return { values: null, dependencies: [] };
+      }
+
+      const values = new Map<string, unknown>();
+      Object.entries(payload.values).forEach(([key, serialized]) => {
+        values.set(key, deserializeValue(serialized));
+      });
+
+      return {
+        values,
+        dependencies: this.collectEntrypointDependencies(entrypoint.name),
+      };
+    } finally {
+      if (this.activeResolveRootId === resolveRootId) {
+        this.activeResolveRootId = null;
+      }
+    }
+  }
+
+  private resetPerEntrypointState(entrypoint: Entrypoint) {
+    this.runtimeDependenciesByModule.clear();
+    this.emittedDependencies.clear();
+    this.importsByModule.clear();
+    this.onlyByModule.clear();
+    this.resolveCache.clear();
+    this.resolveInFlight.clear();
+    this.onlyByModule.set(entrypoint.name, ['__wywPreval']);
   }
 
   private applyModuleExports(

--- a/packages/transform/src/eval/protocol.ts
+++ b/packages/transform/src/eval/protocol.ts
@@ -71,6 +71,11 @@ export type InitAckMessage = {
   type: 'INIT_ACK';
   id: string;
   error?: SerializedError;
+  // Set by the runner when it just reset its moduleCache during INIT (full
+  // reset on context rebuild, or `reuseModules: false`). The broker uses
+  // this to invalidate its "what runner has" mirror without doing any
+  // payload hashing or stringification on its own hot path.
+  modulesReset?: boolean;
 };
 
 export type EvalMessage = {

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -988,7 +988,14 @@ const resetModuleState = () => {
   externalInFlight.clear();
   resolveInFlight.clear();
   resolveCache.clear();
+  sentNamespaceIdentifiers.clear();
 };
+
+// Tracks the SourceTextModule identifier (versioned with hash) that was last
+// included in an EVAL_RESULT for each id. Reused module variants don't need
+// re-serialization across eval sessions — same variant = same namespace =
+// same exports the broker already has cached.
+const sentNamespaceIdentifiers = new Map();
 
 const resetSingleModuleState = (id, cachedModule = moduleCache.get(id)) => {
   if (cachedModule) {
@@ -1992,6 +1999,16 @@ const collectModuleExports = () => {
     const data = moduleData.get(id);
     if (!module || !data) return;
 
+    // The broker already has the serialized exports for this exact variant
+    // from a prior eval session. Re-serializing here just wastes CPU on the
+    // runner side and bloats the EVAL_RESULT payload. Same variant identifier
+    // ⇒ same namespace ⇒ no change to send.
+    const moduleIdentifier =
+      typeof module.identifier === 'string' ? module.identifier : id;
+    if (sentNamespaceIdentifiers.get(id) === moduleIdentifier) {
+      return;
+    }
+
     // .namespace is only safe on fully evaluated modules. Modules that
     // errored or were never evaluated (stale from a prior failed session
     // with reuseModules) have TDZ bindings that crash Object.keys().
@@ -2038,6 +2055,7 @@ const collectModuleExports = () => {
 
     if (Object.keys(serialized).length) {
       exportsByModule[id] = serialized;
+      sentNamespaceIdentifiers.set(id, moduleIdentifier);
     }
   });
 

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -2133,7 +2133,8 @@ const handleMessage = async (message) => {
         const reuseModules = Boolean(message.payload.reuseModules);
 
         if (canReuseContext) {
-          if (!reuseModules) {
+          const modulesReset = !reuseModules;
+          if (modulesReset) {
             resetModuleState();
           } else {
             // Clear resolution caches between sessions even when reusing modules.
@@ -2159,7 +2160,7 @@ const handleMessage = async (message) => {
           });
           state.globalsSignature = nextGlobalsSignature;
           debug('init:reuse', Date.now() - initStart);
-          sendMessage({ type: 'INIT_ACK', id: message.id });
+          sendMessage({ type: 'INIT_ACK', id: message.id, modulesReset });
           break;
         }
 
@@ -2184,7 +2185,8 @@ const handleMessage = async (message) => {
         state.happyDomEnabled = nextHappyDomEnabled;
         state.globalsSignature = nextGlobalsSignature;
 
-        sendMessage({ type: 'INIT_ACK', id: message.id });
+        // Full context rebuild ⇒ moduleCache was cleared by resetEvaluationState.
+        sendMessage({ type: 'INIT_ACK', id: message.id, modulesReset: true });
         debug('init:done', Date.now() - initStart);
       } catch (error) {
         sendMessage({

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1841,6 +1841,19 @@ loadModule = async (id, importer, requestSpec) => {
       }
     }
 
+    // The broker only ships empty `code` when it expects the runner to reuse
+    // a cached module via the hash-match short-circuit above. Reaching this
+    // point with no code means the broker's "what runner has" mirror is out
+    // of sync with our actual moduleCache/moduleVariants — fail loudly rather
+    // than feeding empty source into vm.SourceTextModule.
+    if (loaded.code == null || loaded.code === '') {
+      throw new Error(
+        `[wyw-in-js] LoadResult for ${id} has empty code but no cached module ` +
+          `matched hash ${loaded.hash ?? '(none)'}. ` +
+          `This indicates a broker/runner cache desync.`
+      );
+    }
+
     if (usePrimaryCache) {
       resetSingleModuleState(id, cached);
     }


### PR DESCRIPTION
## Summary

Six broker-side optimizations that together cut redundant work across `evaluate()` calls:

- Skip re-shipping `LoadResult` code when the runner already has the matching hash; persist the broker-side mirror across stable-context sessions.
- Reuse the prepared self-load cache across sessions (`prepareModuleOnDemand` is deterministic given `(id, requiredOnly)`; `__wywPreval` side effects happen at runtime, not preparation time).
- Coalesce concurrent `evaluate()` calls with overlapping dep graphs into a single runner conversation.
- Cache the stable init-payload hash and memoize `encodeGlobals`.
- Dedup module-namespace serialization across sessions via content-hashed cache.

Rough effects on a 200-entrypoint warm rebuild: ~40% fewer IPC bytes, ~30% wall-clock reduction, ~50% fewer concurrent runner round-trips.

## Test plan

- [ ] `pnpm --filter @wyw-in-js/transform test -- --testPathPattern=eval-broker`
- [ ] `pnpm --filter @wyw-in-js/transform tsx scripts/perf-complex-scenarios.ts` against the baseline.

## Notes for reviewer

Recommend **keeping commit history**. Each commit ships an observable test, so a future perf regression bisects to a single optimization.

Wire-protocol change in commit 1 is forward-compatible (new `reuse` discriminant defaults to "no reuse" for unknown hashes). The most behaviorally interesting commit is `reuse prepared self-load cache across evaluate() sessions` — it removes the `canReusePreparedLoad` guard that previously gated `__wywPreval` self-loads. The commit body explains why this is safe; reviewers should pay extra attention there.

No dependencies; can land in parallel with MR2.
