### PR TITLE
fix(nextjs): emit WyW CSS through Turbopack query (#324)

### DIFF
--- a/.changeset/fix-next-turbopack-query-css.md
+++ b/.changeset/fix-next-turbopack-query-css.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/nextjs': patch
+'@wyw-in-js/turbopack-loader': patch
+---
+
+Fix Next.js Turbopack production builds by routing generated WyW CSS through a Turbopack query loader path on versions that support query conditions, while preserving sidecar output as the fallback for older Turbopack configs.

--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
     },
     "apps/website": {
       "name": "@wyw-in-js/website",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0",
       "dependencies": {
         "next": "^13.5.4",
         "nextra": "^2.13.1",
@@ -76,15 +76,15 @@
     },
     "configs/eslint": {
       "name": "@wyw-in-js/eslint-config",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0",
     },
     "configs/ts": {
       "name": "@wyw-in-js/ts-config",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0",
     },
     "crates/wyw_sample_processor": {
       "name": "@wyw-in-js/sample-processor",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
       },
@@ -115,11 +115,11 @@
     },
     "e2e/next-turbopack": {
       "name": "@wyw-in-js/e2e-next-turbopack",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-alpha.2",
       "dependencies": {
         "@wyw-in-js/nextjs": "workspace:*",
         "@wyw-in-js/template-tag-syntax": "workspace:*",
-        "next": "^16.0.0",
+        "next": "^16.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },
@@ -129,7 +129,7 @@
     },
     "e2e/next-webpack": {
       "name": "@wyw-in-js/e2e-next-webpack",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-alpha.2",
       "dependencies": {
         "@wyw-in-js/nextjs": "workspace:*",
         "@wyw-in-js/template-tag-syntax": "workspace:*",
@@ -199,7 +199,7 @@
     },
     "examples/nextjs-wyw-demo": {
       "name": "nextjs-wyw-demo",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-alpha.2",
       "dependencies": {
         "@linaria/core": "^6.0.0",
         "@linaria/react": "^6.0.0",
@@ -233,7 +233,7 @@
     },
     "examples/rsbuild-issue-256": {
       "name": "rsbuild-issue-256-repro",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-alpha.2",
       "dependencies": {
         "@rsbuild/core": "^1.2.19",
         "@rsbuild/plugin-babel": "^1.0.3",
@@ -260,7 +260,7 @@
     },
     "examples/vite-react-refresh": {
       "name": "vite-react-refresh-repro",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-alpha.2",
       "dependencies": {
         "@vitejs/plugin-react": "^5.0.3",
         "@wyw-in-js/template-tag-syntax": "workspace:*",
@@ -272,7 +272,7 @@
     },
     "packages/babel-preset": {
       "name": "@wyw-in-js/babel-preset",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.2",
       "dependencies": {
         "@babel/core": "^7.23.5",
         "@wyw-in-js/shared": "workspace:*",
@@ -287,7 +287,7 @@
     },
     "packages/bun": {
       "name": "@wyw-in-js/bun",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.2",
       "dependencies": {
         "@rollup/pluginutils": "^5.1.4",
         "@wyw-in-js/shared": "workspace:*",
@@ -302,7 +302,7 @@
     },
     "packages/cli": {
       "name": "@wyw-in-js/cli",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.2",
       "bin": {
         "wyw-in-js": "bin/wyw-in-js.js",
       },
@@ -324,7 +324,7 @@
     },
     "packages/esbuild": {
       "name": "@wyw-in-js/esbuild",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.2",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
         "@wyw-in-js/transform": "workspace:*",
@@ -342,7 +342,7 @@
     },
     "packages/nextjs": {
       "name": "@wyw-in-js/nextjs",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.2",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
         "@wyw-in-js/turbopack-loader": "workspace:*",
@@ -362,7 +362,7 @@
     },
     "packages/parcel-transformer": {
       "name": "@wyw-in-js/parcel-transformer",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.2",
       "dependencies": {
         "@parcel/plugin": "^2.16.3",
         "@parcel/source-map": "^2.1.1",
@@ -380,7 +380,7 @@
     },
     "packages/processor-utils": {
       "name": "@wyw-in-js/processor-utils",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
       },
@@ -393,7 +393,7 @@
     },
     "packages/rollup": {
       "name": "@wyw-in-js/rollup",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.2",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.5",
         "@wyw-in-js/shared": "workspace:*",
@@ -412,7 +412,7 @@
     },
     "packages/shared": {
       "name": "@wyw-in-js/shared",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0",
       "dependencies": {
         "debug": "^4.3.4",
         "find-up": "^5.0.0",
@@ -428,7 +428,7 @@
     },
     "packages/transform": {
       "name": "@wyw-in-js/transform",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.2",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "@wyw-in-js/processor-utils": "workspace:*",
@@ -459,7 +459,7 @@
     },
     "packages/turbopack-loader": {
       "name": "@wyw-in-js/turbopack-loader",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.2",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
         "@wyw-in-js/transform": "workspace:*",
@@ -474,7 +474,7 @@
     },
     "packages/vite": {
       "name": "@wyw-in-js/vite",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.2",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
         "@wyw-in-js/transform": "workspace:*",
@@ -492,7 +492,7 @@
     },
     "packages/webpack-loader": {
       "name": "@wyw-in-js/webpack-loader",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.2",
       "dependencies": {
         "@wyw-in-js/shared": "workspace:*",
         "@wyw-in-js/transform": "workspace:*",
@@ -996,25 +996,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
-    "@next/env": ["@next/env@16.1.1", "", {}, "sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA=="],
+    "@next/env": ["@next/env@16.2.9", "", {}, "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.1.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.1.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.9", "", { "os": "linux", "cpu": "x64" }, "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.9", "", { "os": "linux", "cpu": "x64" }, "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.1.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ=="],
 
     "@next/swc-win32-ia32-msvc": ["@next/swc-win32-ia32-msvc@13.5.9", "", { "os": "win32", "cpu": "ia32" }, "sha512-BLiPKJomaPrTAb7ykjA0LPcuuNMLDVK177Z1xe0nAem33+9FIayU4k/OWrtSn9SAJW/U60+1hoey5z+KCHdRLQ=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.1.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.9", "", { "os": "win32", "cpu": "x64" }, "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w=="],
 
     "@nicolo-ribaudo/eslint-scope-5-internals": ["@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1", "", { "dependencies": { "eslint-scope": "5.1.1" } }, "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg=="],
 
@@ -1756,7 +1756,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.9.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.38", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
@@ -2690,7 +2690,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "next": ["next@16.1.1", "", { "dependencies": { "@next/env": "16.1.1", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.1", "@next/swc-darwin-x64": "16.1.1", "@next/swc-linux-arm64-gnu": "16.1.1", "@next/swc-linux-arm64-musl": "16.1.1", "@next/swc-linux-x64-gnu": "16.1.1", "@next/swc-linux-x64-musl": "16.1.1", "@next/swc-win32-arm64-msvc": "16.1.1", "@next/swc-win32-x64-msvc": "16.1.1", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w=="],
+    "next": ["next@16.2.9", "", { "dependencies": { "@next/env": "16.2.9", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.9", "@next/swc-darwin-x64": "16.2.9", "@next/swc-linux-arm64-gnu": "16.2.9", "@next/swc-linux-arm64-musl": "16.2.9", "@next/swc-linux-x64-gnu": "16.2.9", "@next/swc-linux-x64-musl": "16.2.9", "@next/swc-win32-arm64-msvc": "16.2.9", "@next/swc-win32-x64-msvc": "16.2.9", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww=="],
 
     "next-mdx-remote": ["next-mdx-remote@4.4.1", "", { "dependencies": { "@mdx-js/mdx": "^2.2.1", "@mdx-js/react": "^2.2.1", "vfile": "^5.3.0", "vfile-matter": "^3.0.1" }, "peerDependencies": { "react": ">=16.x <=18.x", "react-dom": ">=16.x <=18.x" } }, "sha512-1BvyXaIou6xy3XoNF4yaMZUCb6vD2GTAa5ciOa6WoO+gAUTYsb1K4rI/HSC2ogAWLrb/7VSV52skz07vOzmqIQ=="],
 
@@ -3494,6 +3494,8 @@
 
     "@wyw-in-js/e2e-esbuild/prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
+    "@wyw-in-js/e2e-next-webpack/next": ["next@16.1.1", "", { "dependencies": { "@next/env": "16.1.1", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.1", "@next/swc-darwin-x64": "16.1.1", "@next/swc-linux-arm64-gnu": "16.1.1", "@next/swc-linux-arm64-musl": "16.1.1", "@next/swc-linux-x64-gnu": "16.1.1", "@next/swc-linux-x64-musl": "16.1.1", "@next/swc-win32-arm64-msvc": "16.1.1", "@next/swc-win32-x64-msvc": "16.1.1", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w=="],
+
     "@wyw-in-js/e2e-rollup/prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "@wyw-in-js/e2e-webpack/prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
@@ -3519,6 +3521,8 @@
     "babel-plugin-module-resolver/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.9.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ=="],
 
     "bun-types/@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
 
@@ -3689,6 +3693,8 @@
     "next-mdx-remote/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "nextjs-wyw-demo/@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
+
+    "nextjs-wyw-demo/next": ["next@16.1.1", "", { "dependencies": { "@next/env": "16.1.1", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.1", "@next/swc-darwin-x64": "16.1.1", "@next/swc-linux-arm64-gnu": "16.1.1", "@next/swc-linux-arm64-musl": "16.1.1", "@next/swc-linux-x64-gnu": "16.1.1", "@next/swc-linux-x64-musl": "16.1.1", "@next/swc-win32-arm64-msvc": "16.1.1", "@next/swc-win32-x64-msvc": "16.1.1", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w=="],
 
     "nextra/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
@@ -4110,6 +4116,26 @@
 
     "@vitejs/plugin-react/@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@wyw-in-js/e2e-next-webpack/next/@next/env": ["@next/env@16.1.1", "", {}, "sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA=="],
+
+    "@wyw-in-js/e2e-next-webpack/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.1.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA=="],
+
+    "@wyw-in-js/e2e-next-webpack/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.1.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw=="],
+
+    "@wyw-in-js/e2e-next-webpack/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ=="],
+
+    "@wyw-in-js/e2e-next-webpack/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg=="],
+
+    "@wyw-in-js/e2e-next-webpack/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ=="],
+
+    "@wyw-in-js/e2e-next-webpack/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA=="],
+
+    "@wyw-in-js/e2e-next-webpack/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.1.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA=="],
+
+    "@wyw-in-js/e2e-next-webpack/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.1.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw=="],
+
+    "@wyw-in-js/e2e-next-webpack/next/baseline-browser-mapping": ["baseline-browser-mapping@2.9.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ=="],
+
     "@wyw-in-js/esbuild/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.15.18", "", { "os": "android", "cpu": "arm" }, "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw=="],
 
     "@wyw-in-js/esbuild/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.15.18", "", { "os": "linux", "cpu": "none" }, "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ=="],
@@ -4301,6 +4327,26 @@
     "msgpackr-extract/node-gyp-build-optional-packages/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "next-mdx-remote/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+
+    "nextjs-wyw-demo/next/@next/env": ["@next/env@16.1.1", "", {}, "sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA=="],
+
+    "nextjs-wyw-demo/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.1.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA=="],
+
+    "nextjs-wyw-demo/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.1.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw=="],
+
+    "nextjs-wyw-demo/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ=="],
+
+    "nextjs-wyw-demo/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg=="],
+
+    "nextjs-wyw-demo/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ=="],
+
+    "nextjs-wyw-demo/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA=="],
+
+    "nextjs-wyw-demo/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.1.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA=="],
+
+    "nextjs-wyw-demo/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.1.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw=="],
+
+    "nextjs-wyw-demo/next/baseline-browser-mapping": ["baseline-browser-mapping@2.9.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ=="],
 
     "normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 

--- a/e2e/next-turbopack/package.json
+++ b/e2e/next-turbopack/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@wyw-in-js/nextjs": "workspace:*",
     "@wyw-in-js/template-tag-syntax": "workspace:*",
-    "next": "^16.0.0",
+    "next": "^16.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/e2e/next-turbopack/scripts/test.mjs
+++ b/e2e/next-turbopack/scripts/test.mjs
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { once } from 'node:events';
 import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
@@ -12,6 +12,7 @@ const require = createRequire(import.meta.url);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PKG_DIR = path.resolve(__dirname, '..');
+const MIN_NEXT_VERSION = { major: 16, minor: 2 };
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -125,6 +126,56 @@ const stopDevServer = async (child) => {
   ]);
 };
 
+const getNextBin = () => {
+  const nextPackageJson = require.resolve('next/package.json', {
+    paths: [PKG_DIR],
+  });
+
+  return path.resolve(path.dirname(nextPackageJson), 'dist', 'bin', 'next');
+};
+
+const getNextVersion = () => {
+  const nextPackageJson = require.resolve('next/package.json', {
+    paths: [PKG_DIR],
+  });
+  const { version } = require(nextPackageJson);
+  const [majorPart, minorPart] = version.split('.');
+
+  return {
+    major: Number.parseInt(majorPart, 10),
+    minor: Number.parseInt(minorPart, 10),
+    version,
+  };
+};
+
+const assertSupportedNextVersion = () => {
+  const { major, minor, version } = getNextVersion();
+  const isSupported =
+    major > MIN_NEXT_VERSION.major ||
+    (major === MIN_NEXT_VERSION.major && minor >= MIN_NEXT_VERSION.minor);
+
+  if (!isSupported) {
+    throw new Error(
+      `Expected Next.js ${MIN_NEXT_VERSION.major}.${MIN_NEXT_VERSION.minor}.x or newer, got ${version}`
+    );
+  }
+};
+
+const runProductionBuild = async () => {
+  await fs.rm(path.resolve(PKG_DIR, '.next'), { recursive: true, force: true });
+  await cleanupGeneratedCss();
+
+  execFileSync(process.execPath, [getNextBin(), 'build'], {
+    cwd: PKG_DIR,
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      NEXT_TELEMETRY_DISABLED: '1',
+    },
+    stdio: 'inherit',
+  });
+};
+
 const fetchWithRetries = async (url, child, logs) => {
   let lastError = null;
 
@@ -173,21 +224,40 @@ const runDevSmoke = async () => {
 };
 
 const readCssOutput = async () => {
-  const cssFile = path.resolve(
-    PKG_DIR,
-    'app',
-    'styles.wyw-in-js.module.css'
-  );
+  const cssFiles = [];
 
-  try {
-    return await fs.readFile(cssFile, 'utf8');
-  } catch (error) {
-    if (error?.code === 'ENOENT') {
-      throw new Error(`No generated CSS file found at ${cssFile}`);
+  const walk = async (dir) => {
+    let entries = [];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch (error) {
+      if (error?.code === 'ENOENT') return;
+      throw error;
     }
 
-    throw error;
+    await Promise.all(
+      entries.map(async (entry) => {
+        const fullPath = path.resolve(dir, entry.name);
+        if (entry.isDirectory()) {
+          await walk(fullPath);
+        } else if (entry.isFile() && entry.name.endsWith('.css')) {
+          cssFiles.push(fullPath);
+        }
+      })
+    );
+  };
+
+  await walk(path.resolve(PKG_DIR, '.next'));
+
+  if (cssFiles.length === 0) {
+    throw new Error('No CSS assets emitted by Next build');
   }
+
+  const contents = await Promise.all(
+    cssFiles.map((file) => fs.readFile(file, 'utf8'))
+  );
+
+  return contents.join('\n');
 };
 
 const assertMatches = (css, pattern, label) => {
@@ -198,9 +268,10 @@ const assertMatches = (css, pattern, label) => {
 
 const main = async () => {
   console.log(colors.blue('Package directory:'), PKG_DIR);
+  assertSupportedNextVersion();
 
   try {
-    await runDevSmoke();
+    await runProductionBuild();
 
     const cssOutput = await readCssOutput();
 
@@ -213,6 +284,8 @@ const main = async () => {
     assertMatches(cssOutput, /width:\s*200px/i, 'width');
     assertMatches(cssOutput, /font-size:\s*18px/i, 'font-size');
     assertMatches(cssOutput, /color:\s*tomato/i, 'color');
+
+    await runDevSmoke();
   } finally {
     await cleanupGeneratedCss();
   }

--- a/packages/nextjs/src/__tests__/withWyw.test.ts
+++ b/packages/nextjs/src/__tests__/withWyw.test.ts
@@ -1,22 +1,50 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
 import type { Configuration, RuleSetRule } from 'webpack';
 
 import { withWyw } from '../index';
 
 describe('withWyw', () => {
+  const withFakeNextVersion = <T>(version: string, callback: () => T): T => {
+    const previousCwd = process.cwd();
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-next-'));
+    const nextPackageDir = path.join(tmpDir, 'node_modules', 'next');
+
+    fs.mkdirSync(nextPackageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nextPackageDir, 'package.json'),
+      JSON.stringify({ version })
+    );
+
+    process.chdir(tmpDir);
+    try {
+      return callback();
+    } finally {
+      process.chdir(previousCwd);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  };
+
   const getTurbopackLoaderOptions = (nextConfig: any) => {
     const rules =
       nextConfig.turbopack?.rules ?? nextConfig.experimental?.turbo?.rules;
     const tsRule = rules['*.ts'];
 
     if (Array.isArray(tsRule)) {
-      return tsRule[0].options;
+      const jsRule = tsRule.find(
+        (item) => item.loaders?.[0]?.options?.outputCss !== true
+      );
+
+      return jsRule?.loaders?.[0]?.options ?? tsRule[0].options;
     }
 
     return tsRule.loaders[0].options;
   };
 
-  it('injects Turbopack rules (turbopack.rules or experimental.turbo.rules)', () => {
-    const nextConfig = withWyw();
+  it('injects Turbopack query CSS rules for Next 16.2+', () => {
+    const nextConfig = withFakeNextVersion('16.2.4', () => withWyw());
 
     const rules =
       (nextConfig as any).turbopack?.rules ??
@@ -27,19 +55,49 @@ describe('withWyw', () => {
 
     const tsRule = rules['*.ts'];
 
-    if (Array.isArray(tsRule)) {
-      expect(tsRule[0].loader).toContain('turbopack-loader');
-      expect(tsRule[0].options.importOverrides).toMatchObject({
-        react: { mock: 'react' },
-      });
-      expect(tsRule[0].options).not.toHaveProperty('babelOptions');
-    } else {
-      expect(tsRule.loaders[0].loader).toContain('turbopack-loader');
-      expect(tsRule.loaders[0].options.importOverrides).toMatchObject({
-        react: { mock: 'react' },
-      });
-      expect(tsRule.loaders[0].options).not.toHaveProperty('babelOptions');
-    }
+    expect(Array.isArray(tsRule)).toBe(true);
+    expect(tsRule).toHaveLength(2);
+
+    const [cssRule, jsRule] = tsRule;
+    expect(jsRule.loaders[0].loader).toContain('turbopack-loader');
+    expect(jsRule.loaders[0].options.cssOutputMode).toBe('query');
+    expect(jsRule.loaders[0].options.importOverrides).toMatchObject({
+      react: { mock: 'react' },
+    });
+    expect(jsRule.loaders[0].options).not.toHaveProperty('babelOptions');
+    expect(jsRule.condition.all).toEqual(
+      expect.arrayContaining([
+        { not: 'foreign' },
+        { not: { query: expect.any(RegExp) } },
+      ])
+    );
+
+    expect(cssRule.loaders[0].loader).toContain('turbopack-loader');
+    expect(cssRule.loaders[0].options.cssOutputMode).toBe('query');
+    expect(cssRule.loaders[0].options.outputCss).toBe(true);
+    expect(cssRule.condition.all).toEqual(
+      expect.arrayContaining([
+        { not: 'foreign' },
+        { query: expect.any(RegExp) },
+      ])
+    );
+    expect(cssRule.as).toBe('*.module.css');
+  });
+
+  it('keeps the sidecar Turbopack rule for Next versions without query conditions', () => {
+    const nextConfig = withFakeNextVersion('16.1.1', () => withWyw());
+
+    const rules =
+      (nextConfig as any).turbopack?.rules ??
+      (nextConfig as any).experimental?.turbo?.rules;
+    const tsRule = rules['*.ts'];
+
+    expect(Array.isArray(tsRule)).toBe(false);
+    expect(tsRule.loaders[0].loader).toContain('turbopack-loader');
+    expect(tsRule.loaders[0].options.cssOutputMode).toBe('sidecar');
+    expect(tsRule.condition.all).toEqual(
+      expect.arrayContaining([{ not: 'foreign' }])
+    );
   });
 
   it('lets user-defined Turbopack rule keys win', () => {

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -10,6 +10,8 @@ import type { NextConfig } from 'next';
 import type { Configuration, RuleSetRule, RuleSetUseItem } from 'webpack';
 
 const DEFAULT_EXTENSION = '.wyw-in-js.module.css';
+const CSS_OUTPUT_QUERY = '__wyw_css';
+const CSS_OUTPUT_QUERY_RE = new RegExp(`^\\??${CSS_OUTPUT_QUERY}$`);
 
 const DEFAULT_TURBO_RULE_KEYS = ['*.js', '*.jsx', '*.ts', '*.tsx'];
 
@@ -29,6 +31,10 @@ export type WywNextPluginOptions = {
 
 type NextWebpackConfigFn = NonNullable<NextConfig['webpack']>;
 type NextWebpackOptions = Parameters<NextWebpackConfigFn>[1];
+type NextVersion = {
+  major: number;
+  minor: number;
+};
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -332,23 +338,48 @@ function injectWywLoader(
   ensureWywCssModuleRules(config, extension);
 }
 
-function shouldUseTurbopackConfig(nextConfig: NextConfig) {
-  const explicit = (nextConfig as unknown as Record<string, unknown>).turbopack;
-  if (typeof explicit !== 'undefined') {
-    return true;
-  }
-
+function getInstalledNextVersion(): NextVersion | null {
   try {
     const pkgPath = nodeRequire.resolve('next/package.json', {
       paths: [process.cwd()],
     });
     const pkg = nodeRequire(pkgPath) as { version?: unknown };
     const version = typeof pkg.version === 'string' ? pkg.version : '';
-    const major = Number.parseInt(version.split('.')[0] ?? '', 10);
-    return Number.isFinite(major) && major >= 16;
+    const [majorPart, minorPart] = version.split('.');
+    const major = Number.parseInt(majorPart ?? '', 10);
+    const minor = Number.parseInt(minorPart ?? '', 10);
+
+    if (!Number.isFinite(major) || !Number.isFinite(minor)) {
+      return null;
+    }
+
+    return { major, minor };
   } catch {
+    return null;
+  }
+}
+
+function shouldUseTurbopackConfig(
+  nextConfig: NextConfig,
+  nextVersion: NextVersion | null
+) {
+  const explicit = (nextConfig as unknown as Record<string, unknown>).turbopack;
+  if (typeof explicit !== 'undefined') {
+    return true;
+  }
+
+  return nextVersion !== null && nextVersion.major >= 16;
+}
+
+function supportsTurbopackQueryConditions(nextVersion: NextVersion | null) {
+  if (nextVersion === null) {
     return false;
   }
+
+  return (
+    nextVersion.major > 16 ||
+    (nextVersion.major === 16 && nextVersion.minor >= 2)
+  );
 }
 
 function injectWywTurbopackRules(
@@ -392,22 +423,58 @@ function injectWywTurbopackRules(
       : DEFAULT_REACT_IMPORT_OVERRIDES,
   };
 
-  const useTurbopackConfig = shouldUseTurbopackConfig(nextConfig);
+  const nextVersion = getInstalledNextVersion();
+  const useTurbopackConfig = shouldUseTurbopackConfig(nextConfig, nextVersion);
+  const useCssQueryOutput = supportsTurbopackQueryConditions(nextVersion);
+
+  const commonConditions = [
+    { not: 'foreign' },
+    { not: { path: /(?:^|[\\/])middleware\.[jt]sx?$/ } },
+  ];
+
+  const jsLoaderOptions = {
+    ...loaderOptions,
+    cssOutputMode: useCssQueryOutput ? 'query' : 'sidecar',
+  };
 
   const ruleValue = useTurbopackConfig
     ? {
-        loaders: [{ loader, options: loaderOptions }],
+        loaders: [{ loader, options: jsLoaderOptions }],
         condition: {
-          all: [
-            { not: 'foreign' },
-            { not: { path: /(?:^|[\\/])middleware\.[jt]sx?$/ } },
-          ],
+          all: commonConditions,
         },
       }
-    : [{ loader, options: loaderOptions }];
+    : [{ loader, options: jsLoaderOptions }];
+
+  const jsRuleValue = {
+    loaders: [{ loader, options: jsLoaderOptions }],
+    condition: {
+      all: [...commonConditions, { not: { query: CSS_OUTPUT_QUERY_RE } }],
+    },
+  };
+
+  const cssRuleValue = {
+    loaders: [
+      {
+        loader,
+        options: {
+          ...loaderOptions,
+          cssOutputMode: 'query',
+          outputCss: true,
+        },
+      },
+    ],
+    as: '*.module.css',
+    condition: {
+      all: [...commonConditions, { query: CSS_OUTPUT_QUERY_RE }],
+    },
+  };
 
   const wywRules = Object.fromEntries(
-    DEFAULT_TURBO_RULE_KEYS.map((key) => [key, ruleValue])
+    DEFAULT_TURBO_RULE_KEYS.map((key) => [
+      key,
+      useCssQueryOutput ? [cssRuleValue, jsRuleValue] : ruleValue,
+    ])
   );
 
   if (useTurbopackConfig) {

--- a/packages/turbopack-loader/src/__tests__/loader.test.ts
+++ b/packages/turbopack-loader/src/__tests__/loader.test.ts
@@ -21,7 +21,7 @@ describe('turbopack-loader', () => {
     transformMock.mockReset();
   });
 
-  it('writes CSS next to the module and injects an import after directives', async () => {
+  it('writes CSS next to the module and injects an import after directives by default', async () => {
     const { default: turbopackLoader } = await import('../index');
 
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-turbo-'));
@@ -68,5 +68,95 @@ describe('turbopack-loader', () => {
 
     expect(emitted.code).toContain("'use client'");
     expect(emitted.code).toContain('import "./entry.wyw-in-js.module.css";');
+  });
+
+  it('injects a CSS query import in query output mode without writing a sidecar file', async () => {
+    const { default: turbopackLoader } = await import('../index');
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-turbo-'));
+    const resourcePath = path.join(tmpDir, 'entry.tsx');
+    fs.writeFileSync(resourcePath, "'use client'\\nexport const x = 1;\\n");
+
+    transformMock.mockImplementation(async (_services, code) => {
+      return {
+        code,
+        sourceMap: null,
+        cssText: '.a{color:red}',
+        dependencies: [],
+      };
+    });
+
+    const emitted: { code?: string } = {};
+
+    await new Promise<void>((resolve, reject) => {
+      turbopackLoader.call(
+        {
+          addDependency: jest.fn(),
+          async: jest.fn(),
+          callback: (err: Error | null, code?: string) => {
+            if (err) reject(err);
+            else {
+              emitted.code = code;
+              resolve();
+            }
+          },
+          emitWarning: jest.fn(),
+          getOptions: () => ({ cssOutputMode: 'query' }),
+          getResolve: () => async () => false,
+          resourcePath,
+        } as any,
+        fs.readFileSync(resourcePath, 'utf8'),
+        null
+      );
+    });
+
+    const cssFilePath = path.join(tmpDir, 'entry.wyw-in-js.module.css');
+    expect(fs.existsSync(cssFilePath)).toBe(false);
+
+    expect(emitted.code).toContain("'use client'");
+    expect(emitted.code).toContain('import "./entry.tsx?__wyw_css";');
+  });
+
+  it('returns CSS for the CSS query loader branch', async () => {
+    const { default: turbopackLoader } = await import('../index');
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-turbo-'));
+    const resourcePath = path.join(tmpDir, 'entry.tsx');
+    fs.writeFileSync(resourcePath, 'export const x = 1;\n');
+
+    transformMock.mockImplementation(async (_services, code) => {
+      return {
+        code,
+        sourceMap: null,
+        cssText: '.a{color:red}',
+        dependencies: [],
+      };
+    });
+
+    const emitted: { code?: string } = {};
+
+    await new Promise<void>((resolve, reject) => {
+      turbopackLoader.call(
+        {
+          addDependency: jest.fn(),
+          async: jest.fn(),
+          callback: (err: Error | null, code?: string) => {
+            if (err) reject(err);
+            else {
+              emitted.code = code;
+              resolve();
+            }
+          },
+          emitWarning: jest.fn(),
+          getOptions: () => ({ outputCss: true }),
+          getResolve: () => async () => false,
+          resourcePath,
+        } as any,
+        fs.readFileSync(resourcePath, 'utf8'),
+        null
+      );
+    });
+
+    expect(emitted.code).toBe(':global(.a){color:red}');
   });
 });

--- a/packages/turbopack-loader/src/index.ts
+++ b/packages/turbopack-loader/src/index.ts
@@ -13,6 +13,7 @@ import { writeFileIfChanged } from './file-utils';
 import { insertImportStatement } from './insert-import';
 
 const DEFAULT_EXTENSION = '.wyw-in-js.module.css';
+const CSS_OUTPUT_QUERY = '__wyw_css';
 
 const stripQueryAndHash = (request: string) => {
   const queryIdx = request.indexOf('?');
@@ -27,7 +28,9 @@ const stripQueryAndHash = (request: string) => {
 };
 
 export type LoaderOptions = {
+  cssOutputMode?: 'sidecar' | 'query';
   keepComments?: boolean;
+  outputCss?: boolean;
   prefixer?: boolean;
   sourceMap?: boolean;
 } & Partial<PluginOptions>;
@@ -100,8 +103,15 @@ const turbopackLoader: Loader = function turbopackLoader(
 
   logger('turbopack-loader %s', this.resourcePath);
 
-  const { sourceMap, keepComments, prefixer, configFile, ...rest } =
-    this.getOptions() || {};
+  const {
+    sourceMap,
+    keepComments,
+    outputCss,
+    cssOutputMode = 'sidecar',
+    prefixer,
+    configFile,
+    ...rest
+  } = this.getOptions() || {};
 
   if (configFile) {
     const configPath = path.isAbsolute(configFile)
@@ -176,16 +186,33 @@ const turbopackLoader: Loader = function turbopackLoader(
           )
         );
 
-        writeFileIfChanged(cssFilePath, cssText);
+        if (outputCss) {
+          callback(null, cssText);
+          return;
+        }
 
-        const importStatement = `import ${JSON.stringify(cssImportPath)};`;
+        let importPath = cssImportPath;
+        if (cssOutputMode === 'query') {
+          importPath = `./${path.basename(
+            this.resourcePath
+          )}?${CSS_OUTPUT_QUERY}`;
+        } else {
+          writeFileIfChanged(cssFilePath, cssText);
+        }
+
+        const importStatement = `import ${JSON.stringify(importPath)};`;
         const finalCode = insertImportStatement(result.code, importStatement);
 
         callback(null, finalCode, result.sourceMap ?? undefined);
         return;
       }
 
-      if (fs.existsSync(cssFilePath)) {
+      if (outputCss) {
+        callback(null, '');
+        return;
+      }
+
+      if (cssOutputMode !== 'query' && fs.existsSync(cssFilePath)) {
         writeFileIfChanged(cssFilePath, '');
       }
 


### PR DESCRIPTION
Fixes #324.

## What Changed

- Added a query output mode to `@wyw-in-js/turbopack-loader`, allowing generated WyW CSS to be returned from a `?__wyw_css` loader request instead of being written as a sidecar file.
- Updated `@wyw-in-js/nextjs` to use separate JS and CSS Turbopack rules on Next.js 16.2+, using `condition.query` for the generated CSS request.
- Kept the existing sidecar CSS output as the fallback for older Next.js versions that do not support Turbopack query conditions.
- Updated the Next Turbopack e2e fixture to run against Next.js 16.2+ and verify production CSS output.

## Why

Next.js Turbopack production builds can miss CSS files created by a loader as filesystem side effects during the same build graph pass. Routing generated CSS through a Turbopack-recognized query request makes the CSS part of the module graph directly.

## Validation

- `bun run --filter @wyw-in-js/turbopack-loader lint`
- `bun run --filter @wyw-in-js/nextjs lint`
- `bun run --filter @wyw-in-js/turbopack-loader test`
- `bun run --filter @wyw-in-js/nextjs test`
- `bun run --filter @wyw-in-js/turbopack-loader build:esm`
- `bun run --filter @wyw-in-js/nextjs build:esm`
- `bun run --filter @wyw-in-js/turbopack-loader build:types`
- `bun run --filter @wyw-in-js/nextjs build:types`
- `bun run --filter @wyw-in-js/e2e-next-turbopack test`