### PR TITLE
Fix symbol-keyed preval metadata serialization

### DIFF
--- a/.changeset/quiet-symbols-fix.md
+++ b/.changeset/quiet-symbols-fix.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/transform": patch
+---
+
+Fix build-time evaluation for styled runtime wrappers that attach symbol-keyed metadata.

--- a/packages/transform/src/__tests__/serialize.ipc.test.ts
+++ b/packages/transform/src/__tests__/serialize.ipc.test.ts
@@ -85,6 +85,27 @@ describe('eval IPC serialization', () => {
     expect(roundTripped.nested.marker).toBe(Symbol.for('react.forward_ref'));
   });
 
+  it('drops symbol-keyed properties only when serializing __wywPreval values', () => {
+    const marker = Symbol('runtimeMetadata');
+    const input = {
+      label: 'button',
+      [marker]: 'metadata',
+    };
+
+    const roundTripped = deserializeValue(serializePreval({ input }).input) as {
+      label: string;
+    };
+
+    expect(roundTripped).toEqual({ label: 'button' });
+    expect(Object.getOwnPropertySymbols(roundTripped)).toHaveLength(0);
+    expect(() =>
+      serializeValue(input, {
+        allowSymbols: true,
+        rootLabel: 'value',
+      })
+    ).toThrow('unsupported symbol-keyed property');
+  });
+
   it('unwraps boxed primitives to their primitive payloads', () => {
     const roundTripped = deserializeValue(
       serializeValue({

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -2285,6 +2285,56 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('handles styled runtime wrappers that attach symbol-keyed component references', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const baseFile = join(root, 'BaseImage.js');
+    const hocFile = join(root, 'hocWithSymbol.js');
+    const cache = new TransformCacheCollection();
+
+    writeFileSync(
+      baseFile,
+      dedent`
+        export const BaseImage = (props) => null;
+      `
+    );
+    writeFileSync(
+      hocFile,
+      dedent`
+        export const hocSymbol = Symbol('hocSymbol');
+
+        export function wrapWithSymbol(Component) {
+          const descriptor = { render: Component };
+          descriptor[hocSymbol] = Component;
+          return descriptor;
+        }
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+        import { BaseImage } from './BaseImage.js';
+        import { wrapWithSymbol } from './hocWithSymbol.js';
+
+        export const A = styled(wrapWithSymbol(BaseImage))\`
+          border-radius: 8px;
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, cache);
+
+      expect(result.cssText).toContain('border-radius:8px');
+      expect(result.dependencies).toEqual(
+        expect.arrayContaining(['./BaseImage.js', './hocWithSymbol.js'])
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('inlines nested styled metadata object values with runtime bases without eval', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/eval/runner.js
+++ b/packages/transform/src/eval/runner.js
@@ -359,7 +359,8 @@ const serializeValueAtPath = (
   pathSegments,
   seen,
   allowFunctions,
-  allowSymbols
+  allowSymbols,
+  ignoreSymbolKeys
 ) => {
   if (value === null) {
     return { kind: 'null' };
@@ -434,7 +435,7 @@ const serializeValueAtPath = (
 
   if (Array.isArray(value)) {
     const symbolKeys = getEnumerableSymbolKeys(value);
-    if (symbolKeys.length > 0) {
+    if (symbolKeys.length > 0 && !ignoreSymbolKeys) {
       throwUnsupportedIpcValue(
         rootLabel,
         [...pathSegments, symbolKeys[0]],
@@ -464,7 +465,8 @@ const serializeValueAtPath = (
             [...pathSegments, index],
             seen,
             allowFunctions,
-            allowSymbols
+            allowSymbols,
+            ignoreSymbolKeys
           )
         ),
       };
@@ -482,7 +484,7 @@ const serializeValueAtPath = (
   }
 
   const symbolKeys = getEnumerableSymbolKeys(value);
-  if (symbolKeys.length > 0) {
+  if (symbolKeys.length > 0 && !ignoreSymbolKeys) {
     throwUnsupportedIpcValue(
       rootLabel,
       [...pathSegments, symbolKeys[0]],
@@ -503,7 +505,8 @@ const serializeValueAtPath = (
             [...pathSegments, key],
             seen,
             allowFunctions,
-            allowSymbols
+            allowSymbols,
+            ignoreSymbolKeys
           ),
         ])
       ),
@@ -526,7 +529,8 @@ const serializeValue = (value, options = {}) =>
     options.path ?? [],
     new WeakMap(),
     options.allowFunctions ?? false,
-    options.allowSymbols ?? false
+    options.allowSymbols ?? false,
+    options.ignoreSymbolKeys ?? false
   );
 
 const deserializeValue = (value) => {
@@ -2274,6 +2278,7 @@ async function evaluateEntrypoint(id) {
     values[key] = serializeValue(value, {
       allowFunctions: true,
       allowSymbols: true,
+      ignoreSymbolKeys: true,
       rootLabel: '__wywPreval',
       path: [key],
     });

--- a/packages/transform/src/eval/serialize.ts
+++ b/packages/transform/src/eval/serialize.ts
@@ -55,6 +55,7 @@ type PathSegment = string | number | symbol;
 type SerializeValueOptions = {
   allowFunctions?: boolean;
   allowSymbols?: boolean;
+  ignoreSymbolKeys?: boolean;
   path?: PathSegment[];
   rootLabel?: string;
 };
@@ -169,7 +170,8 @@ const serializeValueAtPath = (
   path: PathSegment[],
   seen: WeakMap<object, string>,
   allowFunctions: boolean,
-  allowSymbols: boolean
+  allowSymbols: boolean,
+  ignoreSymbolKeys: boolean
 ): SerializedValue => {
   if (value === null) {
     return { kind: 'null' };
@@ -264,7 +266,7 @@ const serializeValueAtPath = (
 
   if (Array.isArray(value)) {
     const symbolKeys = getEnumerableSymbolKeys(value);
-    if (symbolKeys.length > 0) {
+    if (symbolKeys.length > 0 && !ignoreSymbolKeys) {
       throwUnsupportedIpcValue(
         rootLabel,
         [...path, symbolKeys[0]],
@@ -294,7 +296,8 @@ const serializeValueAtPath = (
             [...path, index],
             seen,
             allowFunctions,
-            allowSymbols
+            allowSymbols,
+            ignoreSymbolKeys
           )
         ),
       };
@@ -312,7 +315,7 @@ const serializeValueAtPath = (
   }
 
   const symbolKeys = getEnumerableSymbolKeys(value);
-  if (symbolKeys.length > 0) {
+  if (symbolKeys.length > 0 && !ignoreSymbolKeys) {
     throwUnsupportedIpcValue(
       rootLabel,
       [...path, symbolKeys[0]],
@@ -333,7 +336,8 @@ const serializeValueAtPath = (
             [...path, key],
             seen,
             allowFunctions,
-            allowSymbols
+            allowSymbols,
+            ignoreSymbolKeys
           ),
         ])
       ),
@@ -353,7 +357,8 @@ export const serializeValue = (
     options.path ?? [],
     new WeakMap<object, string>(),
     options.allowFunctions ?? false,
-    options.allowSymbols ?? false
+    options.allowSymbols ?? false,
+    options.ignoreSymbolKeys ?? false
   );
 
 export const deserializeValue = (value: SerializedValue): unknown => {
@@ -415,6 +420,7 @@ export const serializePreval = (
       serializeValue(value, {
         allowFunctions: true,
         allowSymbols: true,
+        ignoreSymbolKeys: true,
         rootLabel: '__wywPreval',
         path: [key],
       }),


### PR DESCRIPTION
## Summary
- ignore enumerable symbol-keyed properties only while serializing `__wywPreval` values
- keep generic IPC serialization strict for symbol-keyed properties
- add regression coverage for styled runtime wrappers that attach symbol-keyed component references

Closes #342.

## Checks
- `bun --filter @wyw-in-js/transform lint`
- `bun --filter @wyw-in-js/transform test`
- `bun test packages/transform/src/__tests__/serialize.ipc.test.ts`
- `bun test --timeout 30000 packages/transform/src/__tests__/transform.static-import-values.test.ts`

## Notes
- `bun --filter @wyw-in-js/transform build:types` also fails on clean `origin/main` in a separate baseline worktree with missing workspace package declarations, so this does not appear to be introduced by this PR.