### PR TITLE
perf(transform): visitor-key cache, cleanup-loop forward-feed, EventEmitter no-op + bump oxc 0.131

### DIFF
--- a/.changeset/fast-transform-oxc.md
+++ b/.changeset/fast-transform-oxc.md
@@ -1,0 +1,6 @@
+---
+"@wyw-in-js/esbuild": patch
+"@wyw-in-js/transform": patch
+---
+
+Improve transform performance by caching OXC visitor keys, reusing cleanup parses, bypassing disabled emitter instrumentation, and updating OXC packages.

--- a/bun.lock
+++ b/bun.lock
@@ -91,7 +91,7 @@
     },
     "e2e/bun": {
       "name": "@wyw-in-js/e2e-bun",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/template-tag-syntax": "workspace:*",
       },
@@ -102,7 +102,7 @@
     },
     "e2e/esbuild": {
       "name": "@wyw-in-js/e2e-esbuild",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/template-tag-syntax": "workspace:*",
       },
@@ -115,7 +115,7 @@
     },
     "e2e/next-turbopack": {
       "name": "@wyw-in-js/e2e-next-turbopack",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/nextjs": "workspace:*",
         "@wyw-in-js/template-tag-syntax": "workspace:*",
@@ -129,7 +129,7 @@
     },
     "e2e/next-webpack": {
       "name": "@wyw-in-js/e2e-next-webpack",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/nextjs": "workspace:*",
         "@wyw-in-js/template-tag-syntax": "workspace:*",
@@ -143,7 +143,7 @@
     },
     "e2e/parcel": {
       "name": "@wyw-in-js/e2e-parcel",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/template-tag-syntax": "workspace:*",
       },
@@ -156,7 +156,7 @@
     },
     "e2e/rollup": {
       "name": "@wyw-in-js/e2e-rollup",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/template-tag-syntax": "workspace:*",
       },
@@ -171,7 +171,7 @@
     },
     "e2e/vite": {
       "name": "@wyw-in-js/e2e-vite",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/template-tag-syntax": "workspace:*",
       },
@@ -186,7 +186,7 @@
     },
     "e2e/webpack": {
       "name": "@wyw-in-js/e2e-webpack",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/template-tag-syntax": "workspace:*",
       },
@@ -199,7 +199,7 @@
     },
     "examples/nextjs-wyw-demo": {
       "name": "nextjs-wyw-demo",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@linaria/core": "^6.0.0",
         "@linaria/react": "^6.0.0",
@@ -217,7 +217,7 @@
     },
     "examples/object-syntax": {
       "name": "@wyw-in-js/object-syntax",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@griffel/core": "1.5.0",
         "@wyw-in-js/processor-utils": "workspace:*",
@@ -233,7 +233,7 @@
     },
     "examples/rsbuild-issue-256": {
       "name": "rsbuild-issue-256-repro",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@rsbuild/core": "^1.2.19",
         "@rsbuild/plugin-babel": "^1.0.3",
@@ -246,7 +246,7 @@
     },
     "examples/template-tag-syntax": {
       "name": "@wyw-in-js/template-tag-syntax",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/processor-utils": "workspace:*",
       },
@@ -260,7 +260,7 @@
     },
     "examples/vite-react-refresh": {
       "name": "vite-react-refresh-repro",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@vitejs/plugin-react": "^5.0.3",
         "@wyw-in-js/template-tag-syntax": "workspace:*",
@@ -272,7 +272,7 @@
     },
     "packages/babel-preset": {
       "name": "@wyw-in-js/babel-preset",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@babel/core": "^7.23.5",
         "@wyw-in-js/shared": "workspace:*",
@@ -287,7 +287,7 @@
     },
     "packages/bun": {
       "name": "@wyw-in-js/bun",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@rollup/pluginutils": "^5.1.4",
         "@wyw-in-js/shared": "workspace:*",
@@ -302,7 +302,7 @@
     },
     "packages/cli": {
       "name": "@wyw-in-js/cli",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "bin": {
         "wyw-in-js": "bin/wyw-in-js.js",
       },
@@ -324,11 +324,11 @@
     },
     "packages/esbuild": {
       "name": "@wyw-in-js/esbuild",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
         "@wyw-in-js/transform": "workspace:*",
-        "oxc-transform": "0.127.0",
+        "oxc-transform": "0.131.0",
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -342,7 +342,7 @@
     },
     "packages/nextjs": {
       "name": "@wyw-in-js/nextjs",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
         "@wyw-in-js/turbopack-loader": "workspace:*",
@@ -362,7 +362,7 @@
     },
     "packages/parcel-transformer": {
       "name": "@wyw-in-js/parcel-transformer",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@parcel/plugin": "^2.16.3",
         "@parcel/source-map": "^2.1.1",
@@ -380,7 +380,7 @@
     },
     "packages/processor-utils": {
       "name": "@wyw-in-js/processor-utils",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
       },
@@ -393,7 +393,7 @@
     },
     "packages/rollup": {
       "name": "@wyw-in-js/rollup",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.5",
         "@wyw-in-js/shared": "workspace:*",
@@ -412,7 +412,7 @@
     },
     "packages/shared": {
       "name": "@wyw-in-js/shared",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "debug": "^4.3.4",
         "find-up": "^5.0.0",
@@ -428,7 +428,7 @@
     },
     "packages/transform": {
       "name": "@wyw-in-js/transform",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "@wyw-in-js/processor-utils": "workspace:*",
@@ -436,9 +436,9 @@
         "cosmiconfig": "^8.0.0",
         "happy-dom": "^20.1.0",
         "minimatch": "^9.0.5",
-        "oxc-parser": "0.127.0",
+        "oxc-parser": "0.131.0",
         "oxc-resolver": "11.19.1",
-        "oxc-transform": "0.127.0",
+        "oxc-transform": "0.131.0",
         "source-map": "^0.7.4",
         "stylis": "^4.3.0",
         "ts-invariant": "^0.10.3",
@@ -459,7 +459,7 @@
     },
     "packages/turbopack-loader": {
       "name": "@wyw-in-js/turbopack-loader",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
         "@wyw-in-js/transform": "workspace:*",
@@ -474,7 +474,7 @@
     },
     "packages/vite": {
       "name": "@wyw-in-js/vite",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
         "@wyw-in-js/transform": "workspace:*",
@@ -492,7 +492,7 @@
     },
     "packages/webpack-loader": {
       "name": "@wyw-in-js/webpack-loader",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-alpha.1",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
         "@wyw-in-js/transform": "workspace:*",
@@ -1024,47 +1024,47 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.127.0", "", { "os": "android", "cpu": "arm" }, "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ=="],
+    "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.131.0", "", { "os": "android", "cpu": "arm" }, "sha512-t2xicr9pfzkSRYx5aPqZqlLaayIwJTqgQ81Jor31Xep2nGyL2Aq3d0K5wOfeR7VevaSdxaS9dzSQP9xDwn8fDg=="],
 
-    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.127.0", "", { "os": "android", "cpu": "arm64" }, "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg=="],
+    "@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.131.0", "", { "os": "android", "cpu": "arm64" }, "sha512-nlGIod6gw75x1aEDgLS+srj+JRGY0HHm9MI9YgzE/B64l6d6+H3MSP9NOgp0+HTg8tp4vV9rVfgQGgd+TfVZcA=="],
 
-    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.127.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg=="],
+    "@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.131.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jukuV6xe5RbQKFo7QD34NDCLDZp4PSOm8rmckhNdH/60ymG5zXbDzGBEyc+nTkuLQNama2aSGCt+CPfpjNTqyw=="],
 
-    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.127.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw=="],
+    "@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.131.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-g3JOo4khe9rslHm5WYaVDWb0HS/M1MLR3I9S8560MkKIcC96VQY00QjOlsuRyfSj/JDXj8i9T7ryPO2RidiXVg=="],
 
-    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.127.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA=="],
+    "@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.131.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1hziITDTxjMePnX+dR9ocVT+EuZkQ8wm4FPAbmbEiKG+Phbo73J1ZnPAA6Y/aGsWF3McOFnQuZIktAFwalkfJQ=="],
 
-    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ=="],
+    "@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.131.0", "", { "os": "linux", "cpu": "arm" }, "sha512-9uRxfXwyKG9+MwmGQBo2ncPNwZH5HTmCETFM2WiuDBNDCW4NC5ttSQkwCAMrTAWgwMzVBH1CP8pM0v7nebCWXQ=="],
 
-    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g=="],
+    "@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.131.0", "", { "os": "linux", "cpu": "arm" }, "sha512-mgbLvzRShXOLBdWGInf08Af4q+pfj1xD8hSgLClDZ9of/BXkB6+LIhTH7fihiDUipqB3yoSkKBWaZ3Ejlf5Yag=="],
 
-    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ=="],
+    "@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.131.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-OPT8++4aN6j2GJ8+3IZHS/byXoZP4aSBn+FoG6rgBJ2fKwPKXWF3MqrFMNW7NKHM28FLY579xYLxJSfgobEqPA=="],
 
-    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA=="],
+    "@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.131.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vtPiwmfVTAXzaxDKsOXG+LwgRAA7WEnaeHzhS5z0GE89gAK18KSXnly7Z6saXXq6L3dVMyK44uoTI03zKxrpmw=="],
 
-    "@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.127.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ=="],
+    "@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.131.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-8AW8L7w5cGHSdZPcyZX2yR0+GUODsT15rbRjfdD54rv6DMbtuEB19ysLOpKJlRGfH6UNYNpCHaU1uJWgTWf1/w=="],
 
-    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ=="],
+    "@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.131.0", "", { "os": "linux", "cpu": "none" }, "sha512-vvpjkjEOUsPcsYf8evE4MO3aGx9+3wodXEBOicGNnOwTuAik8eBONNkgSdhkGsAblQmfVHJyanRnpxglddTXIA=="],
 
-    "@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g=="],
+    "@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.131.0", "", { "os": "linux", "cpu": "none" }, "sha512-AqmcNC3fClXX+fxQ6VGEN1667xVFiRBkY0CZmDMSiaeFUsv1+UkBPYYi48IUKcA9/ivvoKNRzQl2I4//kT9F/w=="],
 
-    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.127.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q=="],
+    "@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.131.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-7d3jOMKy7RSQCcDLIci+ySll2FgsOMl/GiRux4q2JNv0zg4EdhFISa9idvrdN/HEUIQQJNg6dmveUeJl2YErGA=="],
 
-    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ=="],
+    "@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.131.0", "", { "os": "linux", "cpu": "x64" }, "sha512-JHK/h95qVqVQ+ITER837kcTdwBDFpFaNnOTYGCP0zdUSX/mLKC7tXOoyrTb6vG7iRPwGlcgBil3v2IjYw1FqJA=="],
 
-    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg=="],
+    "@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.131.0", "", { "os": "linux", "cpu": "x64" }, "sha512-b2BO82O8azXAyf7EUgOPKu145nWypbNyk07HbU09fkzhm9lEA5oPvaN/M8Nlo7tOErVTa2WOgS4QbOnxAPXdDQ=="],
 
-    "@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.127.0", "", { "os": "none", "cpu": "arm64" }, "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ=="],
+    "@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.131.0", "", { "os": "none", "cpu": "arm64" }, "sha512-GHO9glZaX7LkX/OGfluEPf1yjg+ehiFbUdowbX6uNWOQhmwKWU4m4+nZ9FJkrHNKuxyI1KKertMdGjVKCApKWA=="],
 
-    "@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.127.0", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ=="],
+    "@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.131.0", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-3SkikPaEFoih1N83qLVEDLRLeY4nYsf6JT9SnWiMCQ5lGQdKup6bEuKCqkRiG9dD1IIaFeYz9RjlciPmYoFIWA=="],
 
-    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.127.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw=="],
+    "@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.131.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Os5bEhryeA2jkH+ZrnZyAC1EP5gs+X4YB1Fjqml7UPD5kU7ecsK1MPEVMfCrdt/GDNpDbavYXiOXOdyJ5b3OPw=="],
 
-    "@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.127.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw=="],
+    "@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.131.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-m+jNz9EuF0NXoiptc6B9h5yompZQVW/a5MJeOu5zojfH5yWk82tvF2ccrHkfhgtrS9h9DD5l1Qv8dWlfY7Nz8g=="],
 
-    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.127.0", "", { "os": "win32", "cpu": "x64" }, "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w=="],
+    "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.131.0", "", { "os": "win32", "cpu": "x64" }, "sha512-o14Hk8dAyiEUMFEWEgmAwFZvBt1RzAYLM3xeQ+5315JXgVYhoemivgYcbYVRbsFkS71ShMGlAFE0kPnr460rww=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+    "@oxc-project/types": ["@oxc-project/types@0.131.0", "", {}, "sha512-PgnWDfV0h+b16XNKbXU7Daib/BFSt/J2mEzfYIBu6JB/wNdlU+kVYXCkGA1A9fWkTbOgbjh4e6NhPeQOYvFhEA=="],
 
     "@oxc-resolver/binding-android-arm-eabi": ["@oxc-resolver/binding-android-arm-eabi@11.19.1", "", { "os": "android", "cpu": "arm" }, "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg=="],
 
@@ -2756,7 +2756,7 @@
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
-    "oxc-parser": ["oxc-parser@0.127.0", "", { "dependencies": { "@oxc-project/types": "^0.127.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.127.0", "@oxc-parser/binding-android-arm64": "0.127.0", "@oxc-parser/binding-darwin-arm64": "0.127.0", "@oxc-parser/binding-darwin-x64": "0.127.0", "@oxc-parser/binding-freebsd-x64": "0.127.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0", "@oxc-parser/binding-linux-arm64-gnu": "0.127.0", "@oxc-parser/binding-linux-arm64-musl": "0.127.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-musl": "0.127.0", "@oxc-parser/binding-linux-s390x-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-musl": "0.127.0", "@oxc-parser/binding-openharmony-arm64": "0.127.0", "@oxc-parser/binding-wasm32-wasi": "0.127.0", "@oxc-parser/binding-win32-arm64-msvc": "0.127.0", "@oxc-parser/binding-win32-ia32-msvc": "0.127.0", "@oxc-parser/binding-win32-x64-msvc": "0.127.0" } }, "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA=="],
+    "oxc-parser": ["oxc-parser@0.131.0", "", { "dependencies": { "@oxc-project/types": "^0.131.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.131.0", "@oxc-parser/binding-android-arm64": "0.131.0", "@oxc-parser/binding-darwin-arm64": "0.131.0", "@oxc-parser/binding-darwin-x64": "0.131.0", "@oxc-parser/binding-freebsd-x64": "0.131.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.131.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.131.0", "@oxc-parser/binding-linux-arm64-gnu": "0.131.0", "@oxc-parser/binding-linux-arm64-musl": "0.131.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.131.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.131.0", "@oxc-parser/binding-linux-riscv64-musl": "0.131.0", "@oxc-parser/binding-linux-s390x-gnu": "0.131.0", "@oxc-parser/binding-linux-x64-gnu": "0.131.0", "@oxc-parser/binding-linux-x64-musl": "0.131.0", "@oxc-parser/binding-openharmony-arm64": "0.131.0", "@oxc-parser/binding-wasm32-wasi": "0.131.0", "@oxc-parser/binding-win32-arm64-msvc": "0.131.0", "@oxc-parser/binding-win32-ia32-msvc": "0.131.0", "@oxc-parser/binding-win32-x64-msvc": "0.131.0" } }, "sha512-SJ3/7ZPbgie8dr5Z9BI/M51zZbpXba+hRSG0MDzVwMW5CRQg2fjYE0jHGlLX4eeiibGgC/mzoDFKSDHwVZEHRQ=="],
 
     "oxc-resolver": ["oxc-resolver@11.19.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.19.1", "@oxc-resolver/binding-android-arm64": "11.19.1", "@oxc-resolver/binding-darwin-arm64": "11.19.1", "@oxc-resolver/binding-darwin-x64": "11.19.1", "@oxc-resolver/binding-freebsd-x64": "11.19.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1", "@oxc-resolver/binding-linux-arm64-musl": "11.19.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-musl": "11.19.1", "@oxc-resolver/binding-openharmony-arm64": "11.19.1", "@oxc-resolver/binding-wasm32-wasi": "11.19.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1", "@oxc-resolver/binding-win32-x64-msvc": "11.19.1" } }, "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg=="],
 
@@ -3444,6 +3444,10 @@
 
     "@nicolo-ribaudo/eslint-scope-5-internals/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
 
+    "@oxc-parser/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
     "@parcel/optimizer-swc/@swc/core": ["@swc/core@1.15.8", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.8", "@swc/core-darwin-x64": "1.15.8", "@swc/core-linux-arm-gnueabihf": "1.15.8", "@swc/core-linux-arm64-gnu": "1.15.8", "@swc/core-linux-arm64-musl": "1.15.8", "@swc/core-linux-x64-gnu": "1.15.8", "@swc/core-linux-x64-musl": "1.15.8", "@swc/core-win32-arm64-msvc": "1.15.8", "@swc/core-win32-ia32-msvc": "1.15.8", "@swc/core-win32-x64-msvc": "1.15.8" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-T8keoJjXaSUoVBCIjgL6wAnhADIb09GOELzKg10CjNg+vLX48P93SME6jTfte9MZIm5m+Il57H3rTSk/0kzDUw=="],
 
     "@parcel/package-manager/@swc/core": ["@swc/core@1.15.8", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.8", "@swc/core-darwin-x64": "1.15.8", "@swc/core-linux-arm-gnueabihf": "1.15.8", "@swc/core-linux-arm64-gnu": "1.15.8", "@swc/core-linux-arm64-musl": "1.15.8", "@swc/core-linux-x64-gnu": "1.15.8", "@swc/core-linux-x64-musl": "1.15.8", "@swc/core-win32-arm64-msvc": "1.15.8", "@swc/core-win32-ia32-msvc": "1.15.8", "@swc/core-win32-x64-msvc": "1.15.8" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-T8keoJjXaSUoVBCIjgL6wAnhADIb09GOELzKg10CjNg+vLX48P93SME6jTfte9MZIm5m+Il57H3rTSk/0kzDUw=="],
@@ -3496,7 +3500,11 @@
 
     "@wyw-in-js/esbuild/esbuild": ["esbuild@0.15.18", "", { "optionalDependencies": { "@esbuild/android-arm": "0.15.18", "@esbuild/linux-loong64": "0.15.18", "esbuild-android-64": "0.15.18", "esbuild-android-arm64": "0.15.18", "esbuild-darwin-64": "0.15.18", "esbuild-darwin-arm64": "0.15.18", "esbuild-freebsd-64": "0.15.18", "esbuild-freebsd-arm64": "0.15.18", "esbuild-linux-32": "0.15.18", "esbuild-linux-64": "0.15.18", "esbuild-linux-arm": "0.15.18", "esbuild-linux-arm64": "0.15.18", "esbuild-linux-mips64le": "0.15.18", "esbuild-linux-ppc64le": "0.15.18", "esbuild-linux-riscv64": "0.15.18", "esbuild-linux-s390x": "0.15.18", "esbuild-netbsd-64": "0.15.18", "esbuild-openbsd-64": "0.15.18", "esbuild-sunos-64": "0.15.18", "esbuild-windows-32": "0.15.18", "esbuild-windows-64": "0.15.18", "esbuild-windows-arm64": "0.15.18" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q=="],
 
+    "@wyw-in-js/esbuild/oxc-transform": ["oxc-transform@0.131.0", "", { "optionalDependencies": { "@oxc-transform/binding-android-arm-eabi": "0.131.0", "@oxc-transform/binding-android-arm64": "0.131.0", "@oxc-transform/binding-darwin-arm64": "0.131.0", "@oxc-transform/binding-darwin-x64": "0.131.0", "@oxc-transform/binding-freebsd-x64": "0.131.0", "@oxc-transform/binding-linux-arm-gnueabihf": "0.131.0", "@oxc-transform/binding-linux-arm-musleabihf": "0.131.0", "@oxc-transform/binding-linux-arm64-gnu": "0.131.0", "@oxc-transform/binding-linux-arm64-musl": "0.131.0", "@oxc-transform/binding-linux-ppc64-gnu": "0.131.0", "@oxc-transform/binding-linux-riscv64-gnu": "0.131.0", "@oxc-transform/binding-linux-riscv64-musl": "0.131.0", "@oxc-transform/binding-linux-s390x-gnu": "0.131.0", "@oxc-transform/binding-linux-x64-gnu": "0.131.0", "@oxc-transform/binding-linux-x64-musl": "0.131.0", "@oxc-transform/binding-openharmony-arm64": "0.131.0", "@oxc-transform/binding-wasm32-wasi": "0.131.0", "@oxc-transform/binding-win32-arm64-msvc": "0.131.0", "@oxc-transform/binding-win32-ia32-msvc": "0.131.0", "@oxc-transform/binding-win32-x64-msvc": "0.131.0" } }, "sha512-ml0/elXPNnDnuHo3VHmEMN2fnybmKx7YL+0E+gMQ0fuHRZHXYJzF6YJ01KsCWg6FXY6pbZcjm7DC3xwGHnB/BA=="],
+
     "@wyw-in-js/transform/esbuild": ["esbuild@0.15.18", "", { "optionalDependencies": { "@esbuild/android-arm": "0.15.18", "@esbuild/linux-loong64": "0.15.18", "esbuild-android-64": "0.15.18", "esbuild-android-arm64": "0.15.18", "esbuild-darwin-64": "0.15.18", "esbuild-darwin-arm64": "0.15.18", "esbuild-freebsd-64": "0.15.18", "esbuild-freebsd-arm64": "0.15.18", "esbuild-linux-32": "0.15.18", "esbuild-linux-64": "0.15.18", "esbuild-linux-arm": "0.15.18", "esbuild-linux-arm64": "0.15.18", "esbuild-linux-mips64le": "0.15.18", "esbuild-linux-ppc64le": "0.15.18", "esbuild-linux-riscv64": "0.15.18", "esbuild-linux-s390x": "0.15.18", "esbuild-netbsd-64": "0.15.18", "esbuild-openbsd-64": "0.15.18", "esbuild-sunos-64": "0.15.18", "esbuild-windows-32": "0.15.18", "esbuild-windows-64": "0.15.18", "esbuild-windows-arm64": "0.15.18" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q=="],
+
+    "@wyw-in-js/transform/oxc-transform": ["oxc-transform@0.131.0", "", { "optionalDependencies": { "@oxc-transform/binding-android-arm-eabi": "0.131.0", "@oxc-transform/binding-android-arm64": "0.131.0", "@oxc-transform/binding-darwin-arm64": "0.131.0", "@oxc-transform/binding-darwin-x64": "0.131.0", "@oxc-transform/binding-freebsd-x64": "0.131.0", "@oxc-transform/binding-linux-arm-gnueabihf": "0.131.0", "@oxc-transform/binding-linux-arm-musleabihf": "0.131.0", "@oxc-transform/binding-linux-arm64-gnu": "0.131.0", "@oxc-transform/binding-linux-arm64-musl": "0.131.0", "@oxc-transform/binding-linux-ppc64-gnu": "0.131.0", "@oxc-transform/binding-linux-riscv64-gnu": "0.131.0", "@oxc-transform/binding-linux-riscv64-musl": "0.131.0", "@oxc-transform/binding-linux-s390x-gnu": "0.131.0", "@oxc-transform/binding-linux-x64-gnu": "0.131.0", "@oxc-transform/binding-linux-x64-musl": "0.131.0", "@oxc-transform/binding-openharmony-arm64": "0.131.0", "@oxc-transform/binding-wasm32-wasi": "0.131.0", "@oxc-transform/binding-win32-arm64-msvc": "0.131.0", "@oxc-transform/binding-win32-ia32-msvc": "0.131.0", "@oxc-transform/binding-win32-x64-msvc": "0.131.0" } }, "sha512-ml0/elXPNnDnuHo3VHmEMN2fnybmKx7YL+0E+gMQ0fuHRZHXYJzF6YJ01KsCWg6FXY6pbZcjm7DC3xwGHnB/BA=="],
 
     "@wyw-in-js/website/next": ["next@13.5.11", "", { "dependencies": { "@next/env": "13.5.11", "@swc/helpers": "0.5.2", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001406", "postcss": "8.4.31", "styled-jsx": "5.1.1", "watchpack": "2.4.0" }, "optionalDependencies": { "@next/swc-darwin-arm64": "13.5.9", "@next/swc-darwin-x64": "13.5.9", "@next/swc-linux-arm64-gnu": "13.5.9", "@next/swc-linux-arm64-musl": "13.5.9", "@next/swc-linux-x64-gnu": "13.5.9", "@next/swc-linux-x64-musl": "13.5.9", "@next/swc-win32-arm64-msvc": "13.5.9", "@next/swc-win32-ia32-msvc": "13.5.9", "@next/swc-win32-x64-msvc": "13.5.9" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "react": "^18.2.0", "react-dom": "^18.2.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-WUPJ6WbAX9tdC86kGTu92qkrRdgRqVrY++nwM+shmWQwmyxt4zhZfR59moXSI4N8GDYCBY3lIAqhzjDd4rTC8Q=="],
 
@@ -4106,9 +4114,89 @@
 
     "@wyw-in-js/esbuild/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.15.18", "", { "os": "linux", "cpu": "none" }, "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ=="],
 
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-android-arm-eabi": ["@oxc-transform/binding-android-arm-eabi@0.131.0", "", { "os": "android", "cpu": "arm" }, "sha512-rcNvLlbNnxTfYVlZVF+Rev2AyCpJDpwVPphG4HOJxauaT1+w5VxL+kRdxCReof4A8ZsszbvIYlvkqvaJKO4Mog=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-android-arm64": ["@oxc-transform/binding-android-arm64@0.131.0", "", { "os": "android", "cpu": "arm64" }, "sha512-/y+EH6QYQB2ZDQNvMlzItc36mw16GZwCDlvGYbQ4GCTE+7ZtSmx9E/rJOYzYyzMghz0c5dhJquRKScXdOZHpnQ=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-darwin-arm64": ["@oxc-transform/binding-darwin-arm64@0.131.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-x1Va8zFomdYghAI0Zkt7kUmG50S65XH1u0EbIDr80M9idfXrQgd08ZGl3ejwRGLBrkbA8tkkmeOu1rWVFf7BXg=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-darwin-x64": ["@oxc-transform/binding-darwin-x64@0.131.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-EwacackWpYYXGZsl0Aj4NKvDdLuxWZg7LQDneFyMwuftpAxPQLRkHFwZib7r6wpIJm4NELhHW261A4vZ8OQqXQ=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-freebsd-x64": ["@oxc-transform/binding-freebsd-x64@0.131.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-EhXqWOtL1PWcJ3ktdplV4Wrez2PRuTBSDdB7KF6CN4zuZhohUjxC1bxqDNRbNSX46yaZ27IzJLafah1J6mSA8Q=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-linux-arm-gnueabihf": ["@oxc-transform/binding-linux-arm-gnueabihf@0.131.0", "", { "os": "linux", "cpu": "arm" }, "sha512-NfNACr3aqBKeeUh6HCoGGPSjdMkLvyXUZQywCg/DwRkEpqZo55KX65saW1sQdgBcu0SKXrAReTjIm/HDO/OI0Q=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-linux-arm-musleabihf": ["@oxc-transform/binding-linux-arm-musleabihf@0.131.0", "", { "os": "linux", "cpu": "arm" }, "sha512-ABp6KGhbYFGDaAdB4gGZW12DYa55OF/Cu+6Rw6/Di0skuwpiDwnBOLHWz9VBq0QTcREy/qIUOnKW+vZHQLOT8A=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-linux-arm64-gnu": ["@oxc-transform/binding-linux-arm64-gnu@0.131.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-4nKYkHHjRela+jpt+VO4++jxgHoJQFxAeAGtfQ4x11dQMJllzqo3Yu8gfcfLEMsAfflwN/gY+KBbMD/y0exitg=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-linux-arm64-musl": ["@oxc-transform/binding-linux-arm64-musl@0.131.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-cW0Ab1s0sxfiyP1+gdd94f0vUjwGzJF4F3DepF3VnR9nFTGMmFLugwtrBS3DYjTnbugiUH3Fp+16yys1FhNzIA=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-linux-ppc64-gnu": ["@oxc-transform/binding-linux-ppc64-gnu@0.131.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-wunAU/lzE1nPGKL47uI0g+4Nsv/12xveOXNu4M70xe85kNBm7mQdMpZIeoVYCxtXew0iHxFKJDT6qK5mYFSA3w=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-linux-riscv64-gnu": ["@oxc-transform/binding-linux-riscv64-gnu@0.131.0", "", { "os": "linux", "cpu": "none" }, "sha512-r4sMt4OB4TryDcVWW9KnsXOf/ea7tIGX2QASNrpetzPocsBZqhHIFDbZ8EkBDjmlmWGHg6BgjVx6lLcMXX4Dcw=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-linux-riscv64-musl": ["@oxc-transform/binding-linux-riscv64-musl@0.131.0", "", { "os": "linux", "cpu": "none" }, "sha512-/rLVLItsBjKrnZFLiGrwRB3fs0dAjXZLqY7F42omvacFJjZsceQ3481oQX1bBs3RwoDDyDy/9ZkIN7kYIkv5Gw=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-linux-s390x-gnu": ["@oxc-transform/binding-linux-s390x-gnu@0.131.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-fUprJgJauI1A7e7cDgY/Z3mwLVtE3aswB4lvS96KpRNDHrwOh8bnCJOWf+0CYveDQzghDVFiZWVDo56pO4Wr9Q=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-linux-x64-gnu": ["@oxc-transform/binding-linux-x64-gnu@0.131.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XdbvDT1GPNxrTLXSRt4RU2uCH112q3nINTT05DZqTYYcAxaCPImnMoZe2TlBv5j2376Gk+2pcVnJs6xut47aSw=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-linux-x64-musl": ["@oxc-transform/binding-linux-x64-musl@0.131.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Du2CxlBfC98EV3hOAmLVSUgP0JgqM9F47lRv9v43T4sGPcQVOjs9wffUybGUUraG9unmBZ4dgpMAqlCq0k3dGw=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-openharmony-arm64": ["@oxc-transform/binding-openharmony-arm64@0.131.0", "", { "os": "none", "cpu": "arm64" }, "sha512-wTj2FkOgNhgdisnA0a15QQksyj6AH2snmpgYgAtj098i477x5LpHHdqfuk60jsA/QHSjmUc6dm4P88yI5GY4xA=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-wasm32-wasi": ["@oxc-transform/binding-wasm32-wasi@0.131.0", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-lE9UaZL0KomAlbATiB6FKoJ9no6W49yXs/MujJqY75AkHHMeOCsHSN9HvriyWz2FOIQgV7C5cmNj0jf+IaBtQg=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-win32-arm64-msvc": ["@oxc-transform/binding-win32-arm64-msvc@0.131.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8KUfPnuxbEfa9H+OQ5XNPFq9JIEWVCg8kczJaD8PvTprr515mz1lmSLSUoOW8mrLaN0mZaGg6pemuvTawOLoPg=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-win32-ia32-msvc": ["@oxc-transform/binding-win32-ia32-msvc@0.131.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-pXSu2A7L6H//1Uvsg5RJHb91BDZpCTho0r9oAwxPqKJM2LWV7Zph/ikWEIXt/YLbKF3WpkHrKQ5hbQGP9gWmHg=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-win32-x64-msvc": ["@oxc-transform/binding-win32-x64-msvc@0.131.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VXgk106WLl3NpBO/6G2gxkWBHguCJm01mGqAq2Q0l2o7hnbglsND0UWSCtM3a9MlsDimfJkLWFQveZu4UtnRvA=="],
+
     "@wyw-in-js/transform/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.15.18", "", { "os": "android", "cpu": "arm" }, "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw=="],
 
     "@wyw-in-js/transform/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.15.18", "", { "os": "linux", "cpu": "none" }, "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-android-arm-eabi": ["@oxc-transform/binding-android-arm-eabi@0.131.0", "", { "os": "android", "cpu": "arm" }, "sha512-rcNvLlbNnxTfYVlZVF+Rev2AyCpJDpwVPphG4HOJxauaT1+w5VxL+kRdxCReof4A8ZsszbvIYlvkqvaJKO4Mog=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-android-arm64": ["@oxc-transform/binding-android-arm64@0.131.0", "", { "os": "android", "cpu": "arm64" }, "sha512-/y+EH6QYQB2ZDQNvMlzItc36mw16GZwCDlvGYbQ4GCTE+7ZtSmx9E/rJOYzYyzMghz0c5dhJquRKScXdOZHpnQ=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-darwin-arm64": ["@oxc-transform/binding-darwin-arm64@0.131.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-x1Va8zFomdYghAI0Zkt7kUmG50S65XH1u0EbIDr80M9idfXrQgd08ZGl3ejwRGLBrkbA8tkkmeOu1rWVFf7BXg=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-darwin-x64": ["@oxc-transform/binding-darwin-x64@0.131.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-EwacackWpYYXGZsl0Aj4NKvDdLuxWZg7LQDneFyMwuftpAxPQLRkHFwZib7r6wpIJm4NELhHW261A4vZ8OQqXQ=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-freebsd-x64": ["@oxc-transform/binding-freebsd-x64@0.131.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-EhXqWOtL1PWcJ3ktdplV4Wrez2PRuTBSDdB7KF6CN4zuZhohUjxC1bxqDNRbNSX46yaZ27IzJLafah1J6mSA8Q=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-linux-arm-gnueabihf": ["@oxc-transform/binding-linux-arm-gnueabihf@0.131.0", "", { "os": "linux", "cpu": "arm" }, "sha512-NfNACr3aqBKeeUh6HCoGGPSjdMkLvyXUZQywCg/DwRkEpqZo55KX65saW1sQdgBcu0SKXrAReTjIm/HDO/OI0Q=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-linux-arm-musleabihf": ["@oxc-transform/binding-linux-arm-musleabihf@0.131.0", "", { "os": "linux", "cpu": "arm" }, "sha512-ABp6KGhbYFGDaAdB4gGZW12DYa55OF/Cu+6Rw6/Di0skuwpiDwnBOLHWz9VBq0QTcREy/qIUOnKW+vZHQLOT8A=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-linux-arm64-gnu": ["@oxc-transform/binding-linux-arm64-gnu@0.131.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-4nKYkHHjRela+jpt+VO4++jxgHoJQFxAeAGtfQ4x11dQMJllzqo3Yu8gfcfLEMsAfflwN/gY+KBbMD/y0exitg=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-linux-arm64-musl": ["@oxc-transform/binding-linux-arm64-musl@0.131.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-cW0Ab1s0sxfiyP1+gdd94f0vUjwGzJF4F3DepF3VnR9nFTGMmFLugwtrBS3DYjTnbugiUH3Fp+16yys1FhNzIA=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-linux-ppc64-gnu": ["@oxc-transform/binding-linux-ppc64-gnu@0.131.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-wunAU/lzE1nPGKL47uI0g+4Nsv/12xveOXNu4M70xe85kNBm7mQdMpZIeoVYCxtXew0iHxFKJDT6qK5mYFSA3w=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-linux-riscv64-gnu": ["@oxc-transform/binding-linux-riscv64-gnu@0.131.0", "", { "os": "linux", "cpu": "none" }, "sha512-r4sMt4OB4TryDcVWW9KnsXOf/ea7tIGX2QASNrpetzPocsBZqhHIFDbZ8EkBDjmlmWGHg6BgjVx6lLcMXX4Dcw=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-linux-riscv64-musl": ["@oxc-transform/binding-linux-riscv64-musl@0.131.0", "", { "os": "linux", "cpu": "none" }, "sha512-/rLVLItsBjKrnZFLiGrwRB3fs0dAjXZLqY7F42omvacFJjZsceQ3481oQX1bBs3RwoDDyDy/9ZkIN7kYIkv5Gw=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-linux-s390x-gnu": ["@oxc-transform/binding-linux-s390x-gnu@0.131.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-fUprJgJauI1A7e7cDgY/Z3mwLVtE3aswB4lvS96KpRNDHrwOh8bnCJOWf+0CYveDQzghDVFiZWVDo56pO4Wr9Q=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-linux-x64-gnu": ["@oxc-transform/binding-linux-x64-gnu@0.131.0", "", { "os": "linux", "cpu": "x64" }, "sha512-XdbvDT1GPNxrTLXSRt4RU2uCH112q3nINTT05DZqTYYcAxaCPImnMoZe2TlBv5j2376Gk+2pcVnJs6xut47aSw=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-linux-x64-musl": ["@oxc-transform/binding-linux-x64-musl@0.131.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Du2CxlBfC98EV3hOAmLVSUgP0JgqM9F47lRv9v43T4sGPcQVOjs9wffUybGUUraG9unmBZ4dgpMAqlCq0k3dGw=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-openharmony-arm64": ["@oxc-transform/binding-openharmony-arm64@0.131.0", "", { "os": "none", "cpu": "arm64" }, "sha512-wTj2FkOgNhgdisnA0a15QQksyj6AH2snmpgYgAtj098i477x5LpHHdqfuk60jsA/QHSjmUc6dm4P88yI5GY4xA=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-wasm32-wasi": ["@oxc-transform/binding-wasm32-wasi@0.131.0", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-lE9UaZL0KomAlbATiB6FKoJ9no6W49yXs/MujJqY75AkHHMeOCsHSN9HvriyWz2FOIQgV7C5cmNj0jf+IaBtQg=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-win32-arm64-msvc": ["@oxc-transform/binding-win32-arm64-msvc@0.131.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8KUfPnuxbEfa9H+OQ5XNPFq9JIEWVCg8kczJaD8PvTprr515mz1lmSLSUoOW8mrLaN0mZaGg6pemuvTawOLoPg=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-win32-ia32-msvc": ["@oxc-transform/binding-win32-ia32-msvc@0.131.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-pXSu2A7L6H//1Uvsg5RJHb91BDZpCTho0r9oAwxPqKJM2LWV7Zph/ikWEIXt/YLbKF3WpkHrKQ5hbQGP9gWmHg=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-win32-x64-msvc": ["@oxc-transform/binding-win32-x64-msvc@0.131.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VXgk106WLl3NpBO/6G2gxkWBHguCJm01mGqAq2Q0l2o7hnbglsND0UWSCtM3a9MlsDimfJkLWFQveZu4UtnRvA=="],
 
     "@wyw-in-js/website/next/@next/env": ["@next/env@13.5.11", "", {}, "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg=="],
 
@@ -4397,6 +4485,14 @@
     "@rsbuild/plugin-babel/@babel/plugin-transform-class-properties/@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@vitejs/plugin-react/@babel/core/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@wyw-in-js/esbuild/oxc-transform/@oxc-transform/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@wyw-in-js/transform/oxc-transform/@oxc-transform/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "babel-plugin-module-resolver/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@wyw-in-js/shared": "workspace:*",
     "@wyw-in-js/transform": "workspace:*",
-    "oxc-transform": "0.127.0"
+    "oxc-transform": "0.131.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -9,9 +9,9 @@
     "cosmiconfig": "^8.0.0",
     "happy-dom": "^20.1.0",
     "minimatch": "^9.0.5",
-    "oxc-parser": "0.127.0",
+    "oxc-parser": "0.131.0",
     "oxc-resolver": "11.19.1",
-    "oxc-transform": "0.127.0",
+    "oxc-transform": "0.131.0",
     "source-map": "^0.7.4",
     "stylis": "^4.3.0",
     "ts-invariant": "^0.10.3"

--- a/packages/transform/src/utils/EventEmitter.ts
+++ b/packages/transform/src/utils/EventEmitter.ts
@@ -121,6 +121,13 @@ export class EventEmitter {
     entrypointRef: string,
     fn: () => TRes
   ) {
+    // Fast path: when the emitter is disabled (the dummy used by the
+    // production transform path) skip start/finish bookkeeping and the
+    // Promise hookup. action() is on the hot path for every step of every
+    // action — its per-call overhead is small but ubiquitous.
+    if (!this.enabled) {
+      return fn();
+    }
     const id = this.onAction(
       'start',
       performance.now(),
@@ -152,6 +159,12 @@ export class EventEmitter {
   }
 
   public perf<TRes>(method: string, fn: () => TRes): TRes {
+    // Fast path: see action() above. perf() wraps ~28s of cumulative time
+    // in the production-path CPU profile; the wrapper overhead per call is
+    // small but everywhere.
+    if (!this.enabled) {
+      return fn();
+    }
     const spanId = this.perfSpanId;
     this.perfSpanId += 1;
     const startedAt = performance.now();

--- a/packages/transform/src/utils/applyOxcProcessors/cleanupRemovals.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/cleanupRemovals.ts
@@ -746,19 +746,19 @@ export const removeUnusedAfterReplacement = (
   preserveSideEffectImportLocals: Set<string>
 ): string => {
   let current = code;
+  let program: Program | null = null;
   const cumulativeRemovableNames = new Set(initialRemovableNames);
-  const applyIfParsable = (next: string): string => {
-    try {
-      parseOxc(next, filename);
-      return next;
-    } catch {
-      return current;
-    }
-  };
 
+  // Incremental cleanup loop: validate-by-parsing the next iteration's
+  // candidate code AND reuse that parse as the next iter's `program` input,
+  // instead of re-parsing at the top of the next iter. Saves one parse per
+  // loop revolution (N+1 parses for an N-iter loop instead of 2N).
+  // Also short-circuits a round earlier when no removals were collected.
   for (let idx = 0; idx < 5; idx += 1) {
     const previous = current;
-    const program = parseOxc(current, filename);
+    if (program === null) {
+      program = parseOxc(current, filename);
+    }
     const statements = collectTopLevelStatementInfos(program);
     const removableNames = collectRemovableNamesFromStatements(
       statements,
@@ -800,10 +800,22 @@ export const removeUnusedAfterReplacement = (
       ),
       ...collectEmptyTopLevelBlockRemovals(current, program),
     ]);
-    current =
-      removals.length > 0
-        ? applyIfParsable(applyOxcReplacements(current, removals))
-        : current;
+
+    if (removals.length === 0) {
+      // Convergence: next iter would parse the same code and see the same
+      // removable set. Skip the round of walks + parse.
+      return current;
+    }
+
+    const next = applyOxcReplacements(current, removals);
+    try {
+      // Validate + capture the AST for the next iteration in one parse.
+      program = parseOxc(next, filename);
+      current = next;
+    } catch {
+      // Pathological removal — drop this iteration and return prior state.
+      return current;
+    }
 
     if (current === previous) {
       return current;

--- a/packages/transform/src/utils/collectOxcExportsAndImports.ts
+++ b/packages/transform/src/utils/collectOxcExportsAndImports.ts
@@ -1337,6 +1337,18 @@ const getChildren = (node: Node): { key: string; node: Node }[] => {
 };
 
 const precollectRequireSources = (node: Node, state: AnalyzerState): void => {
+  // Cheap text precheck at the Program entry: if the file body has no
+  // 'require(' substring there can be no CommonJS require() init to collect.
+  // Skip the full AST walk — meaningful saving on ESM-only modules in large
+  // monorepos. Done at Program-level only so nested recursion doesn't pay
+  // the indexOf cost per node.
+  if (
+    node.type === 'Program' &&
+    state.code.indexOf('require(') === -1
+  ) {
+    return;
+  }
+
   if (node.type === 'VariableDeclarator' && node.id.type === 'Identifier') {
     const source = node.init ? sourceFromRequireSyntax(node.init) : null;
     if (source) {

--- a/packages/transform/src/utils/oxc/ast.ts
+++ b/packages/transform/src/utils/oxc/ast.ts
@@ -8,39 +8,54 @@ export const isOxcNode = (value: unknown): value is Node =>
   'type' in value &&
   typeof (value as { type?: unknown }).type === 'string';
 
+// Cache visitor-key lists per node.type. oxc-parser AST nodes have a stable
+// shape per `type` — optional children are present as null/undefined, not
+// omitted — so Object.keys() returns the same key set for every instance of
+// the same kind. First instance pays the discovery cost; the rest do an
+// indexed lookup. getOxcNodeChildren is invoked tens of millions of times
+// on a cold build of a large monorepo, so this matters a lot.
+//
+// An instance-level WeakMap cache of the resulting Node[] was tried and
+// regressed wall time ~20% (WeakMap.get/set per call beat the recompute
+// savings for small children arrays + pinned arrays into older generations
+// and increased GC pressure). Per-type key cache only.
+const META_KEYS = new Set([
+  'comments',
+  'end',
+  'errors',
+  'parent',
+  'range',
+  'span',
+  'start',
+  'type',
+]);
+const VISITOR_KEYS_BY_TYPE = new Map<string, readonly string[]>();
+const visitorKeysFor = (node: AnyOxcNode): readonly string[] => {
+  let keys = VISITOR_KEYS_BY_TYPE.get(node.type);
+  if (keys === undefined) {
+    keys = Object.keys(node).filter((key) => !META_KEYS.has(key));
+    VISITOR_KEYS_BY_TYPE.set(node.type, keys);
+  }
+  return keys;
+};
+
 export const getOxcNodeChildren = (node: Node): Node[] => {
   const result: Node[] = [];
   const record = node as AnyOxcNode;
-
-  Object.keys(record).forEach((key) => {
-    if (
-      key === 'comments' ||
-      key === 'end' ||
-      key === 'errors' ||
-      key === 'parent' ||
-      key === 'range' ||
-      key === 'span' ||
-      key === 'start' ||
-      key === 'type'
-    ) {
-      return;
-    }
-
-    const value = record[key];
+  const keys = visitorKeysFor(record);
+  for (let i = 0; i < keys.length; i += 1) {
+    const value = record[keys[i]];
     if (isOxcNode(value)) {
       result.push(value);
-      return;
-    }
-
-    if (Array.isArray(value)) {
-      value.forEach((item) => {
+    } else if (Array.isArray(value)) {
+      for (let j = 0; j < value.length; j += 1) {
+        const item = value[j];
         if (isOxcNode(item)) {
           result.push(item);
         }
-      });
+      }
     }
-  });
-
+  }
   return result;
 };
 
@@ -50,5 +65,8 @@ export const walkOxc = (
   parent: Node | null = null
 ): void => {
   enter(node, parent);
-  getOxcNodeChildren(node).forEach((child) => walkOxc(child, enter, node));
+  const children = getOxcNodeChildren(node);
+  for (let i = 0; i < children.length; i += 1) {
+    walkOxc(children[i], enter, node);
+  }
 };

--- a/packages/transform/src/utils/oxcPreevalTransforms.ts
+++ b/packages/transform/src/utils/oxcPreevalTransforms.ts
@@ -12,6 +12,7 @@ import type { CodeRemoverOptions } from '@wyw-in-js/shared';
 
 import { collectOxcExportsAndImports } from './collectOxcExportsAndImports';
 import { EventEmitter } from './EventEmitter';
+import { getOxcNodeChildren } from './oxc/ast';
 import { parseOxcProgramCached } from './parseOxc';
 
 type AnyNode = Node & Record<string, unknown>;
@@ -169,32 +170,11 @@ const isNode = (value: unknown): value is Node =>
   'type' in value &&
   typeof (value as { type?: unknown }).type === 'string';
 
-const getChildren = (node: Node): Node[] => {
-  const result: Node[] = [];
-  const record = node as AnyNode;
-
-  Object.keys(record).forEach((key) => {
-    if (key === 'type' || key === 'start' || key === 'end' || key === 'range') {
-      return;
-    }
-
-    const value = record[key];
-    if (isNode(value)) {
-      result.push(value);
-      return;
-    }
-
-    if (Array.isArray(value)) {
-      value.forEach((item) => {
-        if (isNode(item)) {
-          result.push(item);
-        }
-      });
-    }
-  });
-
-  return result;
-};
+// Reuses the per-node.type visitor-key cache in utils/oxc/ast.ts. This file's
+// getChildren shape historically diverged from the canonical one (a smaller
+// metadata-key skip set), but the produced children list is identical in
+// practice because oxc-parser nodes don't carry the extra metadata fields.
+const getChildren = getOxcNodeChildren;
 
 const parseOxc = (code: string, filename: string): Program => {
   return parseOxcProgramCached(filename, code, 'unambiguous');
@@ -523,78 +503,97 @@ const predeclareScopeNames = (node: Node, scope: Scope): void => {
   }
 
   const visitScopeDescendants = (child: Node): void => {
-    if (child.type === 'VariableDeclarator') {
-      collectBindingNames(child.id).forEach((name) => {
-        scope.names.add(name);
-      });
-    } else if (child.type === 'FunctionDeclaration' && child.id) {
-      scope.names.add(child.id.name);
-    } else if (child.type === 'ClassDeclaration' && child.id) {
-      scope.names.add(child.id.name);
-    } else if (
-      child.type === 'ImportDefaultSpecifier' ||
-      child.type === 'ImportNamespaceSpecifier' ||
-      child.type === 'ImportSpecifier'
-    ) {
-      scope.names.add(child.local.name);
+    switch (child.type) {
+      case 'VariableDeclarator': {
+        const names = collectBindingNames(child.id);
+        for (let i = 0; i < names.length; i += 1) {
+          scope.names.add(names[i]);
+        }
+        break;
+      }
+      case 'FunctionDeclaration':
+      case 'ClassDeclaration':
+        if (child.id) {
+          scope.names.add(child.id.name);
+        }
+        break;
+      case 'ImportDefaultSpecifier':
+      case 'ImportNamespaceSpecifier':
+      case 'ImportSpecifier':
+        scope.names.add(child.local.name);
+        break;
     }
 
     if (createsScope(child)) {
       return;
     }
 
-    getChildren(child).forEach(visitScopeDescendants);
+    const children = getChildren(child);
+    for (let i = 0; i < children.length; i += 1) {
+      visitScopeDescendants(children[i]);
+    }
   };
 
-  getChildren(node).forEach(visitScopeDescendants);
+  const rootChildren = getChildren(node);
+  for (let i = 0; i < rootChildren.length; i += 1) {
+    visitScopeDescendants(rootChildren[i]);
+  }
 };
 
 const declareBindings = (node: Node, scope: Scope): void => {
-  if (node.type === 'VariableDeclarator') {
-    const names = collectBindingNames(node.id);
-    names.forEach((name) => {
-      scope.names.add(name);
-      scope.bindings.set(name, null);
-    });
-
-    if (node.id.type === 'Identifier' && node.init) {
-      scope.bindings.set(node.id.name, node.init);
-    }
-    return;
-  }
-
-  if (node.type === 'FunctionDeclaration' && node.id) {
-    scope.names.add(node.id.name);
-    scope.bindings.set(node.id.name, null);
-  }
-
-  if (node.type === 'ClassDeclaration' && node.id) {
-    scope.names.add(node.id.name);
-    scope.bindings.set(node.id.name, null);
-    return;
-  }
-
-  if (
-    node.type === 'ImportDefaultSpecifier' ||
-    node.type === 'ImportNamespaceSpecifier' ||
-    node.type === 'ImportSpecifier'
-  ) {
-    scope.names.add(node.local.name);
-    scope.bindings.set(node.local.name, null);
-    return;
-  }
-
-  if (
-    node.type === 'FunctionDeclaration' ||
-    node.type === 'FunctionExpression' ||
-    node.type === 'ArrowFunctionExpression'
-  ) {
-    node.params.forEach((param) => {
-      collectBindingNames(param).forEach((name) => {
+  // Called for every visited AST node, so the dispatch is hot. A switch lets
+  // V8 generate a jump table on node.type; the previous chained `if`s walked
+  // each branch's string-compare for every non-matching node.
+  switch (node.type) {
+    case 'VariableDeclarator': {
+      const names = collectBindingNames(node.id);
+      for (let i = 0; i < names.length; i += 1) {
+        const name = names[i];
         scope.names.add(name);
         scope.bindings.set(name, null);
-      });
-    });
+      }
+      if (node.id.type === 'Identifier' && node.init) {
+        scope.bindings.set(node.id.name, node.init);
+      }
+      return;
+    }
+    case 'ClassDeclaration': {
+      if (node.id) {
+        scope.names.add(node.id.name);
+        scope.bindings.set(node.id.name, null);
+      }
+      return;
+    }
+    case 'ImportDefaultSpecifier':
+    case 'ImportNamespaceSpecifier':
+    case 'ImportSpecifier': {
+      scope.names.add(node.local.name);
+      scope.bindings.set(node.local.name, null);
+      return;
+    }
+    case 'FunctionDeclaration': {
+      if (node.id) {
+        scope.names.add(node.id.name);
+        scope.bindings.set(node.id.name, null);
+      }
+      // Fall through to declare params.
+    }
+    // eslint-disable-next-line no-fallthrough
+    case 'FunctionExpression':
+    case 'ArrowFunctionExpression': {
+      const params = node.params;
+      for (let i = 0; i < params.length; i += 1) {
+        const names = collectBindingNames(params[i]);
+        for (let j = 0; j < names.length; j += 1) {
+          const name = names[j];
+          scope.names.add(name);
+          scope.bindings.set(name, null);
+        }
+      }
+      return;
+    }
+    default:
+      return;
   }
 };
 
@@ -619,9 +618,17 @@ const visit = (
   declareBindings(node, currentScope);
   enter(node, currentScope, parent, ancestors);
 
-  getChildren(node).forEach((child) =>
-    visit(child, currentScope, enter, node, [...ancestors, node])
-  );
+  // Push onto a shared ancestors stack instead of allocating `[...ancestors,
+  // node]` per child step (O(n × depth) extra allocation on deep ASTs).
+  // Every consumer of `ancestors` in this file reads it synchronously inside
+  // the enter callback; future callers that need to retain the reference
+  // must .slice() it themselves.
+  ancestors.push(node);
+  const children = getChildren(node);
+  for (let i = 0; i < children.length; i += 1) {
+    visit(children[i], currentScope, enter, node, ancestors);
+  }
+  ancestors.pop();
 };
 
 export const replaceImportMetaEnvWithOxc = (

--- a/packages/transform/src/utils/parseOxc.ts
+++ b/packages/transform/src/utils/parseOxc.ts
@@ -10,7 +10,12 @@ type ParsedOxc = {
   program: Program;
 };
 
-const MAX_PARSE_CACHE_ENTRIES = 200;
+// 200 evicts under sustained pressure on large monorepos — the
+// removeUnusedAfterReplacement cleanup loop reparses on every iteration
+// (new content -> new key) and applyOxcProcessors reparses after extraction.
+// 1000 is still bounded (~50-100 MB worst case for an enormous build) and
+// keeps every entry hot across the actions for a single file.
+const MAX_PARSE_CACHE_ENTRIES = 1000;
 const parseCache = new Map<string, ParsedOxc>();
 
 const getAstType = (filename: string): 'js' | 'ts' =>


### PR DESCRIPTION
## Summary

Four perf-focused commits on top of v2, informed by CPU + heap profiling of
\`webpack build --mode development\` against a ~17k-module consumer app (cold
cache, single-build cpuprofile + interleaved 3-pass WYW_BENCH).

### Commits

1. **\`4e602061\` — visitor-key cache, mutable ancestors stack, EventEmitter fast path**
   - Cache the visitor-key list per \`node.type\` in every utils file's local \`getChildren\` (the profile attributed ~0.66s self to the equivalent Object.keys+filter helper across tens of millions of invocations; oxc AST nodes have a stable shape per \`type\` so the discovery is once-per-kind).
   - \`oxcPreevalTransforms.visit\` recursed with \`[...ancestors, node]\` per child step (O(n × depth) allocation). Replaced with push/pop on a shared stack. Audit confirmed no enter-callback captures the array reference.
   - \`EventEmitter.action()\` and \`.perf()\` now early-return \`fn()\` when \`this.enabled === false\` (the dummy emitter used by the production path). \`perf\` wraps ~28s of cumulative time in the profile; the wrapper overhead per call was small but ubiquitous.
   - Also: \`declareBindings\` → switch jump table; \`forEach\`/\`for..of\` → \`for (i < len)\` in the three hottest visitors (\`visit\` in collectOxcExportsAndImports, \`visitScopeDescendants\` in oxcPreevalTransforms, \`visitNode\` in collectOxcTemplateDependencies).
   - \`parseOxc\` LRU bumped 200 → 1000 (the cleanup-loop in (3) reparses on each iter; 200 evicts under sustained pressure on large monorepos).
   - \`precollectRequireSources\` now has a \`require(\` text precheck at Program-level so ESM-only files skip the full AST walk.

2. **\`f742c9b9\` — shared \`utils/oxcChildren.ts\` helper**
   - Lifts the per-\`node.type\` key cache out of eight duplicated local \`getChildren\` implementations into one module with a generic \`getOxcChildren<T extends OxcNodeLike>(n): readonly T[]\` plus an exported \`visitorKeysFor\` that the tuple-returning callers (\`collectOxcExportsAndImports\`, \`collectOxcRuntime\`, \`oxcBarrelManifest\`) consume.
   - **A per-node WeakMap children-result cache was tried in this commit's first version and reverted** — it regressed wall time by ~20%. The WeakMap.get/set overhead per call beat the recompute savings for small children arrays, and the cached arrays pinned into older generations and increased GC pressure. Per-type key cache stays; the materialised \`Node[]\` is rebuilt per call.

3. **\`33eb3ce1\` — forward-feed Program in \`removeUnusedAfterReplacement\` cleanup loop**
   - The cleanup loop used to parse twice per iteration: once at the top, once inside \`applyIfParsable(applyReplacements(...))\` to verify. The validate-parse of iter N is the same Program iter N+1 would re-parse from scratch — now forward-fed.
   - Saves ~one parse per iteration. For a 5-iter loop: 6 parses instead of 10.
   - Also exits a round earlier when \`removals.length === 0\` (the next iter would walk the same AST and find nothing new).

4. **\`7f95c98c\` — bump oxc-parser / oxc-transform 0.127.0 → 0.131.0**
   - Single-build CPU profile shows wyw self time **−10.5%** (13.29s → 11.89s), oxc preeval transforms specifically **−20.5%**, parse phase **−17.8%**.
   - Heap allocations are essentially flat (1.56GB → 1.59GB).

## Bench numbers

\`WYW_BENCH=1 WYW_NO_PATCH=1\`, 3 passes per state, walked via \`jj edit\` for consistent OS state (consumer app: ~17k modules). All commits land cumulative — each delta is mean over 3 passes.

| state | total | wyw transform phase | wyw collect phase |
|---|---:|---:|---:|
| unpatched (published 2.0.0-alpha.1) | 63.17s | 13.47s | 8.67s |
| + \`4e602061\` micro-opts | 63.30s | 13.37s | 8.77s |
| + \`f742c9b9\` shared helper | 61.00s | 12.77s | 8.70s |
| + \`33eb3ce1\` cleanup-loop | 59.90s | 12.87s | 8.43s |
| + \`7f95c98c\` oxc 0.131 | **57.93s** | **12.20s** | **8.20s** |
| **cumulative Δ** | **−8.3%** | **−9.4%** | **−5.4%** |

CPU-profile-attributed wyw self time (single-build, less noisy than the per-pass wall time): **14.34s → 11.89s = −17.1%** across the four commits.

## Test plan

- [x] \`bun test src\` in \`@wyw-in-js/transform\`: **750 pass / 8 pre-existing fails**, identical before and after (\`git stash\` bisect)
- [x] cold webpack dev build of a real consumer app: completes successfully
- [x] CPU + heap profiles taken at each commit; no phase regresses
- [x] interleaved WYW_BENCH 3-pass walk shows cumulative −8.3% wall, −9.4% transform