### PR TITLE
feat(transform): add typed processor options

### DIFF
--- a/.changeset/typed-processor-options.md
+++ b/.changeset/typed-processor-options.md
@@ -1,0 +1,7 @@
+---
+"@wyw-in-js/shared": minor
+"@wyw-in-js/processor-utils": minor
+"@wyw-in-js/transform": minor
+---
+
+Add a typed `processors` option channel for processor package options.

--- a/apps/website/pages/configuration.mdx
+++ b/apps/website/pages/configuration.mdx
@@ -442,6 +442,12 @@ module.exports = {
   ];
   ```
 
+- `processors: Object`
+
+  Typed pass-through options for custom processor packages. Processor libraries can augment `WywInJsProcessorOptions`
+  from `@wyw-in-js/shared` and read their namespace from `this.options.processors`; see
+  [Creating Custom Tagged Template Processors](/how-to/custom-tagged-template#processor-options).
+
 - `tagResolver: (source, tag, meta) => string`
 
   A custom function to use when resolving template tags.

--- a/apps/website/pages/how-to/custom-tagged-template.mdx
+++ b/apps/website/pages/how-to/custom-tagged-template.mdx
@@ -135,6 +135,40 @@ diagnostic artifacts.
 
 This method should return a string that represents the source code of the tagged template.
 
+## Processor Options
+
+Processor packages can define their own typed option namespace by augmenting `WywInJsProcessorOptions` from
+`@wyw-in-js/shared`. WyW passes the `processors` option through to processor instances as `this.options.processors`.
+
+```typescript
+declare module '@wyw-in-js/shared' {
+  interface WywInJsProcessorOptions {
+    dxstyle?: {
+      minifyClassNames?: boolean;
+    };
+  }
+}
+```
+
+Applications can then configure the processor namespace in WyW options:
+
+```typescript
+export default {
+  processors: {
+    dxstyle: {
+      minifyClassNames: true,
+    },
+  },
+};
+```
+
+The processor can read the option from its instance options:
+
+```typescript
+const minifyClassNames =
+  this.options.processors?.dxstyle?.minifyClassNames ?? false;
+```
+
 ## Static Evaluation Contract
 
 In v2, processors can optionally describe their static semantics without relying on transform-specific metadata shapes.

--- a/packages/processor-utils/src/utils/types.ts
+++ b/packages/processor-utils/src/utils/types.ts
@@ -1,9 +1,14 @@
-import type { ClassNameFn, VariableNameFn } from '@wyw-in-js/shared';
+import type {
+  ClassNameFn,
+  VariableNameFn,
+  WywInJsProcessorOptions,
+} from '@wyw-in-js/shared';
 
 export interface IOptions {
   classNameSlug?: string | ClassNameFn;
   displayName: boolean;
   extensions?: string[];
+  processors?: WywInJsProcessorOptions;
   variableNameConfig?: 'var' | 'dashes' | 'raw';
   variableNameSlug?: string | VariableNameFn;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -45,6 +45,7 @@ export type {
   EvaluatorConfig,
   FeatureFlags,
   VariableNameFn,
+  WywInJsProcessorOptions,
 } from './options/types';
 export type {
   Artifact,

--- a/packages/shared/src/options/types.ts
+++ b/packages/shared/src/options/types.ts
@@ -230,6 +230,8 @@ export type OxcOptions = {
   transform?: Record<string, unknown>;
 };
 
+export interface WywInJsProcessorOptions {}
+
 export type StrictOptions = {
   classNameSlug?: string | ClassNameFn;
   codeRemover?: CodeRemoverOptions;
@@ -242,6 +244,7 @@ export type StrictOptions = {
   ignore?: RegExp;
   importLoaders?: ImportLoaders;
   importOverrides?: ImportOverrides;
+  processors?: WywInJsProcessorOptions;
   /**
    * Per-source map of imported names to statically-known values. Used by
    * the static evaluator when resolving imports from the listed sources.

--- a/packages/transform/src/__tests__/__fixtures__/test-processor-options-processor.js
+++ b/packages/transform/src/__tests__/__fixtures__/test-processor-options-processor.js
@@ -1,0 +1,32 @@
+const { TaggedTemplateProcessor } = require('@wyw-in-js/processor-utils');
+
+class ProcessorOptionsProcessor extends TaggedTemplateProcessor {
+  get asSelector() {
+    return `.${this.className}`;
+  }
+
+  get value() {
+    return this.astService.stringLiteral(
+      this.options.processors?.processorOptionsTest?.runtimeClassName ??
+        this.className
+    );
+  }
+
+  addInterpolation() {
+    throw new Error('ProcessorOptionsProcessor does not handle interpolations');
+  }
+
+  doEvaltimeReplacement() {
+    this.replacer(this.value, false);
+  }
+
+  doRuntimeReplacement() {
+    this.replacer(this.value, false);
+  }
+
+  extractRules() {
+    return {};
+  }
+}
+
+module.exports = { default: ProcessorOptionsProcessor };

--- a/packages/transform/src/__tests__/applyOxcProcessors.test.ts
+++ b/packages/transform/src/__tests__/applyOxcProcessors.test.ts
@@ -36,6 +36,11 @@ const pureCallProcessorPath = path.resolve(
   '__fixtures__',
   'test-pure-annotation-call-processor.js'
 );
+const processorOptionsProcessorPath = path.resolve(
+  __dirname,
+  '__fixtures__',
+  'test-processor-options-processor.js'
+);
 const linariaStyledProcessorPath = path.resolve(
   __dirname,
   '__fixtures__',
@@ -164,6 +169,33 @@ describe('applyOxcProcessors', () => {
     });
     expect(starts[0]).toEqual({ column: 18, line: 3 });
     expect(cssText.join('\n')).toContain('color: red');
+  });
+
+  it('passes processor options to processor instances', () => {
+    const source = `
+      import { css } from 'test-package';
+      export const a = css\`
+        color: red;
+      \`;
+    `;
+
+    const result = applyOxcProcessors(
+      source,
+      fileContext,
+      {
+        ...options(processorOptionsProcessorPath),
+        processors: {
+          processorOptionsTest: {
+            runtimeClassName: 'processor-options-class',
+          },
+        },
+      },
+      (processor) => {
+        processor.doRuntimeReplacement();
+      }
+    );
+
+    expect(result.code).toContain('"processor-options-class"');
   });
 
   it('derives displayName from object properties and JSX elements', () => {

--- a/packages/transform/src/__tests__/loadWywOptions.test.ts
+++ b/packages/transform/src/__tests__/loadWywOptions.test.ts
@@ -35,6 +35,47 @@ describe('loadWywOptions', () => {
     expect(options.rules[0].oxcOptions).toBe(oxcOptions);
   });
 
+  it('preserves processor options and lets inline processors replace config processors', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'wyw-options-'));
+    const configFile = path.join(root, 'wyw-in-js.config.mjs');
+    const inlineProcessors = {
+      typedProcessorOptionsTest: {
+        minifyClassNames: true,
+      },
+    };
+
+    writeFileSync(
+      configFile,
+      [
+        'export default {',
+        '  processors: {',
+        '    typedProcessorOptionsTest: {',
+        '      configOnly: true,',
+        '      minifyClassNames: false,',
+        '    },',
+        '  },',
+        '};',
+        '',
+      ].join('\n')
+    );
+
+    try {
+      const options = loadWywOptions({
+        configFile,
+        processors: inlineProcessors,
+      });
+
+      expect(options.processors).toBe(inlineProcessors);
+      expect(options.processors).toEqual({
+        typedProcessorOptionsTest: {
+          minifyClassNames: true,
+        },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('accepts native and hybrid resolver modes without changing the default', () => {
     const defaultOptions = loadWywOptions({ configFile: false });
     const nativeOptions = loadWywOptions({

--- a/packages/transform/src/__tests__/processor-options.types.test.ts
+++ b/packages/transform/src/__tests__/processor-options.types.test.ts
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+import type { IOptions } from '@wyw-in-js/processor-utils';
+import type { StrictOptions } from '@wyw-in-js/shared';
+import type {
+  PluginOptions,
+  WywInJsProcessorOptions as TransformProcessorOptions,
+} from '../index';
+
+type SharedProcessorOptions = NonNullable<StrictOptions['processors']>;
+
+declare module '@wyw-in-js/shared' {
+  interface WywInJsProcessorOptions {
+    typedProcessorOptionsTest?: {
+      minifyClassNames?: boolean;
+    };
+  }
+}
+
+describe('typed processor options', () => {
+  it('exposes augmented processor options across public option types', () => {
+    const sharedOptions: SharedProcessorOptions = {
+      typedProcessorOptionsTest: {
+        minifyClassNames: true,
+      },
+    };
+    const transformOptions: TransformProcessorOptions = sharedOptions;
+    const pluginOptions: Pick<PluginOptions, 'processors'> = {
+      processors: transformOptions,
+    };
+    const strictOptions: Pick<StrictOptions, 'processors'> = pluginOptions;
+    const processorOptions: Pick<IOptions, 'processors'> = strictOptions;
+
+    expect(
+      processorOptions.processors?.typedProcessorOptionsTest?.minifyClassNames
+    ).toBe(true);
+  });
+});

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -39,6 +39,7 @@ export type {
   Result,
   Serializable,
   Stage,
+  WywInJsProcessorOptions,
 } from './types';
 export { EvaluatedEntrypoint } from './transform/EvaluatedEntrypoint';
 export type { IEvaluatedEntrypoint } from './transform/EvaluatedEntrypoint';

--- a/packages/transform/src/types.ts
+++ b/packages/transform/src/types.ts
@@ -5,6 +5,7 @@ import type {
   Replacement,
   Rules,
   StrictOptions,
+  WywInJsProcessorOptions,
 } from '@wyw-in-js/shared';
 
 import type {
@@ -13,10 +14,12 @@ import type {
 } from './utils/TransformMetadata';
 import type { WYWTransformDiagnostic } from './utils/TransformDiagnostics';
 
-export type PluginOptions = StrictOptions & {
+export type { WywInJsProcessorOptions };
+
+export interface PluginOptions extends StrictOptions {
   configFile?: string | false;
   stage?: Stage;
-};
+}
 
 export type ParentEntrypoint = {
   evaluated: boolean;

--- a/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
@@ -53,6 +53,7 @@ export const applyOxcProcessors = (
     | 'displayName'
     | 'eval'
     | 'extensions'
+    | 'processors'
     | 'staticBindings'
     | 'tagResolver'
   > & {

--- a/packages/transform/src/utils/applyOxcProcessors/processorFactory.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/processorFactory.ts
@@ -36,7 +36,11 @@ export const createProcessor = (
   fileContext: IFileContext,
   options: Pick<
     StrictOptions,
-    'classNameSlug' | 'displayName' | 'extensions' | 'tagResolver'
+    | 'classNameSlug'
+    | 'displayName'
+    | 'extensions'
+    | 'processors'
+    | 'tagResolver'
   >,
   code: string,
   loc: LocationLookup,

--- a/packages/transform/src/utils/collectOxcRuntime/types.ts
+++ b/packages/transform/src/utils/collectOxcRuntime/types.ts
@@ -9,6 +9,7 @@ export type OxcCollectOptions = Pick<
   | 'displayName'
   | 'eval'
   | 'extensions'
+  | 'processors'
   | 'tagResolver'
   | 'variableNameConfig'
 > & {

--- a/packages/transform/src/utils/oxcPreevalStage/types.ts
+++ b/packages/transform/src/utils/oxcPreevalStage/types.ts
@@ -12,6 +12,7 @@ export type OxcPreevalOptions = Pick<
   | 'eval'
   | 'extensions'
   | 'features'
+  | 'processors'
   | 'staticBindings'
   | 'tagResolver'
 > & { eventEmitter?: EventEmitter };


### PR DESCRIPTION
## Summary
- Add an augmentable `WywInJsProcessorOptions` interface and `processors` option channel across shared, transform, and processor-utils types.
- Pass processor options through the Oxc processor creation path so processors can read `this.options.processors`.
- Document the processor option namespace and add a minor changeset.

## Test Plan
- `bun run --filter @wyw-in-js/shared build:types`
- `bun run --filter @wyw-in-js/processor-utils build:types`
- `bun run --filter @wyw-in-js/transform test`
- `bun run --filter @wyw-in-js/transform build:types`