### PR TITLE
Fix cleanup of forward runtime references

### DIFF
--- a/.changeset/forward-runtime-cleanup.md
+++ b/.changeset/forward-runtime-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@wyw-in-js/transform": patch
+---
+
+Preserve module-level bindings that are referenced before their declaration when runtime cleanup removes CSS-only dependencies.

--- a/packages/transform/src/__tests__/applyOxcProcessors.test.ts
+++ b/packages/transform/src/__tests__/applyOxcProcessors.test.ts
@@ -46,6 +46,11 @@ const linariaStyledProcessorPath = path.resolve(
   '__fixtures__',
   'test-styled-processor.js'
 );
+const runtimeStyledProcessorPath = path.resolve(
+  __dirname,
+  '__fixtures__',
+  'test-runtime-styled-processor.js'
+);
 
 const fileContext = {
   filename: path.join(__dirname, 'source.js'),
@@ -751,6 +756,78 @@ describe('applyOxcProcessors', () => {
     expect(result.code).toContain(
       'formatOptionLabel = formatOptionLabelDefault'
     );
+  });
+
+  it('keeps forward runtime references to styled selector dependencies', () => {
+    const result = applyOxcProcessors(
+      `
+        import { styled } from 'test-runtime-styled-processor';
+
+        export const View = () => <AdL />;
+
+        const AdL = styled.div\`
+          width: 100%;
+        \`;
+
+        const ContainerAds = styled.div\`
+          ${'${AdL}'} {
+            display: none;
+          }
+        \`;
+      `,
+      {
+        ...fileContext,
+        filename: path.join(__dirname, 'forward-styled-ref.tsx'),
+      },
+      {
+        displayName: false,
+        extensions: ['.js', '.ts', '.tsx'],
+        tagResolver: (source, imported) => {
+          if (
+            source === 'test-runtime-styled-processor' &&
+            imported === 'styled'
+          ) {
+            return runtimeStyledProcessorPath;
+          }
+
+          return null;
+        },
+      },
+      (processor) => processor.doRuntimeReplacement(),
+      true
+    );
+
+    expect(result.code).toContain('export const View = () => <AdL />;');
+    expect(result.code).toContain('const AdL =');
+  });
+
+  it('keeps forward runtime references to extracted interpolation dependencies', () => {
+    const result = applyOxcProcessors(
+      `
+        import { makeStyles } from 'test-package';
+
+        export const View = () => (
+          <div style={{ "--h": \`${'${THUMB_SIZE}'}px\` }} />
+        );
+
+        const THUMB_SIZE = 36;
+
+        const styles = makeStyles(THUMB_SIZE / 2);
+      `,
+      {
+        ...fileContext,
+        filename: path.join(__dirname, 'forward-const-ref.tsx'),
+      },
+      {
+        ...options(runtimeDependencyCallProcessorPath, 'makeStyles'),
+        extensions: ['.js', '.ts', '.tsx'],
+      },
+      (processor) => processor.doRuntimeReplacement(),
+      true
+    );
+
+    expect(result.code).toContain('`${THUMB_SIZE}px`');
+    expect(result.code).toContain('const THUMB_SIZE = 36;');
   });
 
   it('inserts imports requested by processors into the transformed module', () => {

--- a/packages/transform/src/utils/applyOxcProcessors/cleanupRemovals.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/cleanupRemovals.ts
@@ -61,6 +61,11 @@ export const collectScopedBindingInfos = (
     kind: ScopedBindingKind,
     declaration: Node
   ): string => {
+    const existingId = scope.bindings.get(name);
+    if (existingId) {
+      return existingId;
+    }
+
     const id = `${kind}:${name}:${declaration.start}:${sequence}`;
     sequence += 1;
 
@@ -85,6 +90,90 @@ export const collectScopedBindingInfos = (
   ): void => {
     collectDeclaredNames(pattern).forEach((name) => {
       addBinding(scope, name, kind, declaration);
+    });
+  };
+
+  const predeclareScopedBindings = (
+    scope: ScopedCleanupScope,
+    node: Node
+  ): void => {
+    if (node.type === 'ImportDeclaration') {
+      const { specifiers } = node as AnyNode;
+      if (Array.isArray(specifiers)) {
+        specifiers.forEach((specifier) => {
+          const { local } = specifier as AnyNode;
+          if (
+            isOxcNode(local) &&
+            local.type === 'Identifier' &&
+            typeof local.name === 'string'
+          ) {
+            addBinding(scope, local.name, 'import', node);
+          }
+        });
+      }
+      return;
+    }
+
+    if (node.type === 'ExportNamedDeclaration' && node.declaration) {
+      predeclareScopedBindings(scope, node.declaration);
+      return;
+    }
+
+    if (node.type === 'ExportDefaultDeclaration') {
+      const { declaration } = node as AnyNode;
+      if (
+        isOxcNode(declaration) &&
+        (declaration.type === 'FunctionDeclaration' ||
+          declaration.type === 'ClassDeclaration') &&
+        declaration.id
+      ) {
+        addBinding(
+          scope,
+          declaration.id.name,
+          declaration.type === 'FunctionDeclaration' ? 'function' : 'variable',
+          declaration
+        );
+      }
+      return;
+    }
+
+    if (node.type === 'VariableDeclaration') {
+      const { declarations } = node as AnyNode;
+      if (!Array.isArray(declarations)) {
+        return;
+      }
+
+      declarations.forEach((declarator) => {
+        const { id } = declarator as AnyNode;
+        if (isOxcNode(id)) {
+          addPatternBindings(scope, id, 'variable', node);
+        }
+      });
+      return;
+    }
+
+    if (node.type === 'FunctionDeclaration' && node.id) {
+      addBinding(scope, node.id.name, 'function', node);
+      return;
+    }
+
+    if (
+      (node.type === 'ClassDeclaration' || node.type === 'TSEnumDeclaration') &&
+      'id' in node
+    ) {
+      const { id } = node as AnyNode;
+      if (isOxcNode(id) && id.type === 'Identifier') {
+        addBinding(scope, id.name, 'variable', node);
+      }
+    }
+  };
+
+  const predeclareScopedStatementBindings = (
+    scope: ScopedCleanupScope,
+    statements: Node[]
+  ): void => {
+    statements.forEach((statement) => {
+      predeclareScopedBindings(scope, statement);
     });
   };
 
@@ -185,6 +274,12 @@ export const collectScopedBindingInfos = (
     parent: Node | null = null,
     ownerBindingId: string | null = null
   ): void => {
+    if (node.type === 'Program') {
+      predeclareScopedStatementBindings(scope, node.body);
+      node.body.forEach((child) => walk(child, scope, node, ownerBindingId));
+      return;
+    }
+
     if (node.type === 'ImportDeclaration') {
       const { specifiers } = node as AnyNode;
       if (Array.isArray(specifiers)) {
@@ -295,6 +390,7 @@ export const collectScopedBindingInfos = (
 
     if (node.type === 'BlockStatement') {
       const blockScope = createScopedCleanupScope(scope);
+      predeclareScopedStatementBindings(blockScope, node.body);
       getOxcNodeChildren(node).forEach((child) =>
         walk(child, blockScope, node, ownerBindingId)
       );


### PR DESCRIPTION
## Summary

- Predeclare scoped cleanup bindings before recording references.
- Preserve module-level declarations used by forward runtime references when those bindings are also extracted from CSS dependencies.
- Add regression coverage for styled selector dependencies and plain const interpolation dependencies.

## Root Cause

Runtime cleanup built its scoped dependency graph in declaration order. If a runtime reference appeared before the binding declaration, cleanup missed that edge. When CSS extraction also marked the binding as removable, the declaration could be removed while the earlier runtime reference stayed in the module.

Closes #348.

## Validation

- `bun test packages/transform/src/__tests__/applyOxcProcessors.test.ts`
- `bun test packages/transform/src/__tests__/transform.static-import-values.test.ts`
- `bun test packages/transform/src/__tests__/oxc-collect-runtime.test.ts`
- `bun run --filter @wyw-in-js/transform build:esm`
- `git diff --check`
