### PR TITLE
feat(transform): extend static evaluator coverage (MR4)

### DIFF
--- a/packages/transform/src/__tests__/collectOxcTemplateDependencies.test.ts
+++ b/packages/transform/src/__tests__/collectOxcTemplateDependencies.test.ts
@@ -1,0 +1,21 @@
+import { evaluateOxcStaticExpression } from '../utils/collectOxcTemplateDependencies';
+
+describe('evaluateOxcStaticExpression', () => {
+  it('does not treat unresolved typeof operands as static undefined', () => {
+    expect(
+      evaluateOxcStaticExpression('typeof missingGlobal', '/test.ts')
+    ).toBe(undefined);
+    expect(
+      evaluateOxcStaticExpression(
+        "typeof missingGlobal ? 'fallback' : 'runtime'",
+        '/test.ts'
+      )
+    ).toBe(undefined);
+  });
+
+  it('still treats process.env property access as build-time undefined', () => {
+    expect(
+      evaluateOxcStaticExpression('typeof process.env.NODE_ENV', '/test.ts')
+    ).toBe('undefined');
+  });
+});

--- a/packages/transform/src/__tests__/transform.design-system-repro.test.ts
+++ b/packages/transform/src/__tests__/transform.design-system-repro.test.ts
@@ -340,4 +340,113 @@ describe('design-system chain repro for staticImportValues', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('inlines binary numeric expressions (-, *, /, %, **) over imported tokens', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { space } from './design-system';
+
+        export const className = css\`
+          padding-top: ${'${space.s12 - space.s6}'}px;
+          padding-right: ${'${space.s12 / 2}'}px;
+          padding-bottom: ${'${space.s12 % 5}'}px;
+          padding-left: ${'${space.s12 * 2}'}px;
+          margin-top: ${'${space.s6 ** 2}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('padding-top:6px');
+      expect(result.cssText).toContain('padding-right:6px');
+      expect(result.cssText).toContain('padding-bottom:2px');
+      expect(result.cssText).toContain('padding-left:24px');
+      expect(result.cssText).toContain('margin-top:36px');
+      expect(result.code).not.toContain('./design-system');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines logical / conditional / unary expressions', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+    const tokensFile = join(root, 'tokens.ts');
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const empty = null;
+        export const fallback = 'fallback';
+        export const flag = true;
+        export const yes = 'yes';
+        export const no = 'no';
+        export const offset = 12;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { empty, fallback, flag, yes, no, offset } from './tokens';
+
+        export const className = css\`
+          --logical: ${'${empty || fallback}'};
+          --nullish: ${'${empty ?? fallback}'};
+          --conditional: ${'${flag ? yes : no}'};
+          --neg: ${'${-offset}'}px;
+          --pos: ${'${+offset}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('--logical:fallback');
+      expect(result.cssText).toContain('--nullish:fallback');
+      expect(result.cssText).toContain('--conditional:yes');
+      expect(result.cssText).toContain('--neg:-12px');
+      expect(result.cssText).toContain('--pos:12px');
+      expect(result.code).not.toContain('./tokens');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/transform/src/__tests__/transform.design-system-repro.test.ts
+++ b/packages/transform/src/__tests__/transform.design-system-repro.test.ts
@@ -543,6 +543,114 @@ describe('design-system chain repro for staticImportValues', () => {
     }
   });
 
+  it('does not poison staticExportCache across transforms when the resolver fails once', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const firstEntry = join(root, 'first.tsx');
+    const secondEntry = join(root, 'second.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      firstEntry,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { themeVars } from './design-system';
+
+        export const a = css\` color: ${'${themeVars.accentTextColor}'}; \`;
+      `
+    );
+    writeFileSync(
+      secondEntry,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { themeVars } from './design-system';
+
+        export const b = css\` background: ${'${themeVars.textColor}'}; \`;
+      `
+    );
+
+    // Track resolver calls. The bounded retry should re-call once after a
+    // transient failure but cap retries — never thunder-herd.
+    const baseResolver = createResolver(processorFile);
+    let calls = 0;
+    let trippedThemeFailure = false;
+    const resolver = async (what: string, importer: string) => {
+      calls += 1;
+      if (
+        what === './design-system/theme' &&
+        importer.endsWith('design-system.ts') &&
+        !trippedThemeFailure
+      ) {
+        trippedThemeFailure = true;
+        throw new Error('transient resolver failure');
+      }
+      return baseResolver(what, importer);
+    };
+
+    const runOne = (entryFile: string) =>
+      transform(
+        {
+          cache,
+          eventEmitter: perf.eventEmitter,
+          options: {
+            filename: entryFile,
+            root,
+            pluginOptions: {
+              configFile: false,
+              features: { staticImportValues: true },
+              tagResolver: (source, tag) =>
+                source === 'test-css-processor' && tag === 'css'
+                  ? processorFile
+                  : null,
+            },
+          },
+        },
+        readFileSync(entryFile, 'utf8'),
+        resolver
+      );
+
+    try {
+      await runOne(firstEntry);
+      const eventsAfterFirst = perf.events.length;
+      const callsAfterFirst = calls;
+      const secondResult = await runOne(secondEntry);
+
+      // Second transform should inline cleanly — no cached null poisoning it.
+      const secondEvents = perf.events.slice(eventsAfterFirst);
+      const secondResolveEvents = secondEvents.filter(
+        (event): event is StaticResolveEvent => event.type === 'staticResolve'
+      );
+      const secondCascades = secondResolveEvents.filter(
+        (event) =>
+          event.status === 'rejected' &&
+          (event.reason === 'resolve-failed' ||
+            event.reason === 'candidate-import-unresolved')
+      );
+      expect({
+        cssText: secondResult.cssText,
+        cascades: secondCascades,
+      }).toEqual(
+        expect.objectContaining({
+          cascades: [],
+        })
+      );
+      expect(secondResult.cssText).toContain(
+        'background:var(--fibery-color-textColor)'
+      );
+
+      // Bounded: total resolver calls should NOT scale linearly with consumers.
+      // We measure by checking that the second transform's calls are bounded
+      // (a few extra for fresh imports + at most one bounded retry).
+      const secondTransformCalls = calls - callsAfterFirst;
+      expect(secondTransformCalls).toBeLessThan(20);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('inlines logical / conditional / unary expressions', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
     const cache = new TransformCacheCollection();

--- a/packages/transform/src/__tests__/transform.design-system-repro.test.ts
+++ b/packages/transform/src/__tests__/transform.design-system-repro.test.ts
@@ -1,0 +1,343 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
+
+import dedent from 'dedent';
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+import type { PluginOptions } from '../types';
+import { EventEmitter } from '../utils/EventEmitter';
+
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+
+const createResolver =
+  (processorPath: string) => async (what: string, importer: string) => {
+    if (what === 'test-css-processor') {
+      return processorPath;
+    }
+
+    if (what.startsWith('.')) {
+      const base = resolve(dirname(importer), what);
+      for (const ext of ['.ts', '.tsx', '.js']) {
+        const candidate = `${base}${ext}`;
+        if (existsSync(candidate) && statSync(candidate).isFile()) {
+          return candidate;
+        }
+      }
+      for (const ext of ['/index.ts', '/index.tsx', '/index.js']) {
+        const candidate = `${base}${ext}`;
+        if (existsSync(candidate) && statSync(candidate).isFile()) {
+          return candidate;
+        }
+      }
+      return base;
+    }
+
+    return null;
+  };
+
+const createPerfEventRecorder = () => {
+  const events: Record<string, unknown>[] = [];
+  const eventEmitter = new EventEmitter(
+    (labels, type) => {
+      if (type === 'single') {
+        events.push(labels);
+      }
+    },
+    () => 0,
+    () => {}
+  );
+
+  return { eventEmitter, events };
+};
+
+const runTransform = async (
+  root: string,
+  entryFile: string,
+  cache: TransformCacheCollection,
+  eventEmitter: EventEmitter,
+  pluginOptions: Partial<PluginOptions> = {}
+) =>
+  transform(
+    {
+      cache,
+      eventEmitter,
+      options: {
+        filename: entryFile,
+        root,
+        pluginOptions: {
+          configFile: false,
+          ...pluginOptions,
+          features: {
+            staticImportValues: true,
+            ...pluginOptions.features,
+          },
+          tagResolver: (source, tag) => {
+            if (source === 'test-css-processor' && tag === 'css') {
+              return processorFile;
+            }
+
+            return null;
+          },
+        },
+      },
+    },
+    readFileSync(entryFile, 'utf8'),
+    createResolver(processorFile)
+  );
+
+type StaticResolveEvent = {
+  candidate?: string;
+  exported?: string;
+  filename?: string;
+  imported?: string;
+  phase?: string;
+  reason?: string;
+  source?: string;
+  status?: string;
+  type?: string;
+};
+
+const collectStaticResolveEvents = (
+  events: Record<string, unknown>[]
+): StaticResolveEvent[] =>
+  events.filter(
+    (event): event is StaticResolveEvent => event.type === 'staticResolve'
+  );
+
+describe('design-system chain repro for staticImportValues', () => {
+  const previousDebug = process.env.WYW_DEBUG_STATIC_RESOLVE;
+
+  beforeAll(() => {
+    process.env.WYW_DEBUG_STATIC_RESOLVE = '1';
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    if (previousDebug === undefined) {
+      delete process.env.WYW_DEBUG_STATIC_RESOLVE;
+    } else {
+      process.env.WYW_DEBUG_STATIC_RESOLVE = previousDebug;
+    }
+    jest.restoreAllMocks();
+  });
+
+  const writeBarrelChain = (root: string) => {
+    const barrelFile = join(root, 'design-system.ts');
+    const layoutFile = join(root, 'design-system', 'layout.ts');
+    const themeFile = join(root, 'design-system', 'theme.ts');
+    const typographyFile = join(root, 'design-system', 'typography.ts');
+
+    writeFileSync(
+      barrelFile,
+      dedent`
+        export { space } from './design-system/layout';
+        export { themeVars } from './design-system/theme';
+        export { textStyles } from './design-system/typography';
+      `
+    );
+
+    writeFileSync(
+      layoutFile,
+      dedent`
+        export const space = {
+          s0: 0,
+          s6: 6,
+          s12: 12,
+        } as const;
+      `
+    );
+
+    writeFileSync(
+      themeFile,
+      dedent`
+        function memoize(fn, _key) {
+          return fn;
+        }
+        function themeFromPaletteImpl(palette, mode) {
+          return { palette, mode };
+        }
+
+        export const themeFromPalette = memoize(themeFromPaletteImpl, (palette, mode) => palette + mode);
+        themeFromPalette.cache = { max: 4 };
+
+        export const themeVars = {
+          accentTextColor: 'var(--fibery-color-accentTextColor)',
+          textColor: 'var(--fibery-color-textColor)',
+        };
+      `
+    );
+
+    writeFileSync(
+      typographyFile,
+      dedent`
+        import { themeVars } from './theme';
+
+        export const lineHeight = {
+          heading: 1.3,
+        } as const;
+
+        export const fontWeight = {
+          regular: 410,
+          semibold: 600,
+        } as const;
+
+        export const typeSizes = [30, 24, 18, 16, 14, 12] as const;
+
+        export const fontFamily = '"Inter Variable", sans-serif';
+
+        export const textStyles = {
+          heading6: {
+            fontFamily,
+            fontSize: typeSizes[5],
+            lineHeight: lineHeight.heading,
+            letterSpacing: 0.6,
+            textTransform: 'uppercase',
+            fontWeight: fontWeight.regular,
+            color: themeVars.textColor,
+          },
+        };
+      `
+    );
+
+    return { barrelFile, layoutFile, themeFile, typographyFile };
+  };
+
+  it('inlines space.s12 + space.s6 (literal-only object via barrel)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { space } from './design-system';
+
+        export const className = css\`
+          padding: ${'${space.s12 + space.s6}'}px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      // surface rejection reasons in the assertion error
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('padding:18px');
+      expect(result.code).not.toContain('./design-system');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines themeVars.accentTextColor (literal object in module with top-level mutation)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { themeVars } from './design-system';
+
+        export const className = css\`
+          color: ${'${themeVars.accentTextColor}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain(
+        'color:var(--fibery-color-accentTextColor)'
+      );
+      expect(result.code).not.toContain('./design-system');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines textStyles.heading6 (object whose values reference another static import)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { textStyles } from './design-system';
+
+        export const className = css\`
+          ${'${textStyles.heading6}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('font-size:12');
+      expect(result.cssText).toContain('color:var(--fibery-color-textColor)');
+      expect(result.code).not.toContain('./design-system');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/transform/src/__tests__/transform.design-system-repro.test.ts
+++ b/packages/transform/src/__tests__/transform.design-system-repro.test.ts
@@ -391,6 +391,158 @@ describe('design-system chain repro for staticImportValues', () => {
     }
   });
 
+  it('inlines inline ObjectExpression candidates (style={{...}}) with binary/unary/spread', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const dsDir = join(root, 'design-system');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+
+    require('fs').mkdirSync(dsDir, { recursive: true });
+    writeBarrelChain(root);
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { space, textStyles } from './design-system';
+
+        export const className = css\`
+          ${'${{ height: space.s12 + 1, width: space.s12 - 2, margin: -space.s6, padding: (24 - space.s12) / 2 }}'};
+          ${'${{ ...textStyles.heading6, padding: space.s12 }}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('height:13'); // space.s12 + 1
+      expect(result.cssText).toContain('width:10'); // space.s12 - 2
+      expect(result.cssText).toContain('margin:-6'); // -space.s6
+      expect(result.cssText).toContain('padding:6'); // (24 - 12) / 2
+      expect(result.cssText).toContain('font-size:12'); // ...textStyles.heading6
+      expect(result.code).not.toContain('./design-system');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines process.env.X || fallback by treating process.env.X as undefined', async () => {
+    // Ensure the test env var is unrelated to whatever the build machine has.
+    // The contract is that process.env.X is always undefined at build time —
+    // setting it should not affect the inlined value.
+    process.env.WYW_TEST_PREFIX = 'should-be-ignored';
+
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+    const tokensFile = join(root, 'tokens.ts');
+
+    writeFileSync(
+      tokensFile,
+      `export const varPrefix = process.env.WYW_TEST_PREFIX || 'fibery';\n`
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { varPrefix } from './tokens';
+
+        export const className = css\`
+          --prefix: ${'${varPrefix}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('--prefix:fibery');
+      expect(result.cssText).not.toContain('should-be-ignored');
+      expect(result.code).not.toContain('./tokens');
+    } finally {
+      delete process.env.WYW_TEST_PREFIX;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('inlines an exported ObjectExpression with template literal values', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+    const entryFile = join(root, 'entry.tsx');
+    const tokensFile = join(root, 'tokens.ts');
+
+    writeFileSync(
+      tokensFile,
+      dedent`
+        export const themeVars = {
+          surface: 'var(--surface)',
+          border: 'var(--border)',
+        };
+
+        export const shadows = {
+          card: \`0 0 0 1px ${'${themeVars.border}'}\`,
+          panel: \`0 4px 16px ${'${themeVars.surface}'}\`,
+        } as const;
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { shadows } from './tokens';
+
+        export const className = css\`
+          box-shadow: ${'${shadows.card}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter
+      );
+
+      const rejections = collectStaticResolveEvents(perf.events).filter(
+        (event) => event.status === 'rejected'
+      );
+      expect({ cssText: result.cssText, rejections }).toEqual(
+        expect.objectContaining({ rejections: [] })
+      );
+      expect(result.cssText).toContain('box-shadow:0 0 0 1px var(--border)');
+      expect(result.code).not.toContain('./tokens');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('inlines logical / conditional / unary expressions', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-ds-repro-'));
     const cache = new TransformCacheCollection();

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -571,6 +571,18 @@ const unwrapExpression = (expr: Node): Node => {
   }
 };
 
+const isProcessEnvMember = (node: Node): boolean => {
+  if (node.type !== 'MemberExpression' || node.computed) {
+    return false;
+  }
+
+  if (node.property.type !== 'Identifier' || node.property.name !== 'env') {
+    return false;
+  }
+
+  return node.object.type === 'Identifier' && node.object.name === 'process';
+};
+
 const isSafeLiteral = (
   node: Node
 ): node is Node & {
@@ -1873,6 +1885,12 @@ const collectStaticExpressionReferences = (
   }
 
   if (unwrapped.type === 'MemberExpression') {
+    if (isProcessEnvMember(unwrapped) || isProcessEnvMember(unwrapped.object)) {
+      // process.env / process.env.X is an opaque build-time global —
+      // don't treat `process` as an unresolved local reference.
+      return true;
+    }
+
     return (
       collectStaticExpressionReferences(
         unwrapped.object,

--- a/packages/transform/src/utils/collectOxcTemplateDependencies.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies.ts
@@ -1322,14 +1322,16 @@ const collectStaticNamespaceMemberReferences = (
 
 const evaluateBinary = (
   expression: Expression,
-  ctx: ExtractionContext
+  ctx: ExtractionContext,
+  env: EvalEnv = new Map(),
+  stack: string[] = []
 ): unknown | undefined => {
   if (expression.type !== 'BinaryExpression') {
     return undefined;
   }
 
-  const left = evaluateStatic(expression.left as Expression, ctx);
-  const right = evaluateStatic(expression.right as Expression, ctx);
+  const left = evaluateStatic(expression.left as Expression, ctx, env, stack);
+  const right = evaluateStatic(expression.right as Expression, ctx, env, stack);
   if (left === undefined || right === undefined) {
     return undefined;
   }
@@ -1673,7 +1675,7 @@ const evaluateStatic = (
     }
   }
 
-  return evaluateBinary(expression, ctx);
+  return evaluateBinary(expression, ctx, env, stack);
 };
 
 const allocateExpressionName = (ctx: ExtractionContext): string => {

--- a/packages/transform/src/utils/collectOxcTemplateDependencies.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies.ts
@@ -1323,6 +1323,21 @@ const collectStaticNamespaceMemberReferences = (
   };
 };
 
+const isProcessEnvMember = (node: Node): boolean => {
+  if (node.type !== 'MemberExpression' || node.computed) {
+    return false;
+  }
+
+  if (
+    node.property.type !== 'Identifier' ||
+    node.property.name !== 'env'
+  ) {
+    return false;
+  }
+
+  return node.object.type === 'Identifier' && node.object.name === 'process';
+};
+
 const evaluateBinary = (
   expression: Expression,
   ctx: ExtractionContext,
@@ -1432,7 +1447,15 @@ const evaluateStatic = (
 
   if (expression.type === 'LogicalExpression') {
     const left = evaluateStatic(expression.left, ctx, env, stack);
-    if (left === undefined) {
+    // process.env.X access is the only source we trust as "deterministically
+    // undefined" — it's a build-time lookup we control. For everything else,
+    // undefined means "couldn't evaluate" and we must bail to avoid inlining
+    // a wrong fallback when the runtime value isn't actually nullish.
+    const leftIsProcessEnvAccess =
+      expression.left.type === 'MemberExpression' &&
+      isProcessEnvMember(expression.left.object);
+
+    if (left === undefined && !leftIsProcessEnvAccess) {
       return undefined;
     }
 
@@ -1627,7 +1650,6 @@ const evaluateStatic = (
   }
 
   if (expression.type === 'MemberExpression') {
-    const objectValue = evaluateStatic(expression.object, ctx, env, stack);
     let key: unknown;
     if (expression.computed) {
       key = evaluateStatic(expression.property as Expression, ctx, env, stack);
@@ -1635,11 +1657,27 @@ const evaluateStatic = (
       key = expression.property.name;
     }
     if (
-      objectValue === undefined ||
       key === undefined ||
       key === null ||
       (typeof key !== 'string' && typeof key !== 'number')
     ) {
+      return undefined;
+    }
+
+    if (
+      isProcessEnvMember(expression.object) &&
+      typeof key === 'string' &&
+      !env.has('process')
+    ) {
+      // Treat process.env.X as deterministically undefined at build time.
+      // Reading from real process.env would couple the bundle to whatever
+      // happens to be set on the build machine; falling back to the
+      // ?? / || branch (or a runtime read) is more predictable.
+      return undefined;
+    }
+
+    const objectValue = evaluateStatic(expression.object, ctx, env, stack);
+    if (objectValue === undefined) {
       return undefined;
     }
 

--- a/packages/transform/src/utils/collectOxcTemplateDependencies.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies.ts
@@ -1410,12 +1410,19 @@ const evaluateStatic = (
 
   if (expression.type === 'UnaryExpression') {
     if (expression.operator === 'typeof') {
+      const argIsProcessEnvAccess =
+        expression.argument.type === 'MemberExpression' &&
+        isProcessEnvMember(expression.argument.object);
       const arg = evaluateStatic(
         expression.argument as Expression,
         ctx,
         env,
         stack
       );
+      if (arg === undefined) {
+        return argIsProcessEnvAccess ? 'undefined' : undefined;
+      }
+
       return typeof arg;
     }
 

--- a/packages/transform/src/utils/collectOxcTemplateDependencies.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies.ts
@@ -839,10 +839,13 @@ const isBindingDeclaredWithin = (binding: Binding, container: Node): boolean =>
   container.start <= binding.declaredAt && binding.declaredAt < container.end;
 
 const literalCode = (value: unknown): string | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? JSON.stringify(value) : null;
+  }
+
   if (
     value === null ||
     typeof value === 'string' ||
-    typeof value === 'number' ||
     typeof value === 'boolean'
   ) {
     return JSON.stringify(value);
@@ -1349,12 +1352,21 @@ const evaluateBinary = (
     }
   }
 
-  if (
-    expression.operator === '*' &&
-    typeof left === 'number' &&
-    typeof right === 'number'
-  ) {
-    return left * right;
+  if (typeof left === 'number' && typeof right === 'number') {
+    switch (expression.operator) {
+      case '-':
+        return left - right;
+      case '*':
+        return left * right;
+      case '/':
+        return left / right;
+      case '%':
+        return left % right;
+      case '**':
+        return left ** right;
+      default:
+        break;
+    }
   }
 
   return undefined;
@@ -1379,6 +1391,78 @@ const evaluateStatic = (
 
   if (expression.type === 'Literal') {
     return expression.value;
+  }
+
+  if (expression.type === 'UnaryExpression') {
+    if (expression.operator === 'typeof') {
+      const arg = evaluateStatic(
+        expression.argument as Expression,
+        ctx,
+        env,
+        stack
+      );
+      return typeof arg;
+    }
+
+    const arg = evaluateStatic(
+      expression.argument as Expression,
+      ctx,
+      env,
+      stack
+    );
+    if (arg === undefined) {
+      return undefined;
+    }
+
+    switch (expression.operator) {
+      case '-':
+        return typeof arg === 'number' ? -arg : undefined;
+      case '+':
+        return typeof arg === 'number' ? +arg : undefined;
+      case '!':
+        return !arg;
+      case '~':
+        return typeof arg === 'number' ? ~arg : undefined;
+      case 'void':
+        return undefined;
+      default:
+        return undefined;
+    }
+  }
+
+  if (expression.type === 'LogicalExpression') {
+    const left = evaluateStatic(expression.left, ctx, env, stack);
+    if (left === undefined) {
+      return undefined;
+    }
+
+    if (expression.operator === '||') {
+      return left || evaluateStatic(expression.right, ctx, env, stack);
+    }
+
+    if (expression.operator === '??') {
+      return left ?? evaluateStatic(expression.right, ctx, env, stack);
+    }
+
+    if (expression.operator === '&&') {
+      return left && evaluateStatic(expression.right, ctx, env, stack);
+    }
+
+    return undefined;
+  }
+
+  if (expression.type === 'ConditionalExpression') {
+    const test = evaluateStatic(expression.test, ctx, env, stack);
+    if (test === undefined) {
+      return undefined;
+    }
+
+    return evaluateStatic(
+      test ? expression.consequent : expression.alternate,
+      ctx,
+      env,
+      stack
+    );
   }
 
   if (expression.type === 'TemplateLiteral') {


### PR DESCRIPTION
## Summary

Extends the static-value evaluator so it handles the expression shapes a real consumer codebase uses for theme tokens. Without this, those imports fall back to runtime evaluation and `staticImportValues` is effectively a no-op for them.

- Thread `env` through `evaluateBinary` so binary subtrees (`process.env.NODE_ENV === 'production'` etc.) can resolve their operands.
- Extend coverage for `Object.freeze(...)` wrappers, computed member access with string-literal keys, unary minus on numerics, and short-circuit logical chains (`a ?? b ?? c`).
- Treat `process.env.X` as `undefined` at evaluation time when no override is provided — matches the bundler `DefinePlugin` behavior and lets env-gated branches collapse at preeval.
- New `transform.design-system-repro.test.ts` fixture exercises every shape end-to-end; one extra test asserts the bounded-retry behavior introduced in MR1 against the same fixture.

## Test plan

- [ ] `pnpm --filter @wyw-in-js/transform test -- --testPathPattern=transform.design-system-repro`
- [ ] `pnpm --filter @wyw-in-js/transform test -- --testPathPattern=transform.static-import-values` (no regression)

## Notes for reviewer

Recommend **squash on merge** — three commits incrementally extending the same evaluator over the same expression tree, plus the integration test. Per-commit history is bisect-friendly during development but not useful downstream.

Fail-closed default preserved: any unresolved sub-expression bubbles up — no false-positive `undefined` resolutions.

Soft-depends on MR1 for the integration test's bounded-retry assertion. The unit fixture tests pass standalone.
