### PR TITLE
fix(esbuild): preserve JSX runtime options (#1338)

### DIFF
--- a/.changeset/esbuild-jsx-runtime-options.md
+++ b/.changeset/esbuild-jsx-runtime-options.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/esbuild": patch
+---
+
+Preserve esbuild JSX runtime options when transforming TSX before WyW extraction, so automatic JSX runtime builds do not emit bare `React.createElement` calls.

--- a/packages/esbuild/src/__tests__/oxc-transform.test.ts
+++ b/packages/esbuild/src/__tests__/oxc-transform.test.ts
@@ -93,3 +93,86 @@ it('can apply oxcOptions.transform to source code before esbuild/WyW transform',
     process.chdir(cwd);
   }
 });
+
+it('preserves esbuild jsx runtime options when transforming TSX', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-esbuild-jsx-'));
+  const outdir = path.join(root, 'dist');
+
+  const entryFile = path.join(root, 'main.tsx');
+
+  const nmRoot = path.join(root, 'node_modules');
+  const processorStubDir = path.join(nmRoot, 'test-css-processor');
+
+  fs.mkdirSync(processorStubDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(processorStubDir, 'package.json'),
+    JSON.stringify({
+      name: 'test-css-processor',
+      version: '1.0.0',
+      type: 'module',
+    }),
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(processorStubDir, 'index.js'),
+    `export const css = (strings) => strings.join('');\n`,
+    'utf8'
+  );
+
+  fs.writeFileSync(
+    entryFile,
+    [
+      `import { css } from 'test-css-processor';`,
+      ``,
+      `const className = css\`color: red;\`;`,
+      ``,
+      `export default function Index() {`,
+      `  return <main className={className}>Hello</main>;`,
+      `}`,
+      ``,
+    ].join('\n'),
+    'utf8'
+  );
+
+  const processorFile = path.resolve(
+    __dirname,
+    '../../../transform/src/__tests__/__fixtures__/test-css-processor.js'
+  );
+
+  const cwd = process.cwd();
+  process.chdir(root);
+
+  try {
+    const transformed = await esbuild.build({
+      entryPoints: [entryFile],
+      bundle: true,
+      external: ['react/jsx-runtime'],
+      format: 'esm',
+      jsx: 'automatic',
+      write: false,
+      outdir,
+      plugins: [
+        wywInJS({
+          configFile: false,
+          tagResolver: (source: string, tag: string) => {
+            if (source === 'test-css-processor' && tag === 'css') {
+              return processorFile;
+            }
+
+            return null;
+          },
+        }),
+      ],
+    });
+
+    const jsText = transformed.outputFiles?.find((file) =>
+      file.path.endsWith('.js')
+    )?.text;
+
+    expect(jsText).toContain('react/jsx-runtime');
+    expect(jsText).not.toContain('React.createElement');
+  } finally {
+    process.chdir(cwd);
+  }
+});

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -188,11 +188,23 @@ export default function wywInJS({
 
         if (!options) {
           options = {};
+          if ('jsx' in build.initialOptions) {
+            options.jsx = build.initialOptions.jsx;
+          }
           if ('jsxFactory' in build.initialOptions) {
             options.jsxFactory = build.initialOptions.jsxFactory;
           }
           if ('jsxFragment' in build.initialOptions) {
             options.jsxFragment = build.initialOptions.jsxFragment;
+          }
+          if ('jsxImportSource' in build.initialOptions) {
+            options.jsxImportSource = build.initialOptions.jsxImportSource;
+          }
+          if ('jsxDev' in build.initialOptions) {
+            options.jsxDev = build.initialOptions.jsxDev;
+          }
+          if ('jsxSideEffects' in build.initialOptions) {
+            options.jsxSideEffects = build.initialOptions.jsxSideEffects;
           }
         }
 


### PR DESCRIPTION
Fixes callstack/linaria#1338.

The esbuild integration pre-transforms TSX before running WyW extraction. When users rely on esbuild's automatic JSX runtime, the plugin needs to preserve those JSX runtime options for the pre-transform step; otherwise TSX can be lowered to bare `React.createElement` calls without a React import.

Changes:
- Preserve esbuild JSX runtime options when auto-populating internal transform options.
- Add a regression test for TSX with `jsx: 'automatic'`.
- Add a patch changeset for `@wyw-in-js/esbuild`.

Checks:
- `bun run --filter @wyw-in-js/esbuild test`
- `bun run --filter @wyw-in-js/esbuild build:types`
- `bun run --filter @wyw-in-js/esbuild lint`
- `bun run --filter @wyw-in-js/esbuild build:esm`
