### PR TITLE
Fix Turbopack package subpath dependency resolution

### DIFF
--- a/.changeset/fuzzy-turbopack-motion.md
+++ b/.changeset/fuzzy-turbopack-motion.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/turbopack-loader": patch
+---
+
+Fix Turbopack builds when extracted CSS dependencies include package subpath imports such as `motion/react`.

--- a/packages/turbopack-loader/src/__tests__/loader.test.ts
+++ b/packages/turbopack-loader/src/__tests__/loader.test.ts
@@ -159,4 +159,67 @@ describe('turbopack-loader', () => {
 
     expect(emitted.code).toBe(':global(.a){color:red}');
   });
+
+  it('keeps CSS output when Turbopack cannot post-resolve a package dependency', async () => {
+    const { default: turbopackLoader } = await import('../index');
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wyw-turbo-'));
+    const resourcePath = path.join(tmpDir, 'entry.tsx');
+    const depPath = path.join(tmpDir, 'dep.tsx');
+    fs.writeFileSync(resourcePath, 'export const x = 1;\n');
+    fs.writeFileSync(depPath, 'export const y = 1;\n');
+
+    transformMock.mockImplementation(async (_services, code) => {
+      return {
+        code,
+        sourceMap: null,
+        cssText: '.a{color:red}',
+        dependencies: ['motion/react', './dep'],
+      };
+    });
+
+    const addDependency = jest.fn();
+    const resolveRequests: string[] = [];
+    const emitted: { code?: string } = {};
+
+    await new Promise<void>((resolve, reject) => {
+      turbopackLoader.call(
+        {
+          addDependency,
+          async: jest.fn(),
+          callback: (err: Error | null, code?: string) => {
+            if (err) reject(err);
+            else {
+              emitted.code = code;
+              resolve();
+            }
+          },
+          emitWarning: jest.fn(),
+          getOptions: () => ({}),
+          getResolve: () => async (_context: string, request: string) => {
+            resolveRequests.push(request);
+
+            if (request === 'motion/react') {
+              throw new Error(
+                "Unable to resolve module 'motion' with subpath '/react'"
+              );
+            }
+
+            if (request === './dep') {
+              return `${depPath}?compiled`;
+            }
+
+            return false;
+          },
+          resourcePath,
+        } as any,
+        fs.readFileSync(resourcePath, 'utf8'),
+        null
+      );
+    });
+
+    expect(resolveRequests).toEqual(['motion/react', './dep']);
+    expect(addDependency).toHaveBeenCalledWith(depPath);
+    expect(emitted.code).toContain('import "./entry.wyw-in-js.module.css";');
+  });
 });

--- a/packages/turbopack-loader/src/index.ts
+++ b/packages/turbopack-loader/src/index.ts
@@ -27,6 +27,49 @@ const stripQueryAndHash = (request: string) => {
   return request.slice(0, Math.min(queryIdx, hashIdx));
 };
 
+const getPackageNameForSubpath = (request: string) => {
+  const fileRequest = stripQueryAndHash(request);
+  if (
+    fileRequest.startsWith('.') ||
+    path.isAbsolute(fileRequest) ||
+    path.win32.isAbsolute(fileRequest)
+  ) {
+    return null;
+  }
+
+  const parts = fileRequest.split('/');
+
+  if (fileRequest.startsWith('@')) {
+    const [scope, name] = parts;
+    if (parts.length <= 2 || scope.length <= 1 || !name) {
+      return null;
+    }
+
+    return `${scope}/${name}`;
+  }
+
+  if (fileRequest.startsWith('#') || parts.length <= 1 || !parts[0]) {
+    return null;
+  }
+
+  return parts[0];
+};
+
+const isTurbopackPackageSubpathResolveError = (
+  request: string,
+  error: unknown
+) => {
+  const packageName = getPackageNameForSubpath(request);
+
+  return (
+    packageName !== null &&
+    error instanceof Error &&
+    error.message.includes(
+      `Unable to resolve module '${packageName}' with subpath`
+    )
+  );
+};
+
 export type LoaderOptions = {
   cssOutputMode?: 'sidecar' | 'query';
   keepComments?: boolean;
@@ -148,6 +191,16 @@ const turbopackLoader: Loader = function turbopackLoader(
     return result;
   };
 
+  const addResolvedDependency = async (dependency: string) => {
+    try {
+      await asyncResolve(dependency, this.resourcePath);
+    } catch (error) {
+      if (!isTurbopackPackageSubpathResolveError(dependency, error)) {
+        throw error;
+      }
+    }
+  };
+
   const transformServices = {
     options: {
       filename: this.resourcePath,
@@ -181,9 +234,7 @@ const turbopackLoader: Loader = function turbopackLoader(
         }
 
         await Promise.all(
-          (result.dependencies ?? []).map((dep) =>
-            asyncResolve(dep, this.resourcePath)
-          )
+          (result.dependencies ?? []).map((dep) => addResolvedDependency(dep))
         );
 
         if (outputCss) {


### PR DESCRIPTION
## Summary
- tolerate Turbopack's post-transform resolve failure for package subpath dependencies such as `motion/react`
- keep file, relative, alias, and other dependency resolve failures strict
- add regression coverage for CSS output with a package subpath dependency and a normal file dependency

Closes #345.

## Checks
- `bun --filter @wyw-in-js/turbopack-loader lint`
- `bun --filter @wyw-in-js/turbopack-loader test`
- `bun --filter @wyw-in-js/turbopack-loader build:esm`
- `bun --filter @wyw-in-js/e2e-next-turbopack test`
- verified the linked public reproduction with the locally built patched loader