### PR TITLE
Fix external ESM asset imports in eval runner

### DIFF
--- a/.changeset/quiet-buckets-collect.md
+++ b/.changeset/quiet-buckets-collect.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/transform": patch
+---
+
+Fix eval runner crashes when external ESM packages import CSS or other assets from node_modules.

--- a/e2e/vite/scripts/test.mjs
+++ b/e2e/vite/scripts/test.mjs
@@ -161,6 +161,70 @@ export const className = css\`
   }
 }
 
+async function runExternalCssSideEffectCase() {
+  const fixtureDir = await fs.mkdtemp(
+    path.join(PKG_DIR, 'external-css-fixture-')
+  );
+  const srcDir = path.join(fixtureDir, 'src');
+  const outDir = path.join(fixtureDir, 'dist');
+  const fakePackageDir = path.join(
+    fixtureDir,
+    'node_modules',
+    'external-css-package'
+  );
+
+  try {
+    await fs.mkdir(srcDir, { recursive: true });
+    await fs.mkdir(fakePackageDir, { recursive: true });
+    await fs.writeFile(
+      path.join(srcDir, 'index.ts'),
+      [
+        "import { css } from '@wyw-in-js/template-tag-syntax';",
+        "import { externalColor } from 'external-css-package';",
+        '',
+        'export const className = css`',
+        '  color: ${externalColor};',
+        '`;',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(fakePackageDir, 'package.json'),
+      `${JSON.stringify(
+        {
+          name: 'external-css-package',
+          version: '1.0.0',
+          type: 'module',
+          exports: './index.js',
+        },
+        null,
+        2
+      )}\n`,
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(fakePackageDir, 'index.js'),
+      [
+        "import './styles.css';",
+        '',
+        "export const externalColor = globalThis.__externalColor || 'red';",
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(fakePackageDir, 'styles.css'),
+      '.external-css-package { color: red; }\n',
+      'utf8'
+    );
+
+    await buildArtefactWithPlugin(fixtureDir, outDir, wyw());
+  } finally {
+    await fs.rm(fixtureDir, { recursive: true, force: true });
+  }
+}
+
 async function assertFileMatches(filePath, pattern) {
   const contents = normalizeLineEndings(await fs.readFile(filePath, 'utf-8'));
 
@@ -318,6 +382,9 @@ const main = async () => {
 
   console.log(colors.blue('Running case:'), 'rebuildOutputMetadata');
   await runReusedPluginMetadataRebuildCase();
+
+  console.log(colors.blue('Running case:'), 'externalCssSideEffect');
+  await runExternalCssSideEffectCase();
 
   const preserveModulesCases = [
     {

--- a/packages/transform/src/__tests__/eval-broker.test.ts
+++ b/packages/transform/src/__tests__/eval-broker.test.ts
@@ -2578,6 +2578,217 @@ describe('EvalBroker', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it('keeps ESM package entries without asset imports on the external path', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entry = join(root, 'entry.js');
+    const nodeModulesDir = join(root, 'node_modules', 'fake');
+    const dep = join(nodeModulesDir, 'index.js');
+
+    mkdirSync(nodeModulesDir, { recursive: true });
+    writeFileSync(join(nodeModulesDir, 'package.json'), '{"type":"module"}');
+    writeFileSync(dep, 'export const value = 42;');
+    writeFileSync(
+      entry,
+      [
+        "import { value } from 'fake';",
+        'export const __wywPreval = {',
+        '  value: () => value,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what === 'fake') {
+        return dep;
+      }
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+
+    const services = createServices(root, entry);
+    const loadAndParse = services.loadAndParseFn;
+    const loadedIds: string[] = [];
+    services.loadAndParseFn = (nextServices, id, ...rest) => {
+      loadedIds.push(id);
+      return loadAndParse(nextServices, id, ...rest);
+    };
+
+    const broker = new EvalBroker(services, asyncResolve);
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      entry,
+      ['__wywPreval'],
+      readFileSync(entry, 'utf-8')
+    );
+
+    const result = await broker.evaluate(entrypoint);
+
+    expect(result.values?.get('value')).toBe(42);
+    expect(loadedIds).not.toContain(dep);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('falls back to broker loading when an external ESM package imports CSS', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entry = join(root, 'entry.js');
+    const nodeModulesDir = join(root, 'node_modules', 'fake');
+    const dep = join(nodeModulesDir, 'index.js');
+    const css = join(nodeModulesDir, 'styles.css');
+
+    mkdirSync(nodeModulesDir, { recursive: true });
+    writeFileSync(join(nodeModulesDir, 'package.json'), '{"type":"module"}');
+    writeFileSync(css, '.fake { color: red; }');
+    writeFileSync(
+      dep,
+      ["import './styles.css';", 'export const value = 42;'].join('\n')
+    );
+    writeFileSync(
+      entry,
+      [
+        "import { value } from 'fake';",
+        'export const __wywPreval = {',
+        '  value: () => value,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what === 'fake') {
+        return dep;
+      }
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+
+    const services = createServices(root, entry);
+    const loadAndParse = services.loadAndParseFn;
+    const loadedIds: string[] = [];
+    services.loadAndParseFn = (nextServices, id, ...rest) => {
+      loadedIds.push(id);
+      return loadAndParse(nextServices, id, ...rest);
+    };
+
+    const broker = new EvalBroker(services, asyncResolve);
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      entry,
+      ['__wywPreval'],
+      readFileSync(entry, 'utf-8')
+    );
+
+    const result = await broker.evaluate(entrypoint);
+
+    expect(result.values?.get('value')).toBe(42);
+    expect(loadedIds).toContain(dep);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('loads direct node_modules asset imports through the broker', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entry = join(root, 'entry.js');
+    const nodeModulesDir = join(root, 'node_modules', 'fake');
+    const css = join(nodeModulesDir, 'styles.css');
+
+    mkdirSync(nodeModulesDir, { recursive: true });
+    writeFileSync(css, '.fake { color: red; }');
+    writeFileSync(
+      entry,
+      [
+        "import cssUrl from 'fake/styles.css';",
+        'export const __wywPreval = {',
+        '  value: () => cssUrl,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what === 'fake/styles.css') {
+        return css;
+      }
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+
+    const services = createServices(root, entry);
+    const broker = new EvalBroker(services, asyncResolve);
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      entry,
+      ['__wywPreval'],
+      readFileSync(entry, 'utf-8')
+    );
+
+    const result = await broker.evaluate(entrypoint);
+
+    expect(result.values?.get('value')).toBe(css);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('keeps CJS package entries on the external path', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
+    const entry = join(root, 'entry.js');
+    const nodeModulesDir = join(root, 'node_modules', 'fake');
+    const dep = join(nodeModulesDir, 'index.js');
+
+    mkdirSync(nodeModulesDir, { recursive: true });
+    writeFileSync(dep, 'module.exports = { value: 42 };');
+    writeFileSync(
+      entry,
+      [
+        "import fake from 'fake';",
+        'export const __wywPreval = {',
+        '  value: () => fake.value,',
+        '};',
+      ].join('\n')
+    );
+
+    const asyncResolve = jest.fn(async (what: string, importer: string) => {
+      if (what === 'fake') {
+        return dep;
+      }
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+      return null;
+    });
+
+    const services = createServices(root, entry);
+    const loadAndParse = services.loadAndParseFn;
+    const loadedIds: string[] = [];
+    services.loadAndParseFn = (nextServices, id, ...rest) => {
+      loadedIds.push(id);
+      return loadAndParse(nextServices, id, ...rest);
+    };
+
+    const broker = new EvalBroker(services, asyncResolve);
+    const entrypoint = Entrypoint.createRoot(
+      services,
+      entry,
+      ['__wywPreval'],
+      readFileSync(entry, 'utf-8')
+    );
+
+    const result = await broker.evaluate(entrypoint);
+
+    expect(result.values?.get('value')).toBe(42);
+    expect(loadedIds).not.toContain(dep);
+
+    broker.dispose();
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it('does not corrupt IPC when an external module logs to console', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-eval-broker-'));
     const entry = join(root, 'entry.js');

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1546,47 +1546,72 @@ const loadExternalModule = async (resolvedId, importer, specifier) => {
     const start = Date.now();
     debug('external:start', { specifier, resolvedId, importer });
     const requireFn = createRequireFn(importer);
-    let value;
-    let hasValue = false;
     const resolvedFile = resolvedId ? stripQueryAndHash(resolvedId) : null;
     const importTarget =
       resolvedFile && path.isAbsolute(resolvedFile)
         ? pathToFileURL(resolvedFile).href
         : specifier;
 
-    if (shouldPreferImport(resolvedFile)) {
-      value = await import(importTarget);
-      hasValue = true;
-    }
-    if (!hasValue) {
-      try {
-        value = requireFn(specifier, resolvedId ?? null);
-        hasValue = true;
-      } catch (error) {
-        if (!isErrRequireEsm(error)) {
-          throw error;
-        }
+    const loadWithNode = async () => {
+      let value;
+      let hasValue = false;
 
-        const isFileSpecifier =
-          specifier.startsWith('.') || path.isAbsolute(specifier);
-        const isPackageSpecifier =
-          !isFileSpecifier && !isBuiltinSpecifier(specifier);
-        if (resolvedId && isPackageSpecifier) {
-          try {
-            value = requireFn(specifier, null);
-            hasValue = true;
-          } catch (retryError) {
-            if (!isErrRequireEsm(retryError)) {
-              throw retryError;
+      if (shouldPreferImport(resolvedFile)) {
+        value = await import(importTarget);
+        hasValue = true;
+      }
+      if (!hasValue) {
+        try {
+          value = requireFn(specifier, resolvedId ?? null);
+          hasValue = true;
+        } catch (error) {
+          if (!isErrRequireEsm(error)) {
+            throw error;
+          }
+
+          const isFileSpecifier =
+            specifier.startsWith('.') || path.isAbsolute(specifier);
+          const isPackageSpecifier =
+            !isFileSpecifier && !isBuiltinSpecifier(specifier);
+          if (resolvedId && isPackageSpecifier) {
+            try {
+              value = requireFn(specifier, null);
+              hasValue = true;
+            } catch (retryError) {
+              if (!isErrRequireEsm(retryError)) {
+                throw retryError;
+              }
             }
           }
-        }
 
-        if (!hasValue) {
-          value = await import(importTarget);
-          hasValue = true;
+          if (!hasValue) {
+            value = await import(importTarget);
+            hasValue = true;
+          }
         }
       }
+
+      return value;
+    };
+
+    let value;
+    try {
+      value = await loadWithNode();
+    } catch (error) {
+      if (
+        resolvedFile &&
+        isNodeModulesId(resolvedFile) &&
+        isUnknownFileExtensionError(error)
+      ) {
+        debug('external:fallback-broker', {
+          specifier,
+          resolvedId,
+          importer,
+          errorCode: error?.code,
+        });
+        return loadModule(resolvedFile, importer, specifier);
+      }
+      throw error;
     }
 
     const module = createSyntheticModule(cacheId, toSyntheticExports(value));
@@ -1606,22 +1631,29 @@ const loadExternalModule = async (resolvedId, importer, specifier) => {
   }
 };
 
-const shouldLoadNodeModulesWithBroker = (resolvedId) => {
+const isUnknownFileExtensionError = (error) => {
+  const seen = new Set();
+  let current = error;
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    if (current.code === 'ERR_UNKNOWN_FILE_EXTENSION') {
+      return true;
+    }
+    seen.add(current);
+    current = current.cause;
+  }
+  return false;
+};
+
+const shouldLoadNodeModulesAssetWithBroker = (resolvedId) => {
   if (!isNodeModulesId(resolvedId)) return false;
 
   const resolvedFile = stripQueryAndHash(resolvedId);
   if (!path.isAbsolute(resolvedFile)) return false;
 
   const extension = path.extname(resolvedFile);
-  if (extension === '.cjs' || extension === '.json' || extension === '.node') {
-    return false;
-  }
-
-  if (extension === '.js') {
-    return shouldPreferImport(resolvedFile);
-  }
-
-  return Boolean(extension);
+  if (!extension) return false;
+  if (extension === '.json' || extension === '.node') return false;
+  return !state.evalOptions.extensions?.includes(extension);
 };
 
 const shouldLoadAsExternalModule = (
@@ -1629,15 +1661,15 @@ const shouldLoadAsExternalModule = (
   resolvedId,
   explicitExternal
 ) => {
+  if (shouldLoadNodeModulesAssetWithBroker(resolvedId)) {
+    return false;
+  }
+
   if (explicitExternal || isBuiltinSpecifier(specifier)) {
     return true;
   }
 
-  if (!isNodeModulesId(resolvedId)) {
-    return false;
-  }
-
-  return !shouldLoadNodeModulesWithBroker(resolvedId);
+  return isNodeModulesId(resolvedId);
 };
 
 let resolveModule;

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1534,6 +1534,22 @@ const toSyntheticExports = (value) => {
   return { default: value };
 };
 
+let resolveModule;
+let loadModule;
+
+const isUnknownFileExtensionError = (error) => {
+  const seen = new Set();
+  let current = error;
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    if (current.code === 'ERR_UNKNOWN_FILE_EXTENSION') {
+      return true;
+    }
+    seen.add(current);
+    current = current.cause;
+  }
+  return false;
+};
+
 const loadExternalModule = async (resolvedId, importer, specifier) => {
   const cacheId = resolvedId ?? specifier;
   const cached = moduleCache.get(cacheId);
@@ -1631,19 +1647,6 @@ const loadExternalModule = async (resolvedId, importer, specifier) => {
   }
 };
 
-const isUnknownFileExtensionError = (error) => {
-  const seen = new Set();
-  let current = error;
-  while (current && typeof current === 'object' && !seen.has(current)) {
-    if (current.code === 'ERR_UNKNOWN_FILE_EXTENSION') {
-      return true;
-    }
-    seen.add(current);
-    current = current.cause;
-  }
-  return false;
-};
-
 const shouldLoadNodeModulesAssetWithBroker = (resolvedId) => {
   if (!isNodeModulesId(resolvedId)) return false;
 
@@ -1671,9 +1674,6 @@ const shouldLoadAsExternalModule = (
 
   return isNodeModulesId(resolvedId);
 };
-
-let resolveModule;
-let loadModule;
 
 const linkModule = async (module) => {
   const cached = linkPromises.get(module);

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -1606,6 +1606,40 @@ const loadExternalModule = async (resolvedId, importer, specifier) => {
   }
 };
 
+const shouldLoadNodeModulesWithBroker = (resolvedId) => {
+  if (!isNodeModulesId(resolvedId)) return false;
+
+  const resolvedFile = stripQueryAndHash(resolvedId);
+  if (!path.isAbsolute(resolvedFile)) return false;
+
+  const extension = path.extname(resolvedFile);
+  if (extension === '.cjs' || extension === '.json' || extension === '.node') {
+    return false;
+  }
+
+  if (extension === '.js') {
+    return shouldPreferImport(resolvedFile);
+  }
+
+  return Boolean(extension);
+};
+
+const shouldLoadAsExternalModule = (
+  specifier,
+  resolvedId,
+  explicitExternal
+) => {
+  if (explicitExternal || isBuiltinSpecifier(specifier)) {
+    return true;
+  }
+
+  if (!isNodeModulesId(resolvedId)) {
+    return false;
+  }
+
+  return !shouldLoadNodeModulesWithBroker(resolvedId);
+};
+
 let resolveModule;
 let loadModule;
 
@@ -1697,18 +1731,19 @@ resolveModule = async (specifier, importer, kind) => {
       );
     }
 
-    const treatExternal =
-      cached.external ||
-      isBuiltinSpecifier(specifier) ||
-      isNodeModulesId(cached.resolvedId);
+    const normalized = normalizeResolvedId(
+      cached.resolvedId,
+      specifier,
+      importerId,
+      state.evalOptions.extensions
+    );
+    const treatExternal = shouldLoadAsExternalModule(
+      specifier,
+      normalized,
+      cached.external
+    );
 
     if (treatExternal) {
-      const normalized = normalizeResolvedId(
-        cached.resolvedId,
-        specifier,
-        importerId,
-        state.evalOptions.extensions
-      );
       const externalModule = await loadExternalModule(
         normalized,
         importerId,
@@ -1717,12 +1752,6 @@ resolveModule = async (specifier, importer, kind) => {
       return externalModule;
     }
 
-    const normalized = normalizeResolvedId(
-      cached.resolvedId,
-      specifier,
-      importerId,
-      state.evalOptions.extensions
-    );
     return loadModule(normalized, importerId, specifier);
   }
 
@@ -1779,10 +1808,11 @@ resolveModule = async (specifier, importer, kind) => {
       );
     }
 
-    const treatExternal =
-      resolved.external ||
-      isBuiltinSpecifier(specifier) ||
-      isNodeModulesId(normalized);
+    const treatExternal = shouldLoadAsExternalModule(
+      specifier,
+      normalized,
+      resolved.external
+    );
 
     if (treatExternal) {
       return loadExternalModule(normalized, importerId, specifier);


### PR DESCRIPTION
## Summary

- route ESM and asset imports from packages in `node_modules` through the eval broker loader instead of raw Node import/require
- keep explicit externals, builtins, CommonJS, JSON, and native addons on the direct external loader path
- add a Vite e2e regression for an ESM package that imports a CSS side effect and exports a value used by `css`

## Root cause

The eval runner treated every resolved path under `node_modules` as an external module. For ESM packages, that path uses Node's native ESM loader directly, so package-side imports like `import './styles.css'` crashed with `ERR_UNKNOWN_FILE_EXTENSION` before WyW's loader fallback could handle them.

Closes #339.

## Validation

- `bun --filter @wyw-in-js/transform test`
- `bun --filter @wyw-in-js/e2e-vite test`
