### PR TITLE
runner+broker: evict poisoned modules so transient load failures recover (port #278 #279 for broker-runner arch)

### DIFF
--- a/.changeset/eval-load-recovery.md
+++ b/.changeset/eval-load-recovery.md
@@ -1,0 +1,7 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Improve evaluation diagnostics and recovery for transient missing imports.
+
+Missing imports during evaluation now report the importing file, requested specifier, resolved path, and original error cause. The evaluator also evicts modules left in failed VM states and refreshes broker-side load tracking, so a subsequent evaluation can recover after the missing file is created instead of rethrowing stale module status errors.

--- a/.changeset/eval-runner-load-cause.md
+++ b/.changeset/eval-runner-load-cause.md
@@ -1,5 +1,0 @@
----
-'@wyw-in-js/transform': patch
----
-
-Preserve the original load failure as `error.cause` when evaluation reports missing import diagnostics.

--- a/.changeset/eval-runner-load-cause.md
+++ b/.changeset/eval-runner-load-cause.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Preserve the original load failure as `error.cause` when evaluation reports missing import diagnostics.

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -2700,6 +2700,58 @@ describe('EvalBroker', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it('missing import surfaces specifier and importer, not opaque ERR_VM_MODULE_STATUS', async () => {
+    // Reproduces: when an import temporarily points at a file that does not
+    // exist on disk, webpack consumers see only:
+    //   "Module status must be one of linked, evaluated, or errored"
+    // with no indication of which import in which file is broken. The
+    // diagnostic must name the missing specifier and the importing file so a
+    // user can fix the import without bisecting the build.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    writeFileSync(
+      join(root, 'entry.js'),
+      [
+        "import { value } from './missing-target.js';",
+        'export const __wywPreval = { v: () => value };',
+      ].join('\n')
+    );
+
+    // Resolver hands back an absolute path even though the file does not
+    // exist — mirrors editor/watch state where the path is momentarily stale.
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, join(root, 'entry.js'));
+    const broker = new EvalBroker(services, asyncResolve);
+
+    const ep = Entrypoint.createRoot(
+      services,
+      join(root, 'entry.js'),
+      ['__wywPreval'],
+      readFileSync(join(root, 'entry.js'), 'utf-8')
+    );
+
+    try {
+      await broker.evaluate(ep);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      const error = err as Error;
+      expect(error.message).not.toMatch(
+        /Module status must be one of linked, evaluated, or errored/
+      );
+      expect(error.message).toMatch(/missing-target\.js/);
+      expect(error.message).toMatch(/entry\.js/);
+    }
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it('concurrent sibling dependencies importing different exports from same barrel succeed', async () => {
     // Reproduces: when two dependency modules concurrently link and both import
     // the same barrel file (for different named exports), the runner's loadInFlight

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -2746,6 +2746,8 @@ describe('EvalBroker', () => {
       );
       expect(error.message).toMatch(/missing-target\.js/);
       expect(error.message).toMatch(/entry\.js/);
+      expect(error.cause).toBeInstanceOf(Error);
+      expect((error.cause as Error).message).toMatch(/missing-target\.js/);
     }
 
     broker.dispose();

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -2752,6 +2752,60 @@ describe('EvalBroker', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it('recovers after a transient missing import is fixed on disk', async () => {
+    // Reproduces (B): once a module fails to load (ENOENT on a transient
+    // missing import target), the runner caches the importer's
+    // SourceTextModule in 'errored' state. On the next eval session — even
+    // after the user creates the missing file — linkModule early-returns
+    // because module.status !== 'unlinked', and module.evaluate() re-throws
+    // the original link error. The build appears stuck despite a clean source
+    // tree.
+    //
+    // Expected: a successful second session once the file exists.
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+
+    writeFileSync(
+      join(root, 'entry.js'),
+      [
+        "import { value } from './target.js';",
+        'export const __wywPreval = { v: () => value };',
+      ].join('\n')
+    );
+    // target.js is intentionally missing for session 1.
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+    const services = createServices(root, join(root, 'entry.js'));
+    const broker = new EvalBroker(services, asyncResolve);
+
+    const ep1 = Entrypoint.createRoot(
+      services,
+      join(root, 'entry.js'),
+      ['__wywPreval'],
+      readFileSync(join(root, 'entry.js'), 'utf-8')
+    );
+    await expect(broker.evaluate(ep1)).rejects.toThrow();
+
+    // User creates the previously-missing file.
+    writeFileSync(join(root, 'target.js'), 'export const value = 42;');
+
+    const ep2 = Entrypoint.createRoot(
+      services,
+      join(root, 'entry.js'),
+      ['__wywPreval'],
+      readFileSync(join(root, 'entry.js'), 'utf-8')
+    );
+    const result = await broker.evaluate(ep2);
+    expect(result.values?.get('v')).toBe(42);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it('concurrent sibling dependencies importing different exports from same barrel succeed', async () => {
     // Reproduces: when two dependency modules concurrently link and both import
     // the same barrel file (for different named exports), the runner's loadInFlight

--- a/packages/transform/src/eval/broker.ts
+++ b/packages/transform/src/eval/broker.ts
@@ -1961,13 +1961,27 @@ export class EvalBroker {
         }
         this.resolvePending(message.id, {});
         return;
-      case 'EVAL_RESULT':
+      case 'EVAL_RESULT': {
+        // Runner reports any ids it dropped from its caches during this
+        // session (e.g. modules whose link errored after a transient missing
+        // import). Mirror those evictions here — otherwise lastSentLoadByModule
+        // would keep claiming the runner has them and handleLoad would ship
+        // empty `code` on the next session, leaving the runner stuck.
+        const evictedIds = (
+          message.payload as { evictedIds?: readonly string[] } | null
+        )?.evictedIds;
+        if (evictedIds && evictedIds.length > 0) {
+          for (const evictedId of evictedIds) {
+            this.lastSentLoadByModule.delete(evictedId);
+          }
+        }
         if (message.error) {
           this.rejectPending(message.id, message.error);
           return;
         }
         this.resolvePending(message.id, message.payload);
         return;
+      }
       case 'RESOLVE':
         this.handleResolve(message.id, message.payload).catch((error) => {
           void this.sendMessage({

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1773,7 +1773,20 @@ loadModule = async (id, importer, requestSpec) => {
       durationMs: Date.now() - loadStart,
     });
     if (loaded.error) {
-      throw new Error(loaded.error.message);
+      // Surface the importer + specifier alongside the broker's message.
+      // Without this, ENOENT and similar load failures bubble up as a bare
+      // path (or, after Node's VM wraps them, as the opaque
+      // ERR_VM_MODULE_STATUS) leaving no clue which file's import is broken.
+      const detail = [
+        `[wyw-in-js] Failed to load module during evaluation.`,
+        `  importer: ${importer ?? '(unknown)'}`,
+        `  request:  ${requestSpec ?? id}`,
+        `  resolved: ${id}`,
+        `  cause:    ${loaded.error.message}`,
+      ].join('\n');
+      const enhanced = new Error(detail);
+      enhanced.cause = loaded.error;
+      throw enhanced;
     }
 
     if (loaded.only) {

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -969,6 +969,12 @@ const resolveInFlight = new Map();
 
 const pending = new Map();
 const loadResultChunks = new Map();
+// Ids evicted during the in-flight EVAL session via resetSingleModuleState.
+// Surfaced in EVAL_RESULT so the broker can drop matching entries from its
+// "what runner has" mirror (lastSentLoadByModule) — otherwise the broker would
+// keep short-circuiting subsequent LOADs with empty `code` and the runner
+// would have no way to obtain fresh source.
+const evictedThisSession = new Set();
 let nextId = 0;
 const stdoutWriteQueue = [];
 let stdoutWriteInFlight = false;
@@ -1012,6 +1018,17 @@ const resetSingleModuleState = (id, cachedModule = moduleCache.get(id)) => {
   moduleData.delete(id);
   moduleVariants.delete(id);
   moduleLastVariant.delete(id);
+  sentNamespaceIdentifiers.delete(id);
+};
+
+// Stronger reset for error paths: clears moduleOnly too and records the id so
+// the broker can drop its lastSentLoadByModule entry. Used when a module's
+// SourceTextModule has reached an unrecoverable state (e.g. link errored
+// against a transient missing import) and should not be reused.
+const evictPoisonedModule = (id) => {
+  resetSingleModuleState(id);
+  moduleOnly.delete(id);
+  evictedThisSession.add(id);
 };
 
 const isFullModuleLoad = (loaded) =>
@@ -1584,6 +1601,17 @@ const linkModule = async (module) => {
       );
       return module;
     } catch (error) {
+      // The vm SourceTextModule is now in 'errored' (or partially-linked)
+      // state and can never be re-linked. With reuseModules:true the cached
+      // module would otherwise stick around and short-circuit linkModule's
+      // status guard above on the next session — surfacing the original
+      // failure forever even after the user fixes the underlying problem.
+      // Drop it so the next LOAD rebuilds a fresh SourceTextModule.
+      const identifier =
+        typeof module.identifier === 'string' ? module.identifier : null;
+      if (identifier) {
+        evictPoisonedModule(toSourceModuleId(identifier));
+      }
       // ERR_VM_MODULE_LINK_FAILURE means a dependency is in "errored" state.
       // Node chains .cause through the link failure hierarchy. Walk to the
       // deepest cause to surface the original evaluation error (e.g. a
@@ -1784,6 +1812,15 @@ loadModule = async (id, importer, requestSpec) => {
         `  resolved: ${id}`,
         `  cause:    ${loaded.error.message}`,
       ].join('\n');
+      // The importer's SourceTextModule (if it was already created and
+      // cached) compiled this `import` against `id`; reusing it next session
+      // would link against the same id and either re-trigger the failure or
+      // skip linking via the status guard. Drop both so the next session
+      // pulls fresh code for both ends of the broken edge.
+      if (importer && importer !== id) {
+        evictPoisonedModule(toSourceModuleId(importer));
+      }
+      evictPoisonedModule(id);
       const enhanced = new Error(detail);
       enhanced.cause = loaded.error;
       throw enhanced;
@@ -2229,6 +2266,7 @@ const handleMessage = async (message) => {
       break;
     }
     case 'EVAL': {
+      evictedThisSession.clear();
       try {
         const { values, modules } = await evaluateEntrypoint(
           message.payload.id
@@ -2239,13 +2277,17 @@ const handleMessage = async (message) => {
           payload: {
             values,
             modules,
+            evictedIds: Array.from(evictedThisSession),
           },
         });
       } catch (error) {
         sendMessage({
           type: 'EVAL_RESULT',
           id: message.id,
-          payload: { values: null },
+          payload: {
+            values: null,
+            evictedIds: Array.from(evictedThisSession),
+          },
           error: serializeError(error),
         });
       }

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1216,6 +1216,24 @@ const sendWarn = (warning) => {
   sendMessage({ type: 'WARN', payload: warning });
 };
 
+const reviveSerializedError = (error) => {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  const revived = new Error(error?.message ?? String(error));
+  if (error?.name) {
+    revived.name = error.name;
+  }
+  if (error?.stack) {
+    revived.stack = error.stack;
+  }
+  if (error?.cause) {
+    revived.cause = reviveSerializedError(error.cause);
+  }
+  return revived;
+};
+
 const serializeError = (error) => {
   const result = {
     message: error?.message ?? String(error),
@@ -1822,7 +1840,7 @@ loadModule = async (id, importer, requestSpec) => {
       }
       evictPoisonedModule(id);
       const enhanced = new Error(detail);
-      enhanced.cause = loaded.error;
+      enhanced.cause = reviveSerializedError(loaded.error);
       throw enhanced;
     }
 


### PR DESCRIPTION
When a module's resolver returned a path to a file that did not exist on
disk (e.g. a transient editor/watch state where the import target was
about to be created, or a typo the user later corrected), the runner's
loadModule re-threw the broker's error message verbatim:

    throw new Error(loaded.error.message);

The user-visible result in webpack was a bare ENOENT or, after Node's vm
machinery wrapped it, the opaque

    Error [ERR_VM_MODULE_STATUS]: Module status must be one of linked,
    evaluated, or errored
        at SourceTextModule.evaluate (node:internal/vm/module:229:15)
        at evaluateEntrypoint (.../eval/runner.js)

with no indication of which import in which file was broken. Bisecting
that across a multi-thousand-module build is painful.

This patch wraps the load failure with the context the runner already
has on hand -- the importer id, the original request specifier, the
resolved id, and the broker's original error chained via error.cause
-- so the diagnostic now reads:

    [wyw-in-js] Failed to load module during evaluation.
      importer: /abs/path/to/entry.tsx
      request:  ./missing-target
      resolved: /abs/path/to/missing-target.js
      cause:    ENOENT: no such file or directory, open '...'

The original error remains accessible via .cause for any consumer that
wants to inspect the underlying Node error code.

Scope:
- Only touches the LOAD-error path in src/eval/runner.js. The successful
  load path, link-failure path (which already walks .cause to surface
  root cause via ERR_VM_MODULE_LINK_FAILURE handling), and evaluation
  path are unchanged.
- esm/eval/runner.js is generated; rebuild with pnpm build:esm in
  packages/transform before regenerating consumer patches.

Test: src/__tests__/eval-broker.test.ts adds
"missing import surfaces specifier and importer, not opaque
ERR_VM_MODULE_STATUS" -- drives the broker with a resolver that returns
a path to a non-existent file and asserts the thrown error mentions
both the importer and the missing specifier and is NOT the opaque
ERR_VM_MODULE_STATUS message.

Out of scope: a separate stickiness bug where, after the user corrects
the import on disk, subsequent eval sessions still fail because cached
runner state is not invalidated. That is being handled via a v1
backport.



Also


Companion fix to "surface importer + specifier when LOAD fails during eval"
(96762f4d). That patch made the failure visible. This patch makes it
recoverable.

Symptom: with reuseModules:true (the default for repeat eval sessions in
webpack/HMR), once a module's link errored against a transient missing
import, every subsequent eval session for the same entrypoint surfaced

    Error [ERR_VM_MODULE_STATUS]: Module status must be one of linked,
    evaluated, or errored

even after the user created the missing file. The build appeared stuck.

Root cause: a vm.SourceTextModule whose link() rejected ends up in
'errored' (or partially-linked) state and cannot be re-linked. The
runner kept it in moduleCache, and on the next session:

  1. linkModule's `if (module.status !== 'unlinked') return module;`
     guard at runner.js:1588 skipped re-linking.
  2. evaluate() then re-threw the original link error -- or, when the
     status was 'linking' rather than 'errored', emitted the opaque
     ERR_VM_MODULE_STATUS above.

Even if the runner had dropped the cached module, the broker's
lastSentLoadByModule mirror still claimed the runner had the cached
variant, so handleLoad would short-circuit with empty `code` on the
next LOAD and the runner would have no way to obtain fresh source.

Fix:

* runner.js — introduce evictPoisonedModule(id), a stronger sibling of
  resetSingleModuleState that additionally clears moduleOnly and records
  the id in evictedThisSession. Called from:
  - linkModule's catch (the SourceTextModule of the module being linked
    is now unrecoverable; drop it before rethrowing).
  - loadModule's loaded.error branch (drop both the failed id and the
    importer whose compiled module has the bad import baked in; the
    importer would otherwise re-trigger the same failure on next link).

* runner.js — extend resetSingleModuleState to clear
  sentNamespaceIdentifiers too, so a re-loaded variant is re-serialized
  in the next EVAL_RESULT rather than skipped under a stale identifier
  match.

* runner.js — EVAL handler: clear evictedThisSession at the start of
  each session and include the accumulated ids as `evictedIds` in the
  EVAL_RESULT payload (both success and error paths).

* broker.ts — on EVAL_RESULT, drop any reported evictedIds from
  lastSentLoadByModule so handleLoad ships fresh code on the next LOAD
  rather than relying on the now-evicted runner-side cache.

Scope notes:

* resetSingleModuleState is still used by the normal hash-mismatch
  cache-bust path at runner.js:1907 and that path must NOT clear
  moduleOnly (the broker just shipped fresh `only` and the runner
  populated moduleOnly a few lines earlier). Keeping moduleOnly removal
  out of resetSingleModuleState and inside evictPoisonedModule preserves
  this invariant -- verified against the broker suite, in particular
  "promotes statically evaluatable dependency modules to wildcard cache
  coverage" and "does not reuse wildcard cached exports for subsequent
  __wywPreval requests".

* Complements upstream https://github.com/Anber/wyw-in-js/pull/278 and https://github.com/Anber/wyw-in-js/pull/279, which fix the
  *transform-level* mtime/disk re-validation cache. Those PRs do not
  touch the eval runner's in-process moduleCache/linkPromises and
  therefore do not address this stickiness on their own.

* esm/eval/runner.js + esm/eval/broker.js are generated; rebuild with
  pnpm build:esm in packages/transform before regenerating consumer
  patches.

Test: src/__tests__/eval-broker.test.ts adds "recovers after a transient
missing import is fixed on disk" -- session 1 evaluates an entrypoint
whose import target does not exist (rejects); session 2, after writing
the previously-missing file, must succeed. Without the runner-side
eviction the second session reproduces the user-reported
ERR_VM_MODULE_STATUS; without the broker-side mirror invalidation it
fails with a broker/runner cache desync. With both, it passes.

The pre-existing test "missing import surfaces specifier and importer,
not opaque ERR_VM_MODULE_STATUS" still passes.