### PR TITLE
fix(cli): initialize yargs through its ESM entrypoint

### DIFF
--- a/.changeset/cli-yargs-esm-startup.md
+++ b/.changeset/cli-yargs-esm-startup.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/cli': patch
+---
+
+Fix ESM CLI startup so TypeScript input files can be processed without requiring a Babel configuration.

--- a/packages/cli/src/__tests__/typescript-cli.test.ts
+++ b/packages/cli/src/__tests__/typescript-cli.test.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+describe('CLI TypeScript input', () => {
+  it('processes TypeScript files without a Babel config', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'wyw-cli-ts-'));
+
+    try {
+      const sourceDir = path.join(root, 'src');
+      mkdirSync(sourceDir, { recursive: true });
+
+      const entryFile = path.join(sourceDir, 'index.ts');
+      writeFileSync(entryFile, 'const a: number = 1;\n', 'utf8');
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          path.resolve(__dirname, '../wyw-in-js.ts'),
+          '--out-dir',
+          path.join(root, 'dist'),
+          '--source-root',
+          root,
+          entryFile,
+        ],
+        {
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.stderr).toBe('');
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Successfully extracted 0 CSS files.');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/wyw-in-js.ts
+++ b/packages/cli/src/wyw-in-js.ts
@@ -15,7 +15,8 @@ import {
 import { globSync } from 'glob';
 import mkdirp from 'mkdirp';
 import normalize from 'normalize-path';
-import yargs from 'yargs';
+import yargs from 'yargs/yargs';
+import { hideBin } from 'yargs/helpers';
 
 import { reportTransformDiagnostics } from './diagnostics';
 import { createMetadataFile } from './metadata';
@@ -28,7 +29,7 @@ const modulesOptions = [
   'native',
 ] as const;
 
-const argv = yargs
+const argv = yargs(hideBin(process.argv))
   .usage('Usage: $0 [options] <files ...>')
   .option('config', {
     alias: 'c',


### PR DESCRIPTION
Fixes the CLI startup path for ESM builds.

The CLI imported `yargs` from the package root and then used it as an already-initialized parser. In ESM, that import resolves to the factory function, so the CLI could fail before processing input files.

Changes:
- Initialize yargs with `hideBin(process.argv)` from `yargs/yargs`.
- Add a regression test that runs the CLI against a TypeScript file without a Babel config.
- Add a patch changeset for `@wyw-in-js/cli`.

Verification:
- `bun test packages/cli/src/__tests__/typescript-cli.test.ts`
- `bun run --filter @wyw-in-js/cli test`
- `bun run --filter @wyw-in-js/cli lint`
- `bun run --filter @wyw-in-js/cli build:types`
- `bun run --filter @wyw-in-js/cli build:esm`