### PR TITLE
feat(transform): actionable eval.strategy "static" failure diagnostics

### DIFF
--- a/.changeset/static-strategy-diagnostics.md
+++ b/.changeset/static-strategy-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/transform": patch
+---
+
+Improve `eval.strategy: "static"` failure diagnostics. Errors now lead with the source expression the developer wrote (e.g. `themeVars.panelBg`) instead of bare `_exp` codegen placeholders, surface the specific per-value reason the resolver determined (unanalyzable import, non-serializable value, missing/undefined export, or runtime function call), and group values by shared cause with `(×N)` dedupe so a real build no longer prints hundreds of near-identical low-signal lines.

--- a/packages/transform/src/__tests__/transform.static-strategy-failure.test.ts
+++ b/packages/transform/src/__tests__/transform.static-strategy-failure.test.ts
@@ -82,7 +82,12 @@ describe('eval.strategy "static" failure diagnostics', () => {
       expect(message).toContain('eval.strategy: "static"');
       // The actionable bits: the source expression and where it came from.
       expect(message).toContain('warm.light');
-      expect(message).toContain('imported from ./theme.js');
+      expect(message).toContain('from ./theme.js');
+      // Source expression leads; the _exp placeholder is not shown when known.
+      expect(message).not.toMatch(/-\s+_exp/);
+      // A specific reason replaces the generic catch-all sentence.
+      expect(message).toContain("isn't statically analyzable");
+      expect(message).not.toContain('They reference runtime-only values');
       // The unresolvable neutral.light DID resolve, so must not be listed.
       expect(message).not.toContain('neutral.light');
       // Hint to the escape hatch.
@@ -114,6 +119,10 @@ describe('eval.strategy "static" failure diagnostics', () => {
       const { message } = error as Error;
       expect(message).toContain('eval.strategy: "static"');
       expect(message).toContain('could not be resolved at build time');
+      // No source expression is available here, so the _exp placeholder is the
+      // fallback and the generic catch-all sentence is retained.
+      expect(message).toMatch(/-\s+_exp/);
+      expect(message).toContain('They reference runtime-only values');
       expect(message).toContain('hybrid');
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/packages/transform/src/__tests__/transform.static-strategy-failure.test.ts
+++ b/packages/transform/src/__tests__/transform.static-strategy-failure.test.ts
@@ -161,4 +161,48 @@ describe('eval.strategy "static" failure diagnostics', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('dedupes repeated values and groups one shared cause', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-fail-'));
+    const genFile = join(root, 'theme.js');
+    const entryFile = join(root, 'entry.js');
+
+    writeFileSync(genFile, `export const themeVars = {};\n`);
+    writeFileSync(
+      entryFile,
+      [
+        `import { css } from 'test-css-processor';`,
+        `import { themeVars } from './theme.js';`,
+        'export const a = css`',
+        '  color: ${themeVars.textColor};',
+        '  outline-color: ${themeVars.textColor};', // duplicate of above
+        '  background: ${themeVars.panelBg};',
+        '`;',
+        'export const b = css`',
+        '  ${{',
+        '    color: themeVars.textColor,',
+        '    backgroundColor: themeVars.panelBg,',
+        '  }}',
+        '`;',
+      ].join('\n')
+    );
+
+    try {
+      await runStatic(root, entryFile);
+      throw new Error('expected static strategy to fail');
+    } catch (error) {
+      const { message } = error as Error;
+      // One shared-cause header, not repeated on every line.
+      expect(message).toContain(
+        'resolved to undefined (export missing or not exported) from ./theme.js:'
+      );
+      expect(message.match(/export missing or not exported/g)?.length).toBe(1);
+      // The repeated themeVars.textColor collapses to a single counted line.
+      expect(message).toContain('- themeVars.textColor (×2)');
+      // Inline objects are kept verbatim (no lossy truncation).
+      expect(message).toContain('backgroundColor: themeVars.panelBg');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/transform/src/__tests__/transform.static-strategy-failure.test.ts
+++ b/packages/transform/src/__tests__/transform.static-strategy-failure.test.ts
@@ -128,4 +128,37 @@ describe('eval.strategy "static" failure diagnostics', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('distinguishes a missing export (undefined) from a genuinely non-serializable value', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-fail-'));
+    const genFile = join(root, 'theme.js');
+    const entryFile = join(root, 'entry.js');
+
+    // themeVars is exported but emptied, so member access yields undefined —
+    // the "emptied module" shape, not a non-serializable value.
+    writeFileSync(genFile, `export const themeVars = {};\n`);
+    writeFileSync(
+      entryFile,
+      [
+        `import { css } from 'test-css-processor';`,
+        `import { themeVars } from './theme.js';`,
+        'export const className = css`',
+        '  color: ${themeVars.accentTextColor};',
+        '`;',
+      ].join('\n')
+    );
+
+    try {
+      await runStatic(root, entryFile);
+      throw new Error('expected static strategy to fail');
+    } catch (error) {
+      const { message } = error as Error;
+      expect(message).toContain('themeVars.accentTextColor');
+      expect(message).toContain('resolved to undefined');
+      // Must NOT mislabel an emptied export as non-serializable.
+      expect(message).not.toContain('non-serializable');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/transform/src/__tests__/transform.static-strategy-failure.test.ts
+++ b/packages/transform/src/__tests__/transform.static-strategy-failure.test.ts
@@ -1,0 +1,122 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+
+const createResolver = () => async (what: string, importer: string) => {
+  if (what === 'test-css-processor') {
+    return processorFile;
+  }
+  if (what.startsWith('.')) {
+    const base = resolve(dirname(importer), what);
+    for (const ext of ['', '.ts', '.tsx', '.js']) {
+      if (existsSync(base + ext)) {
+        return base + ext;
+      }
+    }
+    return base;
+  }
+  return null;
+};
+
+const runStatic = (root: string, entryFile: string) =>
+  transform(
+    {
+      cache: new TransformCacheCollection(),
+      options: {
+        filename: entryFile,
+        root,
+        pluginOptions: {
+          configFile: false,
+          eval: { strategy: 'static' },
+          tagResolver: (s: string, t: string) =>
+            s === 'test-css-processor' && t === 'css' ? processorFile : null,
+        },
+      },
+    },
+    readFileSync(entryFile, 'utf8'),
+    createResolver()
+  );
+
+describe('eval.strategy "static" failure diagnostics', () => {
+  it('names the original interpolation and its import source instead of bare _exp placeholders', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-fail-'));
+    const genFile = join(root, 'theme.js');
+    const entryFile = join(root, 'entry.js');
+
+    writeFileSync(
+      genFile,
+      [
+        `export const neutral = { light: { "--c": "rgb(1,1,1)" } };`,
+        // Not statically foldable -> stays an eval dependency.
+        `export const warm = { light: { "--c": "rgb(" + Date.now() + ")" } };`,
+      ].join('\n')
+    );
+    writeFileSync(
+      entryFile,
+      [
+        `import { css } from 'test-css-processor';`,
+        `import { neutral, warm } from './theme.js';`,
+        'export const className = css`',
+        '  html { ${neutral.light} }',
+        '  html.warm { ${warm.light} }',
+        '`;',
+      ].join('\n')
+    );
+
+    try {
+      await runStatic(root, entryFile);
+      throw new Error('expected static strategy to fail');
+    } catch (error) {
+      const { message } = error as Error;
+      expect(message).toContain('eval.strategy: "static"');
+      // The actionable bits: the source expression and where it came from.
+      expect(message).toContain('warm.light');
+      expect(message).toContain('imported from ./theme.js');
+      // The unresolvable neutral.light DID resolve, so must not be listed.
+      expect(message).not.toContain('neutral.light');
+      // Hint to the escape hatch.
+      expect(message).toContain('hybrid');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still gives the actionable hint when only a placeholder name is available', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-fail-'));
+    const entryFile = join(root, 'entry.js');
+
+    writeFileSync(
+      entryFile,
+      [
+        `import { css } from 'test-css-processor';`,
+        `const spacing = Date.now();`,
+        'export const className = css`',
+        '  margin: ${spacing}px;',
+        '`;',
+      ].join('\n')
+    );
+
+    try {
+      await runStatic(root, entryFile);
+      throw new Error('expected static strategy to fail');
+    } catch (error) {
+      const { message } = error as Error;
+      expect(message).toContain('eval.strategy: "static"');
+      expect(message).toContain('could not be resolved at build time');
+      expect(message).toContain('hybrid');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/candidateResolver.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/candidateResolver.ts
@@ -10,7 +10,11 @@ import {
 } from '../../../utils/collectOxcTemplateDependencies';
 import type { ITransformAction, SyncScenarioFor } from '../../types';
 import { resolveDependency } from './dependencies';
-import { debugStaticResolve, getStaticBindings } from './environment';
+import {
+  debugStaticResolve,
+  getStaticBindings,
+  type StaticRejectionReason,
+} from './environment';
 import { resolveImportValue } from './exportResolver';
 import { resolveImportAsOpaqueRuntime } from './opaqueRuntime';
 import {
@@ -24,8 +28,13 @@ export function* resolveCandidateValue(
   action: ITransformAction,
   candidate: OxcStaticValueCandidate,
   filename: string,
-  memo: Map<string, StaticExportResult | null>
+  memo: Map<string, StaticExportResult | null>,
+  reasons?: Map<string, StaticRejectionReason>
 ): SyncScenarioFor<StaticExportResult | null> {
+  const reject = (reason: StaticRejectionReason): null => {
+    reasons?.set(candidate.name, reason);
+    return null;
+  };
   const env = new Map<string, unknown>();
   const dependencies = new Set<string>();
   const sideEffectDependencies = new Set<string>();
@@ -93,7 +102,7 @@ export function* resolveCandidateValue(
         source: item.source,
         status: 'rejected',
       });
-      return null;
+      return reject('candidate-import-unresolved');
     }
 
     if (resolved.callable === 'zero-arg' && candidateExpression === undefined) {
@@ -124,7 +133,7 @@ export function* resolveCandidateValue(
         source: item.source,
         status: 'rejected',
       });
-      return null;
+      return reject('candidate-callable-usage-unsupported');
     }
 
     if (!expressionForBinding) {
@@ -185,7 +194,7 @@ export function* resolveCandidateValue(
       reason: 'candidate-expression-non-serializable',
       status: 'rejected',
     });
-    return null;
+    return reject('candidate-expression-non-serializable');
   }
 
   debugStaticResolve(action, {

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/candidateResolver.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/candidateResolver.ts
@@ -187,14 +187,21 @@ export function* resolveCandidateValue(
   }
 
   if (!isOxcStaticSerializableValue(value)) {
+    // A bare `undefined` here means the import resolved but the export is
+    // missing/empty (e.g. an emptied module) — distinct from a value that is
+    // genuinely non-serializable (functions are already handled above).
+    const reason =
+      value === undefined
+        ? 'candidate-expression-undefined'
+        : 'candidate-expression-non-serializable';
     debugStaticResolve(action, {
       candidate: candidate.name,
       filename,
       phase: 'candidate',
-      reason: 'candidate-expression-non-serializable',
+      reason,
       status: 'rejected',
     });
-    return reject('candidate-expression-non-serializable');
+    return reject(reason);
   }
 
   debugStaticResolve(action, {

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
@@ -70,20 +70,20 @@ export type UnresolvedValueDetail = {
   reason?: StaticRejectionReason;
 };
 
-const formatUnresolvedValue = (
+const leadFor = (
   name: string,
   detail: UnresolvedValueDetail | undefined
 ): string => {
   // Lead with the source expression the developer wrote; fall back to the
   // `_exp` placeholder only when no source is available.
-  const lead = detail?.source && detail.source !== name ? detail.source : name;
-  const origin = detail?.importedFrom
-    ? ` (from ${detail.importedFrom})`
-    : '';
-  const explanation = detail?.reason
-    ? ` — ${reasonExplanations[detail.reason]}`
-    : '';
-  return `${lead}${explanation}${origin}`;
+  return detail?.source && detail.source !== name ? detail.source : name;
+};
+
+type Grouped = {
+  importedFrom?: string;
+  reason?: StaticRejectionReason;
+  /** lead text -> occurrence count, deduped within the file */
+  leads: Map<string, number>;
 };
 
 export const getStaticStrategyFailure = (
@@ -92,23 +92,61 @@ export const getStaticStrategyFailure = (
   details?: ReadonlyMap<string, UnresolvedValueDetail>
 ): Error => {
   const names = [...dependencyNames];
-  const formatted = names.map((name) =>
-    formatUnresolvedValue(name, details?.get(name))
-  );
+
+  // Group by (module, reason): an emptied module produces one group covering
+  // every value, so the shared cause is stated once and the leads listed bare.
+  const groups: Grouped[] = [];
+  for (const name of names) {
+    const detail = details?.get(name);
+    const lead = leadFor(name, detail);
+    let group = groups.find(
+      (g) =>
+        g.importedFrom === detail?.importedFrom && g.reason === detail?.reason
+    );
+    if (!group) {
+      group = {
+        importedFrom: detail?.importedFrom,
+        reason: detail?.reason,
+        leads: new Map(),
+      };
+      groups.push(group);
+    }
+    group.leads.set(lead, (group.leads.get(lead) ?? 0) + 1);
+  }
+
+  const renderLead = (lead: string, count: number): string =>
+    count > 1 ? `  - ${lead} (×${count})` : `  - ${lead}`;
+
+  const renderGroup = (group: Grouped): string => {
+    const leadLines = [...group.leads]
+      .map(([lead, count]) => renderLead(lead, count))
+      .join('\n');
+    const explanation = group.reason
+      ? reasonExplanations[group.reason]
+      : undefined;
+    const origin = group.importedFrom ? ` from ${group.importedFrom}` : '';
+    // A single shared cause becomes a header; otherwise leave leads bare.
+    if (explanation || origin) {
+      return `${
+        explanation ?? 'could not be resolved'
+      }${origin}:\n${leadLines}`;
+    }
+    return leadLines;
+  };
+
+  const body = groups.map(renderGroup).join('\n\n');
 
   // The generic catch-all is only useful when no value carries a specific
-  // reason; otherwise the per-line explanations already say why.
-  const anyReason = names.some((name) => details?.get(name)?.reason);
+  // reason; otherwise the per-group explanations already say why.
+  const anyReason = groups.some((group) => group.reason);
   const generic = anyReason
     ? ''
-    : `\n\nThey reference runtime-only values (function calls, mutated objects, ` +
-      `non-serializable data, or modules the static evaluator skips).`;
+    : `\nThey reference runtime-only values (function calls, mutated objects, ` +
+      `non-serializable data, or modules the static evaluator skips).\n`;
 
   return new Error(
     `[wyw-in-js] eval.strategy: "static" cannot fall back to the build-time evaluator for ${filename}.\n` +
-      `These interpolated values could not be resolved at build time:\n${formatted
-        .map((line) => `  - ${line}`)
-        .join('\n')}${generic}\n\n` +
+      `These interpolated values could not be resolved at build time:\n${body}\n${generic}\n` +
       `Either make them statically analyzable, or relax eval.strategy from "static" to "hybrid".`
   );
 };

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
@@ -41,14 +41,49 @@ export const isEnvDisabled = (value: string): boolean =>
 export const getEvalStrategy = (action: ITransformAction) =>
   action.services.options.pluginOptions.eval?.strategy ?? 'execute';
 
+export type UnresolvedValueDetail = {
+  /** Original source text of the interpolation, e.g. `theme.warm.light`. */
+  source?: string;
+  /** Module the value was imported from, when it originates from an import. */
+  importedFrom?: string;
+};
+
+const formatUnresolvedValue = (
+  name: string,
+  detail: UnresolvedValueDetail | undefined
+): string => {
+  if (!detail?.source || detail.source === name) {
+    return detail?.importedFrom
+      ? `${name} (imported from ${detail.importedFrom})`
+      : name;
+  }
+
+  const origin = detail.importedFrom
+    ? `, imported from ${detail.importedFrom}`
+    : '';
+  return `${name} (\`${detail.source}\`${origin})`;
+};
+
 export const getStaticStrategyFailure = (
   filename: string,
-  dependencyNames: Iterable<string>
-): Error =>
-  new Error(
-    `[wyw-in-js] eval.strategy: "static" cannot fall back to the build-time evaluator for ${filename}. ` +
-      `Unresolved values: ${[...dependencyNames].join(', ')}.`
+  dependencyNames: Iterable<string>,
+  details?: ReadonlyMap<string, UnresolvedValueDetail>
+): Error => {
+  const formatted = [...dependencyNames].map((name) =>
+    formatUnresolvedValue(name, details?.get(name))
   );
+
+  return new Error(
+    `[wyw-in-js] eval.strategy: "static" cannot fall back to the build-time evaluator for ${filename}.\n` +
+      `These interpolated values could not be resolved at build time:\n${formatted
+        .map((line) => `  - ${line}`)
+        .join(
+          '\n'
+        )}\n\nThey reference runtime-only values (function calls, mutated objects, ` +
+      `non-serializable data, or modules the static evaluator skips). ` +
+      `Either make them statically analyzable, or relax eval.strategy from "static" to "hybrid".`
+  );
+};
 
 export const debugStaticResolve = (
   action: ITransformAction,

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
@@ -41,27 +41,46 @@ export const isEnvDisabled = (value: string): boolean =>
 export const getEvalStrategy = (action: ITransformAction) =>
   action.services.options.pluginOptions.eval?.strategy ?? 'execute';
 
+/** Reason codes emitted by the static resolver when a candidate is rejected. */
+export type StaticRejectionReason =
+  | 'candidate-import-unresolved'
+  | 'candidate-callable-usage-unsupported'
+  | 'candidate-expression-non-serializable'
+  | 'runtime-callback'
+  | 'not-eval-dependency';
+
+const reasonExplanations: Record<StaticRejectionReason, string> = {
+  'candidate-import-unresolved': "imported value isn't statically analyzable",
+  'candidate-callable-usage-unsupported': 'depends on a runtime function call',
+  'candidate-expression-non-serializable':
+    'value is non-serializable at build time',
+  'runtime-callback': 'depends on a runtime function call',
+  'not-eval-dependency': "imported value isn't statically analyzable",
+};
+
 export type UnresolvedValueDetail = {
   /** Original source text of the interpolation, e.g. `theme.warm.light`. */
   source?: string;
   /** Module the value was imported from, when it originates from an import. */
   importedFrom?: string;
+  /** Why the value could not be resolved, when the resolver determined it. */
+  reason?: StaticRejectionReason;
 };
 
 const formatUnresolvedValue = (
   name: string,
   detail: UnresolvedValueDetail | undefined
 ): string => {
-  if (!detail?.source || detail.source === name) {
-    return detail?.importedFrom
-      ? `${name} (imported from ${detail.importedFrom})`
-      : name;
-  }
-
-  const origin = detail.importedFrom
-    ? `, imported from ${detail.importedFrom}`
+  // Lead with the source expression the developer wrote; fall back to the
+  // `_exp` placeholder only when no source is available.
+  const lead = detail?.source && detail.source !== name ? detail.source : name;
+  const origin = detail?.importedFrom
+    ? ` (from ${detail.importedFrom})`
     : '';
-  return `${name} (\`${detail.source}\`${origin})`;
+  const explanation = detail?.reason
+    ? ` — ${reasonExplanations[detail.reason]}`
+    : '';
+  return `${lead}${explanation}${origin}`;
 };
 
 export const getStaticStrategyFailure = (
@@ -69,18 +88,24 @@ export const getStaticStrategyFailure = (
   dependencyNames: Iterable<string>,
   details?: ReadonlyMap<string, UnresolvedValueDetail>
 ): Error => {
-  const formatted = [...dependencyNames].map((name) =>
+  const names = [...dependencyNames];
+  const formatted = names.map((name) =>
     formatUnresolvedValue(name, details?.get(name))
   );
+
+  // The generic catch-all is only useful when no value carries a specific
+  // reason; otherwise the per-line explanations already say why.
+  const anyReason = names.some((name) => details?.get(name)?.reason);
+  const generic = anyReason
+    ? ''
+    : `\n\nThey reference runtime-only values (function calls, mutated objects, ` +
+      `non-serializable data, or modules the static evaluator skips).`;
 
   return new Error(
     `[wyw-in-js] eval.strategy: "static" cannot fall back to the build-time evaluator for ${filename}.\n` +
       `These interpolated values could not be resolved at build time:\n${formatted
         .map((line) => `  - ${line}`)
-        .join(
-          '\n'
-        )}\n\nThey reference runtime-only values (function calls, mutated objects, ` +
-      `non-serializable data, or modules the static evaluator skips). ` +
+        .join('\n')}${generic}\n\n` +
       `Either make them statically analyzable, or relax eval.strategy from "static" to "hybrid".`
   );
 };

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/environment.ts
@@ -46,6 +46,7 @@ export type StaticRejectionReason =
   | 'candidate-import-unresolved'
   | 'candidate-callable-usage-unsupported'
   | 'candidate-expression-non-serializable'
+  | 'candidate-expression-undefined'
   | 'runtime-callback'
   | 'not-eval-dependency';
 
@@ -54,6 +55,8 @@ const reasonExplanations: Record<StaticRejectionReason, string> = {
   'candidate-callable-usage-unsupported': 'depends on a runtime function call',
   'candidate-expression-non-serializable':
     'value is non-serializable at build time',
+  'candidate-expression-undefined':
+    'resolved to undefined (export missing or not exported)',
   'runtime-callback': 'depends on a runtime function call',
   'not-eval-dependency': "imported value isn't statically analyzable",
 };

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/resolveStaticOxcPreevalValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/resolveStaticOxcPreevalValues.ts
@@ -15,7 +15,10 @@ import {
   getStaticStrategyFailure,
   parseProgram,
 } from './environment';
-import type { UnresolvedValueDetail } from './environment';
+import type {
+  StaticRejectionReason,
+  UnresolvedValueDetail,
+} from './environment';
 import {
   collectWYWMetaExtendsHelperNames,
   createSameFileStaticWYWMetaHelperResolver,
@@ -49,6 +52,9 @@ export function* resolveStaticOxcPreevalValues(
   }
   const staticOnly = evalStrategy === 'static';
 
+  // candidate name -> why it was rejected, populated by the resolvers below.
+  const rejectionReasons = new Map<string, StaticRejectionReason>();
+
   const buildUnresolvedDetails = (
     names: Iterable<string>
   ): Map<string, UnresolvedValueDetail> => {
@@ -62,6 +68,7 @@ export function* resolveStaticOxcPreevalValues(
       details.set(candidate.name, {
         source: candidate.source,
         importedFrom: candidate.imports[0]?.source,
+        reason: rejectionReasons.get(candidate.name),
       });
     }
 
@@ -149,6 +156,7 @@ export function* resolveStaticOxcPreevalValues(
       !isOpaqueRuntimeBaseHelper &&
       !staticValueCache.has(candidate.name)
     ) {
+      rejectionReasons.set(candidate.name, 'not-eval-dependency');
       debugStaticResolve(this, {
         candidate: candidate.name,
         filename,
@@ -194,11 +202,18 @@ export function* resolveStaticOxcPreevalValues(
           this,
           candidate,
           filename,
-          memo
+          memo,
+          rejectionReasons
         );
       }
     } else {
-      resolved = yield* resolveCandidateValue(this, candidate, filename, memo);
+      resolved = yield* resolveCandidateValue(
+        this,
+        candidate,
+        filename,
+        memo,
+        rejectionReasons
+      );
     }
     if (!resolved) {
       continue;

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/resolveStaticOxcPreevalValues.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/resolveStaticOxcPreevalValues.ts
@@ -15,6 +15,7 @@ import {
   getStaticStrategyFailure,
   parseProgram,
 } from './environment';
+import type { UnresolvedValueDetail } from './environment';
 import {
   collectWYWMetaExtendsHelperNames,
   createSameFileStaticWYWMetaHelperResolver,
@@ -47,6 +48,25 @@ export function* resolveStaticOxcPreevalValues(
     return false;
   }
   const staticOnly = evalStrategy === 'static';
+
+  const buildUnresolvedDetails = (
+    names: Iterable<string>
+  ): Map<string, UnresolvedValueDetail> => {
+    const wanted = new Set(names);
+    const details = new Map<string, UnresolvedValueDetail>();
+    for (const candidate of candidates) {
+      if (!wanted.has(candidate.name) || details.has(candidate.name)) {
+        continue;
+      }
+
+      details.set(candidate.name, {
+        source: candidate.source,
+        importedFrom: candidate.imports[0]?.source,
+      });
+    }
+
+    return details;
+  };
 
   const staticValueCache =
     preevalResult.staticValueCache ?? new Map<string, unknown>();
@@ -223,7 +243,11 @@ export function* resolveStaticOxcPreevalValues(
     (!hasKnownStaticCandidate || preevalResult.staticValuesApplied)
   ) {
     if (staticOnly && evalDependencyNames.size > 0) {
-      throw getStaticStrategyFailure(filename, evalDependencyNames);
+      throw getStaticStrategyFailure(
+        filename,
+        evalDependencyNames,
+        buildUnresolvedDetails(evalDependencyNames)
+      );
     }
     return false;
   }
@@ -233,7 +257,11 @@ export function* resolveStaticOxcPreevalValues(
       !staticValueCache.has(name) && !runtimeOnlyCandidateNames.has(name)
   );
   if (staticOnly && dependencyNames.length > 0) {
-    throw getStaticStrategyFailure(filename, dependencyNames);
+    throw getStaticStrategyFailure(
+      filename,
+      dependencyNames,
+      buildUnresolvedDetails(dependencyNames)
+    );
   }
   preevalResult.dependencyNames = dependencyNames;
   preevalResult.staticValueCache = staticValueCache;


### PR DESCRIPTION
## What

Improves the error thrown when `eval.strategy: "static"` cannot resolve an
interpolated value at build time. Previously each value was listed as a bare
codegen placeholder (`_exp7`, `_exp22`, …) followed by a generic
four-reason sentence repeated on every error — in a real build that meant
hundreds of near-identical, low-signal lines.

## Changes

- **Source-first lines.** Lead with the expression the developer wrote
  (`themeVars.smth`), not the `_exp` placeholder. The
  placeholder is only shown as a fallback when no source is available.
- **Per-value reason.** Surface the actual reason the resolver determined,
  replacing the generic catch-all:
  - `imported value isn't statically analyzable`
  - `value is non-serializable at build time`
  - `resolved to undefined (export missing or not exported)` — distinguishes
    an emptied/missing export (previously mislabeled "non-serializable")
  - `depends on a runtime function call`
- **Grouping + dedupe.** Values are grouped by `(module, reason)` under one
  shared-cause header; identical entries collapse to a single line with a
  `(×N)` count. Mixed-reason files split into per-reason sections.
- Object/template-literal sources are shown verbatim (no lossy truncation).

## Example
```
resolved to undefined (export missing or not exported) from ./design-system:
  - themeVars.borderSeparatorDimmed
  - themeVars.panelBg
  - themeVars.accentTextColor (×3)
```

## Tests

`packages/transform/src/__tests__/transform.static-strategy-failure.test.ts`
covers source-first formatting, the `_exp` fallback, the missing-export vs
non-serializable distinction, and grouping/dedupe. Typecheck clean.
