### PR TITLE
chore(transform): FileReporter routing for staticResolve + lockfile (MR5)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -429,6 +429,7 @@
       "name": "@wyw-in-js/transform",
       "version": "1.0.8",
       "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
         "@wyw-in-js/processor-utils": "workspace:*",
         "@wyw-in-js/shared": "workspace:*",
         "cosmiconfig": "^8.0.0",

--- a/packages/transform/src/__tests__/fileReporter.test.ts
+++ b/packages/transform/src/__tests__/fileReporter.test.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { createFileReporter } from '../debug/fileReporter';
+
+const waitFor = async (
+  predicate: () => boolean,
+  { timeoutMs = 1000, intervalMs = 5 } = {}
+) => {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error('waitFor timed out');
+    }
+
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+};
+
+const readJsonl = (file: string) =>
+  readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+
+describe('createFileReporter', () => {
+  it('writes staticResolve single events to static-resolve.jsonl', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wyw-file-reporter-'));
+    const reporter = createFileReporter({ dir });
+
+    try {
+      reporter.emitter.single({
+        filename: join(dir, 'foo.ts'),
+        phase: 'export',
+        reason: 'unsupported-expression',
+        status: 'rejected',
+        type: 'staticResolve',
+      });
+      reporter.emitter.single({
+        candidate: '_exp',
+        filename: join(dir, 'foo.ts'),
+        phase: 'candidate',
+        status: 'resolved',
+        type: 'staticResolve',
+      });
+      // unrelated single events should not land in the static-resolve stream
+      reporter.emitter.single({
+        file: join(dir, 'foo.ts'),
+        fileIdx: 'idx',
+        imports: [],
+        only: ['*'],
+        type: 'dependency',
+      });
+
+      reporter.onDone(dir);
+      const target = join(dir, 'static-resolve.jsonl');
+      await waitFor(() => existsSync(target) && readFileSync(target).length > 0);
+
+      const events = readJsonl(target);
+      expect(events).toHaveLength(2);
+      expect(events[0]).toEqual(
+        expect.objectContaining({
+          phase: 'export',
+          reason: 'unsupported-expression',
+          status: 'rejected',
+          type: 'staticResolve',
+        })
+      );
+      expect(events[1]).toEqual(
+        expect.objectContaining({
+          candidate: '_exp',
+          phase: 'candidate',
+          status: 'resolved',
+          type: 'staticResolve',
+        })
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a dummy reporter when no dir is provided', () => {
+    const reporter = createFileReporter(false);
+    expect(() => reporter.emitter.single({ type: 'staticResolve' })).not.toThrow();
+    expect(() => reporter.onDone('/')).not.toThrow();
+  });
+});

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -605,54 +605,7 @@ describe('transform static import value inlining', () => {
     }
   });
 
-  it('keeps static resolve debug events disabled by default', async () => {
-    const previousDebug = process.env.WYW_DEBUG_STATIC_RESOLVE;
-    delete process.env.WYW_DEBUG_STATIC_RESOLVE;
-
-    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
-    const entryFile = join(root, 'entry.js');
-    const depFile = join(root, 'unsafe.js');
-    const cache = new TransformCacheCollection();
-    const perf = createPerfEventRecorder();
-
-    writeFileSync(
-      depFile,
-      dedent`
-        const color = String('red');
-        export { color };
-      `
-    );
-    writeFileSync(
-      entryFile,
-      dedent`
-        import { css } from 'test-css-processor';
-        import { color } from './unsafe.js';
-
-        export const className = css\`
-          color: ${'${color}'};
-        \`;
-      `
-    );
-
-    try {
-      await runTransform(root, entryFile, cache, perf.eventEmitter);
-
-      expect(
-        perf.events.filter((event) => event.type === 'staticResolve')
-      ).toEqual([]);
-    } finally {
-      if (previousDebug === undefined) {
-        delete process.env.WYW_DEBUG_STATIC_RESOLVE;
-      } else {
-        process.env.WYW_DEBUG_STATIC_RESOLVE = previousDebug;
-      }
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it('emits static resolve debug rejection reasons when requested', async () => {
-    const previousDebug = process.env.WYW_DEBUG_STATIC_RESOLVE;
-    process.env.WYW_DEBUG_STATIC_RESOLVE = '1';
+  it('emits static resolve debug rejection reasons whenever the feature is enabled', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
@@ -696,20 +649,52 @@ describe('transform static import value inlining', () => {
           }),
         ])
       );
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[wyw-static-resolve]',
-        expect.objectContaining({
-          reason: 'unsupported-expression',
-          type: 'staticResolve',
-        })
-      );
+      expect(warnSpy).not.toHaveBeenCalled();
     } finally {
       warnSpy.mockRestore();
-      if (previousDebug === undefined) {
-        delete process.env.WYW_DEBUG_STATIC_RESOLVE;
-      } else {
-        process.env.WYW_DEBUG_STATIC_RESOLVE = previousDebug;
-      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not emit static resolve debug events when the feature is disabled', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const depFile = join(root, 'unsafe.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      depFile,
+      dedent`
+        const color = String('red');
+        export { color };
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { color } from './unsafe.js';
+
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+      `
+    );
+
+    try {
+      await runTransformWithOptions(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter,
+        { features: { staticImportValues: false } }
+      );
+
+      expect(
+        perf.events.filter((event) => event.type === 'staticResolve')
+      ).toEqual([]);
+    } finally {
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/packages/transform/src/debug/fileReporter.ts
+++ b/packages/transform/src/debug/fileReporter.ts
@@ -116,6 +116,10 @@ export const createFileReporter = (
     path.join(options.dir, 'entrypoints.jsonl')
   );
 
+  const staticResolveStream = createWriteStream(
+    path.join(options.dir, 'static-resolve.jsonl')
+  );
+
   const startedAt = performance.now();
   const timings: Timings = new Map();
   const addTiming = (label: string, key: string, value: number) => {
@@ -146,6 +150,11 @@ export const createFileReporter = (
   ) => {
     if (meta.type === 'dependency') {
       processDependencyEvent(meta as IProcessedEvent);
+      return;
+    }
+
+    if (meta.type === 'staticResolve') {
+      writeJSONl(staticResolveStream, meta);
     }
   };
 
@@ -224,6 +233,8 @@ export const createFileReporter = (
 
       actionStream.end();
       dependenciesStream.end();
+      entrypointStream.end();
+      staticResolveStream.end();
       timings.clear();
     },
   };

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues.ts
@@ -170,19 +170,10 @@ const isStaticImportValuesEnabled = (
   );
 };
 
-const isStaticResolveDebugEnabled = (): boolean => {
-  const envValue = process.env.WYW_DEBUG_STATIC_RESOLVE?.trim().toLowerCase();
-  return !!envValue && !isEnvDisabled(envValue);
-};
-
 const debugStaticResolve = (
   action: ITransformAction,
   event: StaticResolveDebugEvent
 ): void => {
-  if (!isStaticResolveDebugEnabled()) {
-    return;
-  }
-
   const labels = Object.fromEntries(
     Object.entries({
       ...event,
@@ -191,8 +182,6 @@ const debugStaticResolve = (
   );
 
   action.services.eventEmitter.single(labels);
-  // eslint-disable-next-line no-console
-  console.warn('[wyw-static-resolve]', labels);
 };
 
 const parseProgram = (code: string, filename: string): Program =>
@@ -240,7 +229,7 @@ const isStaticResolveCacheEnabled = (): boolean => {
     return !isEnvDisabled(envValue);
   }
 
-  return !isStaticResolveDebugEnabled();
+  return true;
 };
 
 const staticCachePrefix = (action: ITransformAction): string =>


### PR DESCRIPTION
## Summary

- Sync `bun.lock` to declare `@jridgewell/remapping@^2.3.5` for `@wyw-in-js/transform` (already referenced by `collectOxcRuntime.ts:52`).
- Route `staticResolve` debug events through the existing `FileReporter` infrastructure (jsonl, gated by `WYW_DEBUG_FILE_REPORTER`) instead of free-form stderr writes.

## Test plan

- [ ] `pnpm --filter @wyw-in-js/transform test -- --testPathPattern='(fileReporter|transform.static-import-values)'`
- [ ] Manual: run a transform with `WYW_DEBUG_FILE_REPORTER=1` and confirm one jsonl line per static-resolve attempt.

## Notes for reviewer

Two small unrelated chores. Happy to split into separate PRs if preferred.
