### PR TITLE
Fixes static inlining for expressions guarded by  TypeScript ambient globals.

### DIFF
--- a/packages/transform/src/__tests__/transform.design-system-repro.test.ts
+++ b/packages/transform/src/__tests__/transform.design-system-repro.test.ts
@@ -2757,6 +2757,10 @@ describe('design-system chain repro for staticImportValues', () => {
       dedent`
         import { isFlagPresent } from './flags';
 
+        declare global {
+          const __DISABLE_VERTICAL_MOBILE_BREAKPOINT__: boolean | undefined;
+        }
+
         export const phoneMediaQuery =
           (typeof __DISABLE_VERTICAL_MOBILE_BREAKPOINT__ !== 'undefined' &&
             __DISABLE_VERTICAL_MOBILE_BREAKPOINT__) ||

--- a/packages/transform/src/utils/collectOxcTemplateDependencies.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies.ts
@@ -577,6 +577,10 @@ const analyzeProgram = (
       usedNames.add(node.name);
     }
 
+    if (isInTypeContext(ancestors)) {
+      return;
+    }
+
     if (
       node.type === 'FunctionDeclaration' ||
       node.type === 'FunctionExpression' ||


### PR DESCRIPTION
Rebased on #313 (to be merged after)

  `phoneMediaQuery` was still falling back to eval because `declare global { const __DISABLE_VERTICAL_MOBILE_BREAKPOINT__ ... }` was treated as a runtime binding during static analysis. That prevented `typeof __DISABLE_VERTICAL_MOBILE_BREAKPOINT__` from folding to `"undefined"`, so the conditional stayed non-serializable and pulled `use-is-phone.tsx` / `flags.ts` into eval.

  ## Changes

  - Ignore bindings found inside TypeScript-only
  contexts during static dependency analysis.
  - Extend the existing `phoneMediaQuery` repro with
  the real `declare global` shape from `use-is-
  phone.tsx`.

  ## Verification

  ```sh
  bun test packages/transform/src/__tests__/transform.static-import-values.test.ts packages/transform/src/__tests__/transform.design-system-repro.test.ts