### PR TITLE
Fix webpack watch memory retention

### DIFF
--- a/.changeset/tidy-watches-rest.md
+++ b/.changeset/tidy-watches-rest.md
@@ -1,0 +1,6 @@
+---
+'@wyw-in-js/transform': patch
+'@wyw-in-js/webpack-loader': patch
+---
+
+Fix memory retention in webpack watch mode by clearing completed transform action graphs and avoiding cached loader context references.

--- a/packages/transform/src/__tests__/transform.action-context.test.ts
+++ b/packages/transform/src/__tests__/transform.action-context.test.ts
@@ -1,0 +1,87 @@
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+import type {
+  IWorkflowAction,
+  SyncScenarioForAction,
+} from '../transform/types';
+import { EventEmitter } from '../utils/EventEmitter';
+
+// eslint-disable-next-line require-yield
+const workflow = function* workflow(): SyncScenarioForAction<IWorkflowAction> {
+  return {
+    code: 'module.exports = 1;',
+    sourceMap: null,
+  };
+};
+
+const runTransform = (
+  cache: TransformCacheCollection,
+  eventEmitter: EventEmitter
+) =>
+  transform(
+    {
+      cache,
+      eventEmitter,
+      options: {
+        filename: '/abs/entry.tsx',
+        root: '/abs',
+        pluginOptions: {
+          configFile: false,
+        },
+      },
+    },
+    'export default 1;',
+    async () => null,
+    { workflow }
+  );
+
+describe('transform action context lifecycle', () => {
+  it('recreates the workflow action after a successful transform', async () => {
+    const cache = new TransformCacheCollection();
+    let workflowActionsCreated = 0;
+    const eventEmitter = new EventEmitter(
+      () => {},
+      () => 0,
+      (_sequenceId, _timestamp, event) => {
+        if (event.type === 'actionCreated' && event.actionType === 'workflow') {
+          workflowActionsCreated += 1;
+        }
+      }
+    );
+
+    await runTransform(cache, eventEmitter);
+    await runTransform(cache, eventEmitter);
+
+    expect(workflowActionsCreated).toBe(2);
+  });
+
+  it('disposes the action context when action instrumentation throws', async () => {
+    const cache = new TransformCacheCollection();
+    let shouldThrow = true;
+    let workflowActionsCreated = 0;
+    const eventEmitter = new EventEmitter(
+      () => {},
+      () => 0,
+      (_sequenceId, _timestamp, event) => {
+        if (event.type !== 'actionCreated' || event.actionType !== 'workflow') {
+          return;
+        }
+
+        workflowActionsCreated += 1;
+        if (shouldThrow) {
+          shouldThrow = false;
+          throw new Error('action instrumentation failed');
+        }
+      }
+    );
+
+    await expect(runTransform(cache, eventEmitter)).rejects.toThrow(
+      'action instrumentation failed'
+    );
+    await expect(runTransform(cache, eventEmitter)).resolves.toMatchObject({
+      code: 'module.exports = 1;',
+    });
+
+    expect(workflowActionsCreated).toBe(2);
+  });
+});

--- a/packages/transform/src/transform.ts
+++ b/packages/transform/src/transform.ts
@@ -187,11 +187,12 @@ export async function transform(
 
   // Separate top-level runs must not share action state, even for the same
   // entrypoint, otherwise concurrent transforms can collide in BaseAction.run.
+  const actionContext = Entrypoint.createActionContext();
   const workflowAction = entrypoint.createAction(
     'workflow',
     undefined,
     null,
-    {}
+    actionContext
   );
 
   if (!memoizedAsyncResolve.has(asyncResolve)) {
@@ -230,5 +231,7 @@ export async function transform(
     }
 
     throw err;
+  } finally {
+    Entrypoint.disposeActionContext(actionContext);
   }
 }

--- a/packages/transform/src/transform.ts
+++ b/packages/transform/src/transform.ts
@@ -15,6 +15,10 @@ import { isFeatureEnabled } from '@wyw-in-js/shared';
 import type { PartialOptions } from './transform/helpers/loadWywOptions';
 import { loadWywOptions } from './transform/helpers/loadWywOptions';
 import { TransformCacheCollection } from './cache';
+import {
+  createActionContext,
+  disposeActionContext,
+} from './transform/ActionContext';
 import { Entrypoint } from './transform/Entrypoint';
 import { asyncActionRunner } from './transform/actions/actionRunner';
 import { baseHandlers } from './transform/generators';
@@ -187,25 +191,26 @@ export async function transform(
 
   // Separate top-level runs must not share action state, even for the same
   // entrypoint, otherwise concurrent transforms can collide in BaseAction.run.
-  const actionContext = Entrypoint.createActionContext();
-  const workflowAction = entrypoint.createAction(
-    'workflow',
-    undefined,
-    null,
-    actionContext
-  );
-
-  if (!memoizedAsyncResolve.has(asyncResolve)) {
-    const resolveImports = function resolveImports(
-      this: IResolveImportsAction
-    ) {
-      return asyncResolveImports.call(this, asyncResolve);
-    };
-
-    memoizedAsyncResolve.set(asyncResolve, resolveImports);
-  }
+  const actionContext = createActionContext();
 
   try {
+    const workflowAction = entrypoint.createAction(
+      'workflow',
+      undefined,
+      null,
+      actionContext
+    );
+
+    if (!memoizedAsyncResolve.has(asyncResolve)) {
+      const resolveImports = function resolveImports(
+        this: IResolveImportsAction
+      ) {
+        return asyncResolveImports.call(this, asyncResolve);
+      };
+
+      memoizedAsyncResolve.set(asyncResolve, resolveImports);
+    }
+
     const result = await asyncActionRunner(workflowAction, {
       ...baseHandlers,
       ...customHandlers,
@@ -232,6 +237,6 @@ export async function transform(
 
     throw err;
   } finally {
-    Entrypoint.disposeActionContext(actionContext);
+    disposeActionContext(actionContext);
   }
 }

--- a/packages/transform/src/transform/ActionContext.ts
+++ b/packages/transform/src/transform/ActionContext.ts
@@ -1,0 +1,32 @@
+const MANAGED_ACTION_CONTEXT = Symbol('managedActionContext');
+
+type ManagedActionContext = {
+  [MANAGED_ACTION_CONTEXT]: Map<object, () => void>;
+};
+
+const isManagedActionContext = (
+  value: unknown
+): value is ManagedActionContext =>
+  typeof value === 'object' &&
+  value !== null &&
+  MANAGED_ACTION_CONTEXT in value;
+
+export const createActionContext = (): object => ({
+  [MANAGED_ACTION_CONTEXT]: new Map<object, () => void>(),
+});
+
+export const getActionContextOwners = (
+  actionContext: unknown
+): Map<object, () => void> | null =>
+  isManagedActionContext(actionContext)
+    ? actionContext[MANAGED_ACTION_CONTEXT]
+    : null;
+
+export const disposeActionContext = (actionContext: object): void => {
+  const owners = getActionContextOwners(actionContext);
+  if (!owners) return;
+
+  const cleanups = [...owners.values()];
+  owners.clear();
+  cleanups.forEach((cleanup) => cleanup());
+};

--- a/packages/transform/src/transform/Entrypoint.ts
+++ b/packages/transform/src/transform/Entrypoint.ts
@@ -21,6 +21,18 @@ import { stripQueryAndHash } from '../utils/parseRequest';
 
 const EMPTY_FILE = '=== empty file ===';
 const DEFAULT_ACTION_CONTEXT = Symbol('defaultActionContext');
+const MANAGED_ACTION_CONTEXT = Symbol('managedActionContext');
+
+type ManagedActionContext = {
+  [MANAGED_ACTION_CONTEXT]: Set<Entrypoint>;
+};
+
+const isManagedActionContext = (
+  value: unknown
+): value is ManagedActionContext =>
+  typeof value === 'object' &&
+  value !== null &&
+  MANAGED_ACTION_CONTEXT in value;
 
 type CreateEntrypointOptions = {
   mergeCachedOnly?: boolean;
@@ -194,6 +206,19 @@ export class Entrypoint extends BaseEntrypoint {
     invariant(created !== 'loop', 'loop detected');
 
     return created;
+  }
+
+  public static createActionContext(): object {
+    return { [MANAGED_ACTION_CONTEXT]: new Set<Entrypoint>() };
+  }
+
+  public static disposeActionContext(actionContext: object): void {
+    if (!isManagedActionContext(actionContext)) return;
+
+    actionContext[MANAGED_ACTION_CONTEXT].forEach((entrypoint) => {
+      entrypoint.clearActions(actionContext);
+    });
+    actionContext[MANAGED_ACTION_CONTEXT].clear();
   }
 
   protected static create(
@@ -489,6 +514,10 @@ export class Entrypoint extends BaseEntrypoint {
     abortSignal: AbortSignal | null = null,
     actionContext: unknown = DEFAULT_ACTION_CONTEXT
   ): BaseAction<TAction> {
+    if (isManagedActionContext(actionContext)) {
+      actionContext[MANAGED_ACTION_CONTEXT].add(this);
+    }
+
     if (!this.actionsCache.has(actionType)) {
       this.actionsCache.set(actionType, new Map());
     }
@@ -522,6 +551,15 @@ export class Entrypoint extends BaseEntrypoint {
     });
 
     return newAction;
+  }
+
+  private clearActions(actionContext: unknown): void {
+    this.actionsCache.forEach((contexts, actionType) => {
+      contexts.delete(actionContext);
+      if (contexts.size === 0) {
+        this.actionsCache.delete(actionType);
+      }
+    });
   }
 
   public createChild(

--- a/packages/transform/src/transform/Entrypoint.ts
+++ b/packages/transform/src/transform/Entrypoint.ts
@@ -3,6 +3,7 @@ import { invariant } from 'ts-invariant';
 
 import type { ParentEntrypoint, ITransformFileResult } from '../types';
 
+import { getActionContextOwners } from './ActionContext';
 import { BaseEntrypoint } from './BaseEntrypoint';
 import { isSuperSet, mergeOnly } from './Entrypoint.helpers';
 import type {
@@ -21,18 +22,6 @@ import { stripQueryAndHash } from '../utils/parseRequest';
 
 const EMPTY_FILE = '=== empty file ===';
 const DEFAULT_ACTION_CONTEXT = Symbol('defaultActionContext');
-const MANAGED_ACTION_CONTEXT = Symbol('managedActionContext');
-
-type ManagedActionContext = {
-  [MANAGED_ACTION_CONTEXT]: Set<Entrypoint>;
-};
-
-const isManagedActionContext = (
-  value: unknown
-): value is ManagedActionContext =>
-  typeof value === 'object' &&
-  value !== null &&
-  MANAGED_ACTION_CONTEXT in value;
 
 type CreateEntrypointOptions = {
   mergeCachedOnly?: boolean;
@@ -206,19 +195,6 @@ export class Entrypoint extends BaseEntrypoint {
     invariant(created !== 'loop', 'loop detected');
 
     return created;
-  }
-
-  public static createActionContext(): object {
-    return { [MANAGED_ACTION_CONTEXT]: new Set<Entrypoint>() };
-  }
-
-  public static disposeActionContext(actionContext: object): void {
-    if (!isManagedActionContext(actionContext)) return;
-
-    actionContext[MANAGED_ACTION_CONTEXT].forEach((entrypoint) => {
-      entrypoint.clearActions(actionContext);
-    });
-    actionContext[MANAGED_ACTION_CONTEXT].clear();
   }
 
   protected static create(
@@ -514,8 +490,9 @@ export class Entrypoint extends BaseEntrypoint {
     abortSignal: AbortSignal | null = null,
     actionContext: unknown = DEFAULT_ACTION_CONTEXT
   ): BaseAction<TAction> {
-    if (isManagedActionContext(actionContext)) {
-      actionContext[MANAGED_ACTION_CONTEXT].add(this);
+    const actionContextOwners = getActionContextOwners(actionContext);
+    if (actionContextOwners && !actionContextOwners.has(this)) {
+      actionContextOwners.set(this, () => this.clearActions(actionContext));
     }
 
     if (!this.actionsCache.has(actionType)) {

--- a/packages/transform/src/transform/__tests__/createEntrypoint.test.ts
+++ b/packages/transform/src/transform/__tests__/createEntrypoint.test.ts
@@ -1,4 +1,5 @@
 import type { Services } from '../types';
+import { Entrypoint } from '../Entrypoint';
 
 import { createEntrypoint, createServices } from './entrypoint-helpers';
 
@@ -22,6 +23,33 @@ describe('createEntrypoint', () => {
     const entrypoint1 = createEntrypoint(services, '/foo/bar.js', ['default']);
     const entrypoint2 = createEntrypoint(services, '/foo/bar.js', ['default']);
     expect(entrypoint1).toBe(entrypoint2);
+  });
+
+  it('disposes actions created for a completed transform context', () => {
+    const entrypoint1 = createEntrypoint(services, '/foo/bar.js', ['default']);
+    const entrypoint2 = createEntrypoint(services, '/foo/baz.js', ['default']);
+    const actionContext = Entrypoint.createActionContext();
+    const action1 = entrypoint1.createAction(
+      'workflow',
+      undefined,
+      null,
+      actionContext
+    );
+    const action2 = entrypoint2.createAction(
+      'workflow',
+      undefined,
+      null,
+      actionContext
+    );
+
+    Entrypoint.disposeActionContext(actionContext);
+
+    expect(
+      entrypoint1.createAction('workflow', undefined, null, actionContext)
+    ).not.toBe(action1);
+    expect(
+      entrypoint2.createAction('workflow', undefined, null, actionContext)
+    ).not.toBe(action2);
   });
 
   it('should invalidate cache if source code was changed', () => {

--- a/packages/transform/src/transform/__tests__/createEntrypoint.test.ts
+++ b/packages/transform/src/transform/__tests__/createEntrypoint.test.ts
@@ -1,5 +1,5 @@
 import type { Services } from '../types';
-import { Entrypoint } from '../Entrypoint';
+import { createActionContext, disposeActionContext } from '../ActionContext';
 
 import { createEntrypoint, createServices } from './entrypoint-helpers';
 
@@ -28,7 +28,7 @@ describe('createEntrypoint', () => {
   it('disposes actions created for a completed transform context', () => {
     const entrypoint1 = createEntrypoint(services, '/foo/bar.js', ['default']);
     const entrypoint2 = createEntrypoint(services, '/foo/baz.js', ['default']);
-    const actionContext = Entrypoint.createActionContext();
+    const actionContext = createActionContext();
     const action1 = entrypoint1.createAction(
       'workflow',
       undefined,
@@ -42,7 +42,7 @@ describe('createEntrypoint', () => {
       actionContext
     );
 
-    Entrypoint.disposeActionContext(actionContext);
+    disposeActionContext(actionContext);
 
     expect(
       entrypoint1.createAction('workflow', undefined, null, actionContext)

--- a/packages/webpack-loader/src/__tests__/emit-warning.test.ts
+++ b/packages/webpack-loader/src/__tests__/emit-warning.test.ts
@@ -85,4 +85,84 @@ describe('webpack-loader emitWarning', () => {
     // webpack won't render the message a second time as "Error: <msg>"
     expect(warning.stack).toBeUndefined();
   });
+
+  it('drops stale loader callbacks and routes cached services to the current compilation', async () => {
+    const { default: webpackLoader } = await import('../index');
+    const createHook = () => {
+      const handlers: Array<() => void> = [];
+      return {
+        call: () => handlers.forEach((handler) => handler()),
+        tap: (_name: string, handler: () => void) => handlers.push(handler),
+      };
+    };
+    const compiler = {
+      hooks: {
+        done: createHook(),
+        failed: createHook(),
+        shutdown: createHook(),
+        watchClose: createHook(),
+      },
+    };
+    const cachedEmitWarnings: Array<(message: string) => void> = [];
+
+    transformMock.mockImplementation(
+      async (services: { emitWarning: (message: string) => void }) => {
+        cachedEmitWarnings.push(services.emitWarning);
+        return {
+          code: 'module.exports = 1;',
+          sourceMap: null,
+          cssText: null,
+          cssSourceMapText: '',
+          dependencies: [],
+        };
+      }
+    );
+
+    const runLoader = (emitWarning: jest.Mock) =>
+      new Promise<void>((resolve, reject) => {
+        webpackLoader.call(
+          {
+            _compiler: compiler,
+            hot: false,
+            addDependency: jest.fn(),
+            async: jest.fn(),
+            callback: (err: Error | null) => (err ? reject(err) : resolve()),
+            context: process.cwd(),
+            emitWarning,
+            getDependencies: () => [],
+            getOptions: () => ({}),
+            getResolve: () =>
+              jest.fn(
+                (
+                  _ctx: string,
+                  _token: string,
+                  cb: (err: unknown, res: unknown) => void
+                ) => cb(null, null)
+              ),
+            resourcePath: '/abs/test.tsx',
+            rootContext: process.cwd(),
+            utils: {
+              contextify: (_ctx: string, request: string) => request,
+            },
+          } as never,
+          'module.exports = 1;',
+          null
+        );
+      });
+
+    const firstEmitWarning = jest.fn();
+    await runLoader(firstEmitWarning);
+    compiler.hooks.done.call();
+
+    cachedEmitWarnings[0]('stale');
+    expect(firstEmitWarning).not.toHaveBeenCalled();
+
+    const secondEmitWarning = jest.fn();
+    await runLoader(secondEmitWarning);
+    cachedEmitWarnings[0]('current');
+
+    expect(firstEmitWarning).not.toHaveBeenCalled();
+    expect(secondEmitWarning).toHaveBeenCalledTimes(1);
+    expect(secondEmitWarning.mock.calls[0][0].message).toBe('current');
+  });
 });

--- a/packages/webpack-loader/src/index.ts
+++ b/packages/webpack-loader/src/index.ts
@@ -65,6 +65,8 @@ type Resolver = (
   stack?: string[]
 ) => Promise<string>;
 
+type WarningEmitter = (message: string) => void;
+
 type DoneHook = {
   tap: (name: string, handler: (stats: Stats) => void) => void;
 };
@@ -96,8 +98,13 @@ type ResolverScope = {
   asyncResolve: Resolver;
   cache: TransformCacheCollection;
   dispose: () => void;
+  emitWarning: (resourcePath: string, message: string) => void;
   key: string;
   replaceResolver: (resourcePath: string, resolver: Resolver) => void;
+  replaceWarningEmitter: (
+    resourcePath: string,
+    emitWarning: WarningEmitter
+  ) => void;
 };
 
 type CompilerState = ResolverScope & {
@@ -116,6 +123,7 @@ const getResolverKey = (importer: string, stack: string[]): string => {
 
 const createResolverScope = (): ResolverScope => {
   const resolvers = new Map<string, Resolver>();
+  const warningEmitters = new Map<string, WarningEmitter>();
   compilerScopeId += 1;
   const key = `webpack:${compilerScopeId}`;
 
@@ -154,10 +162,20 @@ const createResolverScope = (): ResolverScope => {
     cache: new TransformCacheCollection(),
     dispose: () => {
       resolvers.clear();
+      warningEmitters.clear();
+    },
+    emitWarning: (resourcePath: string, message: string) => {
+      warningEmitters.get(stripQueryAndHash(resourcePath))?.(message);
     },
     key,
     replaceResolver: (resourcePath: string, resolver: Resolver) => {
       resolvers.set(stripQueryAndHash(resourcePath), resolver);
+    },
+    replaceWarningEmitter: (
+      resourcePath: string,
+      emitWarning: WarningEmitter
+    ) => {
+      warningEmitters.set(stripQueryAndHash(resourcePath), emitWarning);
     },
   };
 };
@@ -218,6 +236,11 @@ const createInvocationScope = (): ResolverScope => {
     },
   };
 };
+
+const createWarningDispatcher =
+  (scope: ResolverScope, resourcePath: string): WarningEmitter =>
+  (message: string) =>
+    scope.emitWarning(resourcePath, message);
 
 const webpack5Loader: Loader = function webpack5LoaderPlugin(
   content,
@@ -288,12 +311,16 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
       }
     });
 
+  const { resourcePath } = this;
   const { _compiler: compiler } = this as LoaderContextWithCompiler;
   const compilerState = compiler
     ? getCompilerState(compiler)
     : createInvocationScope();
 
-  compilerState.replaceResolver(this.resourcePath, (what, importer) => {
+  // Do not let cached transform services capture the webpack loader context.
+  // The per-resource callbacks below are short-lived and cleared with the
+  // resolver scope when the compilation finishes.
+  compilerState.replaceResolver(resourcePath, (what, importer) => {
     const importerPath = stripQueryAndHash(importer);
     const context = path.isAbsolute(importerPath)
       ? path.dirname(importerPath)
@@ -307,6 +334,14 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
 
       return result;
     });
+  });
+  compilerState.replaceWarningEmitter(resourcePath, (message: string) => {
+    const warning = new Error(message);
+    // Remove the stack so webpack's ModuleWarning doesn't copy it into
+    // `details`, which causes the message to render twice (once from
+    // .message, once from .details containing "Error: <same message>").
+    delete warning.stack;
+    this.emitWarning(warning);
   });
   const {
     asyncResolve,
@@ -334,8 +369,8 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
 
   const transformServices = {
     options: {
-      filename: this.resourcePath,
-      inputSourceMap: convertSourceMap(inputSourceMap, this.resourcePath),
+      filename: resourcePath,
+      inputSourceMap: convertSourceMap(inputSourceMap, resourcePath),
       pluginOptions: {
         ...rest,
         oxcOptions: mergeOxcResolverAlias(rest.oxcOptions, nativeResolverAlias),
@@ -347,14 +382,7 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
     },
     asyncResolveKey,
     cache: transformCache,
-    emitWarning: (message: string) => {
-      const warning = new Error(message);
-      // Remove the stack so webpack's ModuleWarning doesn't copy it into
-      // `details`, which causes the message to render twice (once from
-      // .message, once from .details containing "Error: <same message>").
-      delete warning.stack;
-      this.emitWarning(warning);
-    },
+    emitWarning: createWarningDispatcher(compilerState, resourcePath),
     eventEmitter: sharedState.emitter,
   };
 
@@ -373,7 +401,7 @@ const webpack5Loader: Loader = function webpack5LoaderPlugin(
 
             await Promise.all(
               result.dependencies?.map((dep) =>
-                asyncResolve(dep, this.resourcePath)
+                asyncResolve(dep, resourcePath)
               ) ?? []
             );
 


### PR DESCRIPTION
## Summary

Fix two retention paths that caused memory usage to grow across webpack watch rebuilds:

- cached transform services retained a webpack loader context through the per-invocation `emitWarning` callback
- completed top-level transform action graphs remained stored in `Entrypoint.actionsCache`

## Changes

- add a compiler-scoped warning-emitter registry alongside the existing resolver registry
- expose a stable warning dispatcher to cached transform services instead of capturing the loader context
- replace the per-resource warning callback on each loader invocation
- clear warning callbacks together with resolvers on `done` and `failed`, and dispose them on `watchClose` and `shutdown`
- add managed action contexts that track every touched entrypoint
- dispose the top-level transform action context in `finally`, including error and soft-error paths
- remove empty per-action cache maps after the context is disposed

## Why

Heap snapshots from a long-running webpack session showed historical compilations retained through:

```text
TransformCacheCollection
└─ cached Entrypoint.services
   └─ emitWarning
      └─ webpack loader context
         └─ old Compilation
```

Each retained main compilation also retained its child compilations, significantly amplifying the heap growth in projects that create worker child compilers.

The action cache had a separate issue: every top-level transform created a unique context object, so those entries could not provide reuse across transforms, but remained strongly referenced after the transform completed.

## Results

In a high-fan-out webpack rebuild sequence, heap snapshots changed from approximately 2.1 GB → 5.7 GB before the fix to 1.6 GB → 1.8 GB after six builds. Rebuild duration still varies with dependency fan-out, but memory no longer grows with each completed transform generation.
