### PR TITLE
fix(cli): dispose eval runner after processing

### DIFF
--- a/.changeset/cli-eval-runner-exit.md
+++ b/.changeset/cli-eval-runner-exit.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/cli': patch
+---
+
+Dispose the eval runner after CLI processing so the process can exit normally.

--- a/packages/cli/src/__tests__/eval-cli.test.ts
+++ b/packages/cli/src/__tests__/eval-cli.test.ts
@@ -1,0 +1,109 @@
+import { spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+describe('CLI evaluation', () => {
+  it('exits after evaluating imported values', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'wyw-cli-eval-'));
+
+    try {
+      const sourceDir = path.join(root, 'src');
+      const processorDir = path.join(
+        root,
+        'node_modules',
+        'test-css-processor'
+      );
+      const themeDir = path.join(root, 'node_modules', 'fake-theme');
+      mkdirSync(sourceDir, { recursive: true });
+      mkdirSync(processorDir, { recursive: true });
+      mkdirSync(themeDir, { recursive: true });
+
+      writeFileSync(
+        path.join(processorDir, 'package.json'),
+        JSON.stringify({
+          name: 'test-css-processor',
+          version: '1.0.0',
+          type: 'module',
+        })
+      );
+      writeFileSync(
+        path.join(processorDir, 'index.js'),
+        "export const css = (strings) => strings.join('');\n"
+      );
+      writeFileSync(
+        path.join(themeDir, 'package.json'),
+        JSON.stringify({
+          name: 'fake-theme',
+          version: '1.0.0',
+          main: 'index.cjs',
+        })
+      );
+      writeFileSync(
+        path.join(themeDir, 'index.cjs'),
+        "const parts = ['r', 'e', 'd'];\nexports.primaryColor = parts.join('');\n"
+      );
+
+      const processorPath = path.resolve(
+        __dirname,
+        '../../../transform/src/__tests__/__fixtures__/test-css-processor.js'
+      );
+      const configFile = path.join(root, 'wyw-in-js.config.cjs');
+      writeFileSync(
+        configFile,
+        [
+          'module.exports = {',
+          '  tagResolver(source, tag) {',
+          `    if (source === 'test-css-processor' && tag === 'css') return ${JSON.stringify(
+            processorPath
+          )};`,
+          '    return null;',
+          '  },',
+          '};',
+          '',
+        ].join('\n')
+      );
+
+      const entryFile = path.join(sourceDir, 'index.js');
+      writeFileSync(
+        entryFile,
+        [
+          "import { css } from 'test-css-processor';",
+          "import { primaryColor } from 'fake-theme';",
+          '',
+          'export const className = css`',
+          '  color: ${primaryColor};',
+          '`;',
+          '',
+        ].join('\n')
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          path.resolve(__dirname, '../wyw-in-js.ts'),
+          '--config',
+          configFile,
+          '--out-dir',
+          path.join(root, 'dist'),
+          '--source-root',
+          root,
+          entryFile,
+        ],
+        {
+          encoding: 'utf8',
+          timeout: 10_000,
+        }
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.stderr).toContain(
+        '[wyw-in-js] Runtime require() fallback during eval'
+      );
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Successfully extracted 1 CSS files.');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/wyw-in-js.ts
+++ b/packages/cli/src/wyw-in-js.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import { asyncResolveFallback } from '@wyw-in-js/shared';
 import {
   createFileReporter,
+  disposeEvalBroker,
   TransformCacheCollection,
   transform,
 } from '@wyw-in-js/transform';
@@ -286,34 +287,37 @@ async function processFiles(files: (number | string)[], options: Options) {
     );
   }
 
-  if (options.parallel) {
-    const res = await Promise.all(tasks.map((task) => task()));
-    console.log(
-      `Successfully extracted ${res.filter((i) => i).length} CSS files.`
-    );
-  } else {
-    let count = 0;
-    for (const task of tasks) {
-      // eslint-disable-next-line no-await-in-loop
-      const res = await task();
-      if (res) {
-        count += 1;
+  try {
+    if (options.parallel) {
+      const res = await Promise.all(tasks.map((task) => task()));
+      console.log(
+        `Successfully extracted ${res.filter((i) => i).length} CSS files.`
+      );
+    } else {
+      let count = 0;
+      for (const task of tasks) {
+        // eslint-disable-next-line no-await-in-loop
+        const res = await task();
+        if (res) {
+          count += 1;
+        }
       }
+
+      console.log(`Successfully extracted ${count} CSS files.`);
     }
 
-    console.log(`Successfully extracted ${count} CSS files.`);
+    modifiedFiles.forEach(({ name, content }) => {
+      fs.writeFileSync(name, content);
+    });
+
+    onDone(options.sourceRoot ?? process.cwd());
+  } finally {
+    disposeEvalBroker(cache);
+    cache.clear('all');
+    modifiedFiles.length = 0;
+    resolvedFiles.length = 0;
+    tasks.length = 0;
   }
-
-  modifiedFiles.forEach(({ name, content }) => {
-    fs.writeFileSync(name, content);
-  });
-
-  cache.clear('all');
-  modifiedFiles.length = 0;
-  resolvedFiles.length = 0;
-  tasks.length = 0;
-
-  onDone(options.sourceRoot ?? process.cwd());
 }
 
 processFiles(argv._, {


### PR DESCRIPTION
## Summary

- dispose the eval broker in a `finally` block after CLI processing
- add an integration test that forces the eval runner and verifies the CLI exits
- add a patch changeset

## Root cause

The CLI cleared its transform cache but never disposed the eval broker associated with that cache. The broker's child Node.js process and stdio pipes therefore kept the CLI event loop alive after extraction completed.

## Validation

- `bun test packages/cli/src --timeout 20000`
- `bun run --filter @wyw-in-js/cli lint`
- `bun turbo run build:esm build:types --filter=@wyw-in-js/cli`

Closes #352
