### PR TITLE
fix(rollup): allow stable css filenames

### DIFF
--- a/.changeset/rollup-css-filename-option.md
+++ b/.changeset/rollup-css-filename-option.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/rollup': patch
+---
+
+Add a `cssFilename` option to customize generated virtual CSS filenames in Rollup builds. This lets watch-mode setups use stable CSS ids with CSS bundler plugins that cache transformed CSS by filename.

--- a/apps/website/pages/bundlers/rollup.mdx
+++ b/apps/website/pages/bundlers/rollup.mdx
@@ -67,6 +67,18 @@ wyw({
 });
 ```
 
+### Stable CSS filenames in watch mode
+
+By default, the Rollup plugin includes a slug based on the generated CSS content in the virtual CSS filename. Some CSS
+bundler plugins cache transformed CSS by filename during watch mode and work better with a stable id. You can override
+the generated CSS filename with `cssFilename`:
+
+```js
+wyw({
+  cssFilename: ({ id }) => `${id.replace(/\.[jt]sx?$/, '')}.css`,
+});
+```
+
 ### Disabling vendor prefixing
 
 Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:

--- a/packages/rollup/README.md
+++ b/packages/rollup/README.md
@@ -53,6 +53,18 @@ wyw({
 });
 ```
 
+### Stable CSS filenames in watch mode
+
+By default, the Rollup plugin includes a slug based on the generated CSS content in the virtual CSS filename. Some CSS
+bundler plugins cache transformed CSS by filename during watch mode and work better with a stable id. You can override
+the generated CSS filename with `cssFilename`:
+
+```js
+wyw({
+  cssFilename: ({ id }) => `${id.replace(/\.[jt]sx?$/, '')}.css`,
+});
+```
+
 ## Disabling vendor prefixing
 
 Stylis adds vendor-prefixed CSS by default. To disable it (and reduce CSS size), pass `prefixer: false`:

--- a/packages/rollup/src/__tests__/serialize-transform.test.ts
+++ b/packages/rollup/src/__tests__/serialize-transform.test.ts
@@ -1,5 +1,6 @@
 const transformMock = jest.fn();
 const cacheGetMock = jest.fn();
+const slugifyMock = jest.fn();
 
 let activeTransforms = 0;
 let maxActiveTransforms = 0;
@@ -20,7 +21,7 @@ jest.mock('@wyw-in-js/shared', () => ({
         (resolved) => onResolve(resolved, what, importer, stack)
       ),
   logger: createLogger(),
-  slugify: () => 'slug',
+  slugify: (...args: unknown[]) => slugifyMock(...args),
   syncResolve: () => null,
 }));
 
@@ -45,7 +46,9 @@ describe('@wyw-in-js/rollup serializeTransform', () => {
   beforeEach(() => {
     transformMock.mockReset();
     cacheGetMock.mockReset();
+    slugifyMock.mockReset();
     cacheGetMock.mockReturnValue(undefined);
+    slugifyMock.mockReturnValue('slug');
     activeTransforms = 0;
     maxActiveTransforms = 0;
 
@@ -317,5 +320,32 @@ describe('@wyw-in-js/rollup serializeTransform', () => {
     await plugin.transform!.call(ctx, 'console.log("test")', '/abs/entry.ts');
 
     expect(calls).toEqual(['entry:start', 'dependency', 'entry:end']);
+  });
+
+  it('supports stable CSS filenames for CSS bundlers with watch caches', async () => {
+    const { default: wywInJS } = await import('../index');
+    const plugin = wywInJS({
+      cssFilename: ({ id }) => `${id.replace(/\.[jt]sx?$/, '')}.css`,
+    });
+    const ctx = createContext();
+
+    transformMock
+      .mockResolvedValueOnce({
+        code: 'export const x = 1;',
+        cssText: '.a{color:red}',
+        sourceMap: null,
+      })
+      .mockResolvedValueOnce({
+        code: 'export const x = 1;',
+        cssText: '.a{color:blue}',
+        sourceMap: null,
+      });
+
+    const first = await plugin.transform!.call(ctx, 'export {}', '/abs/a.ts');
+    const second = await plugin.transform!.call(ctx, 'export {}', '/abs/a.ts');
+
+    expect(first?.code).toContain('import "/abs/a.css";');
+    expect(second?.code).toContain('import "/abs/a.css";');
+    expect(plugin.load?.call(ctx, '/abs/a.css')).toBe('.a{color:blue}');
   });
 });

--- a/packages/rollup/src/index.ts
+++ b/packages/rollup/src/index.ts
@@ -21,7 +21,15 @@ import {
   TransformCacheCollection,
 } from '@wyw-in-js/transform';
 
+type RollupCssFilenameContext = {
+  cssText: string;
+  defaultFilename: string;
+  id: string;
+  slug: string;
+};
+
 type RollupPluginOptions = {
+  cssFilename?: (context: RollupCssFilenameContext) => string;
   exclude?: string | string[];
   include?: string | string[];
   keepComments?: boolean | RegExp;
@@ -32,6 +40,7 @@ type RollupPluginOptions = {
 } & Partial<PluginOptions>;
 
 export default function wywInJS({
+  cssFilename,
   exclude,
   include,
   keepComments,
@@ -203,7 +212,10 @@ export default function wywInJS({
         let { cssText } = result;
 
         const slug = slugify(cssText);
-        const filename = `${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`;
+        const defaultFilename = `${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`;
+        const filename =
+          cssFilename?.({ cssText, defaultFilename, id, slug }) ??
+          defaultFilename;
 
         if (sourceMap && result.cssSourceMapText) {
           const map = Buffer.from(result.cssSourceMapText).toString('base64');


### PR DESCRIPTION
Adds a `cssFilename` option to the Rollup plugin so watch-mode setups can opt into stable virtual CSS filenames.

By default, the Rollup plugin keeps the existing content-slugged CSS filename behavior. CSS bundler plugins that cache transformed CSS by filename can now provide a stable filename derived from the source module id.

Changes:
- Add `cssFilename` callback support to `@wyw-in-js/rollup`.
- Cover stable CSS filename behavior in Rollup unit tests.
- Document the option in the Rollup README and website docs.
- Add a patch changeset.

Tests:
- bun run --filter @wyw-in-js/rollup test
- bun run --filter @wyw-in-js/rollup build:types
- bun run --filter @wyw-in-js/rollup lint
- bun run --filter @wyw-in-js/rollup build:esm
- bun run --filter @wyw-in-js/e2e-rollup test