### PR TITLE
fix(transform): parse JSX in JavaScript files

### DIFF
--- a/.changeset/parse-js-jsx-before-babel.md
+++ b/.changeset/parse-js-jsx-before-babel.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Fix Oxc parsing for `.js` files that contain JSX before downstream JSX transforms run.

--- a/packages/transform/src/__tests__/oxc-workflow.test.ts
+++ b/packages/transform/src/__tests__/oxc-workflow.test.ts
@@ -160,6 +160,56 @@ describe('explicit Oxc workflow', () => {
     expect(result.cssText).toContain('color: red');
   });
 
+  it('keeps JSX parsing restricted to .js compatibility fallback', async () => {
+    const filename = join(__dirname, 'source-with-jsx.mjs');
+    await expect(
+      transformFile(
+        {
+          options: {
+            filename,
+            preprocessor: 'none',
+            root: __dirname,
+            pluginOptions: createPluginOptions(),
+          },
+        },
+        dedent`
+          import { css } from 'test-css-processor';
+
+          export const className = css\`
+            color: red;
+          \`;
+          export const element = <div className={className} />;
+        `,
+        async () => null
+      )
+    ).rejects.toThrow('Unexpected JSX expression');
+  });
+
+  it('keeps non-JSX syntax errors fatal in .js files', async () => {
+    const filename = join(__dirname, 'invalid-source.js');
+    await expect(
+      transformFile(
+        {
+          options: {
+            filename,
+            preprocessor: 'none',
+            root: __dirname,
+            pluginOptions: createPluginOptions(),
+          },
+        },
+        dedent`
+          import { css } from 'test-css-processor';
+
+          export const className = css\`
+            color: red;
+          \`;
+          export const broken = ;
+        `,
+        async () => null
+      )
+    ).rejects.toThrow();
+  });
+
   it('does not resolve imports for __wywPreval-only modules without metadata', async () => {
     const filename = join(__dirname, 'no-metadata-source.js');
     const source = dedent`

--- a/packages/transform/src/__tests__/oxc-workflow.test.ts
+++ b/packages/transform/src/__tests__/oxc-workflow.test.ts
@@ -132,6 +132,34 @@ describe('explicit Oxc workflow', () => {
     expect(result.sourceMap?.sourcesContent?.[0]).toContain('css`');
   });
 
+  it('handles JSX syntax in .js files before downstream JSX transforms run', async () => {
+    const filename = join(__dirname, 'source-with-jsx.js');
+    const result = await transformFile(
+      {
+        options: {
+          filename,
+          preprocessor: 'none',
+          root: __dirname,
+          pluginOptions: createPluginOptions(),
+        },
+      },
+      dedent`
+        import { css } from 'test-css-processor';
+
+        const color = 'red';
+        export const className = css\`
+          color: ${'${color}'};
+        \`;
+        export const element = <div className={className} />;
+      `,
+      async () => null
+    );
+
+    expect(result.code).not.toContain('css`');
+    expect(result.code).toContain('<div className={className} />');
+    expect(result.cssText).toContain('color: red');
+  });
+
   it('does not resolve imports for __wywPreval-only modules without metadata', async () => {
     const filename = join(__dirname, 'no-metadata-source.js');
     const source = dedent`

--- a/packages/transform/src/utils/collectOxcRuntime/normalizeRuntimeCode.ts
+++ b/packages/transform/src/utils/collectOxcRuntime/normalizeRuntimeCode.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-restricted-syntax */
 
-import { parseSync } from 'oxc-parser';
 import type { Node, Program } from 'oxc-parser';
 
+import { parseOxcProgramCached } from '../parseOxc';
 import type { RuntimeReplacement } from './types';
 
 type AnyNode = Node & Record<string, unknown>;
@@ -15,18 +15,7 @@ type AnyProperty = AnyNode & {
 };
 
 const parseOxc = (code: string, filename: string): Program => {
-  const parsed = parseSync(filename, code, {
-    astType:
-      filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js',
-    range: true,
-    sourceType: 'module',
-  });
-  const fatalError = parsed.errors.find((error) => error.severity === 'Error');
-  if (fatalError) {
-    throw new Error(fatalError.message);
-  }
-
-  return parsed.program as Program;
+  return parseOxcProgramCached(filename, code, 'module');
 };
 
 const applyReplacements = (

--- a/packages/transform/src/utils/parseOxc.ts
+++ b/packages/transform/src/utils/parseOxc.ts
@@ -23,8 +23,6 @@ const getAstType = (filename: string): 'js' | 'ts' =>
 
 const getJsxFallbackFilename = (filename: string): string | null => {
   if (filename.endsWith('.js')) return `${filename}x`;
-  if (filename.endsWith('.mjs')) return filename.replace(/\.mjs$/, '.jsx');
-  if (filename.endsWith('.cjs')) return filename.replace(/\.cjs$/, '.jsx');
 
   return null;
 };

--- a/packages/transform/src/utils/parseOxc.ts
+++ b/packages/transform/src/utils/parseOxc.ts
@@ -21,6 +21,14 @@ const parseCache = new Map<string, ParsedOxc>();
 const getAstType = (filename: string): 'js' | 'ts' =>
   filename.endsWith('.ts') || filename.endsWith('.tsx') ? 'ts' : 'js';
 
+const getJsxFallbackFilename = (filename: string): string | null => {
+  if (filename.endsWith('.js')) return `${filename}x`;
+  if (filename.endsWith('.mjs')) return filename.replace(/\.mjs$/, '.jsx');
+  if (filename.endsWith('.cjs')) return filename.replace(/\.cjs$/, '.jsx');
+
+  return null;
+};
+
 const makeCacheKey = (
   filename: string,
   code: string,
@@ -50,12 +58,23 @@ export const parseOxcCached = (
     return cached;
   }
 
-  const parsed = parseSync(filename, code, {
+  let parsed = parseSync(filename, code, {
     astType: getAstType(filename),
     range: true,
     sourceType,
   });
-  const fatalError = parsed.errors.find((error) => error.severity === 'Error');
+  let fatalError = parsed.errors.find((error) => error.severity === 'Error');
+  const jsxFallbackFilename = getJsxFallbackFilename(filename);
+  if (fatalError?.message.includes('JSX') && jsxFallbackFilename) {
+    // Some bundlers pass .js files with JSX to WyW before a later JSX transform.
+    parsed = parseSync(jsxFallbackFilename, code, {
+      astType: getAstType(jsxFallbackFilename),
+      range: true,
+      sourceType,
+    });
+    fatalError = parsed.errors.find((error) => error.severity === 'Error');
+  }
+
   if (fatalError) {
     throw new Error(fatalError.message);
   }


### PR DESCRIPTION
Refs callstack/linaria#1413.

Rollup can pass `.js` files that still contain JSX into WyW before a downstream JSX transform runs. Oxc parses `.js` as plain JavaScript, so transform failed with `Unexpected JSX expression`.

Changes:
- Retry Oxc parsing for `.js` files as JSX only when the initial parse fails on JSX.
- Reuse the shared Oxc parser wrapper in runtime-code normalization.
- Add regression coverage for `.js` files containing JSX during transform.
- Add negative coverage to keep non-`.js` JSX and non-JSX syntax errors on the normal fatal path.

Verification:
- `bun run --filter @wyw-in-js/transform test`
- `bun run --filter @wyw-in-js/transform lint`
- `bun run --filter @wyw-in-js/transform build:types`
- `bun run --filter @wyw-in-js/transform build:esm`
- Rollup repro from callstack/linaria#1413 with a local `@wyw-in-js/transform` build: `npm run build`
