### PR TITLE
fix(transform): evaluate mixed processor object members

### DIFF
--- a/.changeset/stale-bikes-fold.md
+++ b/.changeset/stale-bikes-fold.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/transform": patch
+---
+
+Fix static evaluation of object member interpolations when sibling object properties contain same-file processor templates.

--- a/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.test.ts
+++ b/packages/transform/src/utils/__tests__/collectOxcTemplateDependencies.test.ts
@@ -275,6 +275,30 @@ describe('collectOxcTemplateDependencies', () => {
     expect(result.code).not.toContain('let val =');
   });
 
+  it('statically evaluates object members with processor-managed siblings', () => {
+    const code = dedent`
+      import { css } from "test-package";
+
+      function Component() {
+        const classes = {
+          value: 0.2,
+          cell: css\`
+            opacity: 0;
+          \`,
+        };
+        const template = tag\`${'${classes.value}'}\`;
+      }
+    `;
+
+    const result = collectOxcTemplateDependencies(code, filename, true);
+
+    expect(result.code).toContain('const _exp = () => (0.2);');
+    expect(result.staticValues).toEqual(
+      expect.arrayContaining([{ name: '_exp', value: 0.2 }])
+    );
+    expect(result.staticValueCandidates).toEqual([]);
+  });
+
   it('statically evaluates simple local function calls', () => {
     const code = dedent`
       const size = () => 5;

--- a/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
+++ b/packages/transform/src/utils/collectOxcTemplateDependencies/staticEvaluator.ts
@@ -86,6 +86,102 @@ const getObjectMember = (
   return (objectValue as Record<string | number, unknown>)[property];
 };
 
+const staticObjectPropertyKey = (
+  property: Node & { computed?: boolean; key?: Node },
+  ctx: ExtractionContext,
+  env: EvalEnv,
+  stack: string[]
+): string | number | null => {
+  if (!property.key) {
+    return null;
+  }
+
+  let key: unknown;
+  if (property.computed) {
+    key = evaluateStatic(property.key as Expression, ctx, env, stack);
+  } else if (property.key.type === 'Identifier') {
+    key = property.key.name;
+  } else if (property.key.type === 'Literal') {
+    key = property.key.value;
+  }
+
+  return typeof key === 'string' || typeof key === 'number' ? key : null;
+};
+
+const evaluateObjectExpressionMember = (
+  expression: Expression,
+  propertyKey: string | number,
+  ctx: ExtractionContext,
+  env: EvalEnv,
+  stack: string[]
+): unknown | undefined => {
+  if (expression.type !== 'ObjectExpression') {
+    return undefined;
+  }
+
+  for (let idx = expression.properties.length - 1; idx >= 0; idx -= 1) {
+    const property = expression.properties[idx]!;
+    if (property.type === 'SpreadElement') {
+      return undefined;
+    }
+
+    const key = staticObjectPropertyKey(property, ctx, env, stack);
+    if (key === null) {
+      return undefined;
+    }
+
+    if (key === propertyKey) {
+      return evaluateStatic(property.value, ctx, env, stack);
+    }
+  }
+
+  return undefined;
+};
+
+const evaluateKnownObjectMember = (
+  expression: Expression,
+  propertyKey: string | number,
+  ctx: ExtractionContext,
+  env: EvalEnv,
+  stack: string[]
+): unknown | undefined => {
+  const objectMember = evaluateObjectExpressionMember(
+    expression,
+    propertyKey,
+    ctx,
+    env,
+    stack
+  );
+  if (objectMember !== undefined) {
+    return objectMember;
+  }
+
+  if (expression.type !== 'Identifier' || env.has(expression.name)) {
+    return undefined;
+  }
+
+  const binding = resolveBindingAt(ctx, expression.name, expression.start);
+  if (
+    !binding ||
+    binding.kind === 'param' ||
+    binding.importedFrom ||
+    binding.isRoot ||
+    stack.includes(binding.name) ||
+    !binding.declarator?.init ||
+    binding.declarator.id.type !== 'Identifier'
+  ) {
+    return undefined;
+  }
+
+  return evaluateKnownObjectMember(
+    binding.declarator.init,
+    propertyKey,
+    ctx,
+    env,
+    [...stack, binding.name]
+  );
+};
+
 type EvalEnv = Map<string, unknown>;
 
 const oxcStaticCallableValue = Symbol('wyw.oxc.staticCallableValue');
@@ -765,6 +861,17 @@ export const evaluateStatic = (
       // happens to be set on the build machine; falling back to the
       // ?? / || branch (or a runtime read) is more predictable.
       return undefined;
+    }
+
+    const knownObjectMember = evaluateKnownObjectMember(
+      expression.object as Expression,
+      key,
+      ctx,
+      env,
+      stack
+    );
+    if (knownObjectMember !== undefined) {
+      return knownObjectMember;
     }
 
     const objectValue = evaluateStatic(expression.object, ctx, env, stack);


### PR DESCRIPTION
Fixes a regression introduced by the 2.0.1 same-file processor CSS fix.

When an object mixes a processor-managed member and a plain static member, for example:

```ts
const classes = {
  value: 0.2,
  cell: css`opacity: 0;`,
};

css`opacity: ${classes.value};`
```

2.0.1 treated the whole object binding as processor-managed and left `classes.value` in the eval candidate, where the local `classes` binding is unavailable. The static evaluator now resolves known object members directly without requiring sibling processor-template properties to be evaluated.

Changes:
- Add regression coverage for object member interpolation with processor-managed sibling properties.
- Lazily evaluate known object literal members before falling back to whole-object evaluation.
- Add a patch changeset for `@wyw-in-js/transform`.

Validation:
- `bun test src` from `packages/transform`: 772 pass, 1 skip, 0 fail.
- `bun run --filter @wyw-in-js/transform build:types`.
- `bun run --filter @wyw-in-js/transform lint`.
- Verified the Linaria failure locally with this transform build: `pnpm --filter @linaria/testkit test -- src/babel.test.ts -t "complex interpolation inside components"`.