### PR TITLE
fix(release): skip private workspaces in version alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "sp:format": "syncpack format",
     "sp:list": "syncpack list-mismatches",
     "validate-versions": "node ./scripts/validate-versions.mjs",
-    "test": "bun run --filter './apps/*' --filter './e2e/*' --filter './examples/*' --filter './packages/*' --if-present test",
+    "test": "bun run test:scripts && bun run --filter './apps/*' --filter './e2e/*' --filter './examples/*' --filter './packages/*' --if-present test",
+    "test:scripts": "node --test scripts/__tests__/*.test.mjs",
     "version": "node ./scripts/bump-versions.mjs && changeset version",
     "version:alpha": "node ./scripts/ensure-prerelease-mode.mjs alpha && bun run version",
     "website": "bun run --filter @wyw-in-js/website deploy"

--- a/scripts/__tests__/bump-versions.test.mjs
+++ b/scripts/__tests__/bump-versions.test.mjs
@@ -1,0 +1,138 @@
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../..');
+const bumpVersionsScript = join(repoRoot, 'scripts/bump-versions.mjs');
+const changesetBin = join(
+  repoRoot,
+  process.platform === 'win32'
+    ? 'node_modules/.bin/changeset.cmd'
+    : 'node_modules/.bin/changeset'
+);
+
+function writeJSON(filename, value) {
+  writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writePackage(root, packagePath, packageJson) {
+  const packageRoot = join(root, packagePath);
+  mkdirSync(packageRoot, { recursive: true });
+  writeJSON(join(packageRoot, 'package.json'), packageJson);
+}
+
+test('bump-versions aligns only publishable workspaces', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wyw-bump-versions-'));
+
+  try {
+    writeJSON(join(root, 'package.json'), {
+      name: 'fixture-root',
+      private: true,
+      version: '1.0.0',
+      workspaces: ['.', 'packages/*', 'examples/*'],
+    });
+
+    mkdirSync(join(root, '.changeset'), { recursive: true });
+    writeJSON(join(root, '.changeset/config.json'), {
+      access: 'restricted',
+      baseBranch: 'main',
+      changelog: false,
+      commit: false,
+      fixed: [],
+      ignore: [],
+      linked: [],
+      privatePackages: {
+        tag: false,
+        version: false,
+      },
+      updateInternalDependencies: 'patch',
+    });
+    writeFileSync(
+      join(root, '.changeset/minor-core.md'),
+      [
+        '---',
+        '"@fixture/core": minor',
+        '---',
+        '',
+        'Add a public API.',
+        '',
+      ].join('\n')
+    );
+
+    writePackage(root, 'packages/core', {
+      name: '@fixture/core',
+      version: '1.0.0',
+    });
+    writePackage(root, 'packages/adapter', {
+      name: '@fixture/adapter',
+      version: '1.0.5',
+    });
+    writePackage(root, 'examples/demo', {
+      name: '@fixture/demo',
+      private: true,
+      version: '0.1.0',
+    });
+
+    const result = spawnSync(process.execPath, [bumpVersionsScript], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`.trim());
+
+    const generatedChangeset = readdirSync(join(root, '.changeset'))
+      .filter((filename) => filename.endsWith('.md'))
+      .filter((filename) => filename !== 'minor-core.md');
+
+    assert.equal(generatedChangeset.length, 1);
+
+    const contents = readFileSync(
+      join(root, '.changeset', generatedChangeset[0]),
+      'utf8'
+    );
+
+    assert.match(contents, /"@fixture\/adapter": minor/);
+    assert.doesNotMatch(contents, /@fixture\/demo/);
+
+    const versionResult = spawnSync(changesetBin, ['version'], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+
+    assert.equal(
+      versionResult.status,
+      0,
+      `${versionResult.stdout}\n${versionResult.stderr}`.trim()
+    );
+    assert.equal(
+      JSON.parse(readFileSync(join(root, 'packages/core/package.json'), 'utf8'))
+        .version,
+      '1.1.0'
+    );
+    assert.equal(
+      JSON.parse(
+        readFileSync(join(root, 'packages/adapter/package.json'), 'utf8')
+      ).version,
+      '1.1.0'
+    );
+    assert.equal(
+      JSON.parse(readFileSync(join(root, 'examples/demo/package.json'), 'utf8'))
+        .version,
+      '0.1.0'
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});

--- a/scripts/bump-versions.mjs
+++ b/scripts/bump-versions.mjs
@@ -7,7 +7,7 @@ import semver from 'semver';
 import { getWorkspaces } from './helpers/getWorkspaces.mjs';
 
 const { releases } = await getReleasePlan.default(cwd(), undefined, {});
-const workspaces = getWorkspaces(cwd());
+const workspaces = getWorkspaces(cwd(), { includePrivate: false });
 
 const shouldAlignAll = releases.some(
   (release) => release.type === 'major' || release.type === 'minor'

--- a/scripts/helpers/getWorkspaces.mjs
+++ b/scripts/helpers/getWorkspaces.mjs
@@ -4,7 +4,8 @@ import { globSync } from 'glob';
 
 import { getJSON } from './getJSON.mjs';
 
-export function getWorkspaces(cwd) {
+export function getWorkspaces(cwd, options = {}) {
+  const { includePrivate = true } = options;
   const pkgJson = getJSON(join(cwd, 'package.json'));
   const globs = getWorkspacePatterns(pkgJson);
 
@@ -13,12 +14,17 @@ export function getWorkspaces(cwd) {
       const pkgJson = getJSON(pkg);
       return {
         name: pkgJson.name,
+        private: Boolean(pkgJson.private),
         version: pkgJson.version,
       };
     })
   );
 
   return packages.reduce((acc, pkg) => {
+    if (!includePrivate && pkg.private) {
+      return acc;
+    }
+
     acc[pkg.name] = pkg.version;
     return acc;
   }, {});


### PR DESCRIPTION
## Summary

Fix the release version alignment step so the synthetic "Bump versions" changeset only includes publishable workspaces.

## Root Cause

`bump-versions.mjs` aligned all workspaces when a minor or major release was present. That included private root, docs, examples, configs, and e2e packages. With `privatePackages.version=false`, Changesets treats those packages as ignored, so the generated alignment changeset became mixed and `changeset version` failed.

## Changes

- Add an `includePrivate` option to the workspace helper.
- Use publishable workspaces only for release version alignment.
- Add a script-level regression test that runs `bump-versions.mjs` and then `changeset version` in a temporary fixture with public and private workspaces.
- Include script tests in the root `test` command.

## Verification

- `node --test scripts/__tests__/bump-versions.test.mjs`
- `bun run test:scripts`
- `bun run lint:scripts`
