### PR TITLE
fix(transform): avoid duplicate same-file processor CSS

### DIFF
--- a/.changeset/quiet-rings-reflect.md
+++ b/.changeset/quiet-rings-reflect.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/transform": patch
+---
+
+Avoid extracting duplicate CSS rules for same-file processor bindings that are referenced from another processor template inside a local scope.

--- a/packages/transform/src/__tests__/applyOxcProcessors.test.ts
+++ b/packages/transform/src/__tests__/applyOxcProcessors.test.ts
@@ -326,6 +326,38 @@ describe('applyOxcProcessors', () => {
     expect(result.code).toContain('return keep + cls;');
   });
 
+  it('does not create processors from hoisted same-file processor dependencies', () => {
+    const result = applyOxcProcessors(
+      `
+        import { css } from 'test-package';
+        function Component() {
+          const outer = css\`
+            color: red;
+          \`;
+          const inner = css\`
+            color: green;
+            .${'${outer}'} {
+              color: blue;
+            }
+          \`;
+          return outer + inner;
+        }
+      `,
+      fileContext,
+      {
+        ...options(processorPath),
+        eval: { strategy: 'hybrid' },
+      },
+      (processor) => processor.doEvaltimeReplacement(),
+      true
+    );
+
+    expect(result.processors.map((processor) => processor.displayName)).toEqual(
+      ['outer', 'inner']
+    );
+    expect(result.code).not.toContain('_outer');
+  });
+
   it('does not emit pure annotation for non-call replacements', () => {
     const result = applyOxcProcessors(
       `

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/expressionExtraction.ts
@@ -491,10 +491,12 @@ const extractExpression = (
         hasNonStaticLocalReference = true;
       }
 
-      assertHoistable(binding, ctx);
-      addHoistedDeclaration(binding, ctx);
-      if (!binding.isRoot && binding.declarator?.id.type === 'Identifier') {
-        identifierReplacements.set(name, getHoistedBindingName(binding, ctx));
+      if (!isProcessorManagedLocal) {
+        assertHoistable(binding, ctx);
+        addHoistedDeclaration(binding, ctx);
+        if (!binding.isRoot && binding.declarator?.id.type === 'Identifier') {
+          identifierReplacements.set(name, getHoistedBindingName(binding, ctx));
+        }
       }
     }
   );


### PR DESCRIPTION
## Summary

Fix duplicate CSS extraction when a same-file processor binding is referenced from another processor template inside a local scope.

## Root Cause

During Oxc template dependency extraction, processor-managed locals such as `const outer = css``...`` were hoisted into synthetic bindings like `_outer`. `applyOxcProcessors` then reparsed the rewritten code and collected both the synthetic `_outer` processor and the real `outer` processor, which emitted duplicate CSS while runtime code only referenced the real class name.

## Changes

- Skip hoisting processor-managed local bindings during static expression extraction.
- Keep same-file processor values available through inline constants.
- Add a regression test that asserts only the real `outer` and `inner` processors are created.

## Validation

- `bun test src/__tests__/applyOxcProcessors.test.ts`
- `bun test src/utils/__tests__/collectOxcTemplateDependencies.test.ts src/__tests__/collectOxcTemplateDependencies.test.ts`
- `bun run --filter @wyw-in-js/transform build:types`