### PR TITLE
fix(transform): preserve aliased preeval export bindings

### DIFF
--- a/.changeset/preserve-preeval-export-aliases.md
+++ b/.changeset/preserve-preeval-export-aliases.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Preserve aliased export bindings during preevaluation when their source depends on browser-only globals.

--- a/packages/transform/src/__tests__/oxc-preeval-transforms.test.ts
+++ b/packages/transform/src/__tests__/oxc-preeval-transforms.test.ts
@@ -780,5 +780,53 @@ describe('oxc preeval transforms', () => {
       expect(code).not.toContain('window.location');
       expect(() => stripTypesAndJsxWithOxc(code, filename)).not.toThrow();
     });
+
+    it('preserves a default-exported alias whose source transitively references a forbidden global', () => {
+      const code = removeDangerousCodeWithOxc(
+        [
+          'const Button_Button = (props) => {',
+          '  window.setTimeout(() => {}, 100);',
+          '  return props ?? null;',
+          '};',
+          'const Core_Button = Button_Button;',
+          'export default Core_Button;',
+        ].join('\n'),
+        filename
+      );
+
+      expect(code).toContain('const Core_Button = undefined;');
+      expect(code).toContain('export default Core_Button;');
+      expect(() => stripTypesAndJsxWithOxc(code, filename)).not.toThrow();
+    });
+
+    it.each([
+      ['detached named export', 'const Alias = Source;', 'export { Alias };'],
+      [
+        'detached default export',
+        'const Alias = Source;',
+        'export { Alias as default };',
+      ],
+      ['direct named export', 'export const Alias = Source;', ''],
+    ])(
+      'preserves an alias binding used by a %s',
+      (_, declaration, exportStatement) => {
+        const code = removeDangerousCodeWithOxc(
+          [
+            'const Source = window.location;',
+            declaration,
+            exportStatement,
+          ].join('\n'),
+          filename
+        );
+
+        expect(code).toContain('const Alias = undefined;');
+        if (exportStatement) {
+          expect(code).toContain(exportStatement);
+        } else {
+          expect(code).toContain('export const Alias = undefined;');
+        }
+        expect(() => stripTypesAndJsxWithOxc(code, filename)).not.toThrow();
+      }
+    );
   });
 });

--- a/packages/transform/src/utils/oxcPreevalTransforms.ts
+++ b/packages/transform/src/utils/oxcPreevalTransforms.ts
@@ -962,9 +962,17 @@ type ExportedBindingProtection = {
   value: string;
 };
 
-const collectReExportedLocalNames = (program: Program): Set<string> => {
+const collectExportedLocalNames = (program: Program): Set<string> => {
   const names = new Set<string>();
   for (const stmt of program.body) {
+    if (
+      stmt.type === 'ExportDefaultDeclaration' &&
+      stmt.declaration.type === 'Identifier'
+    ) {
+      names.add(stmt.declaration.name);
+      continue;
+    }
+
     if (
       stmt.type !== 'ExportNamedDeclaration' ||
       stmt.declaration ||
@@ -989,7 +997,7 @@ const collectReExportedLocalNames = (program: Program): Set<string> => {
 const findExportedBindingProtection = (
   node: Node,
   ancestors: Node[],
-  reExportedLocalNames: Set<string>
+  exportedLocalNames: Set<string>
 ): ExportedBindingProtection | null => {
   for (let idx = ancestors.length - 1; idx >= 0; idx -= 1) {
     const ancestor = ancestors[idx];
@@ -1006,11 +1014,7 @@ const findExportedBindingProtection = (
       continue;
     }
 
-    if (
-      ancestor.id.type !== 'Identifier' ||
-      !ancestor.init ||
-      ancestor.init === node
-    ) {
+    if (ancestor.id.type !== 'Identifier' || !ancestor.init) {
       return null;
     }
 
@@ -1026,10 +1030,10 @@ const findExportedBindingProtection = (
       wrapper.declaration === varDecl;
     const isTopLevelDeclaration =
       wrapper === null || wrapper?.type === 'Program';
-    const isReExported =
-      isTopLevelDeclaration && reExportedLocalNames.has(ancestor.id.name);
+    const isDetachedExport =
+      isTopLevelDeclaration && exportedLocalNames.has(ancestor.id.name);
 
-    if (!isDirectExport && !isReExported) {
+    if (!isDirectExport && !isDetachedExport) {
       return null;
     }
 
@@ -1576,7 +1580,7 @@ export const removeDangerousCodeWithOxc = (
   const windowScopedNames = windowTokenRe.test(code)
     ? collectWindowScopedNames(program)
     : new Set<string>();
-  const reExportedLocalNames = collectReExportedLocalNames(program);
+  const exportedLocalNames = collectExportedLocalNames(program);
 
   const derivedBindingDiscovery = { found: true };
   while (derivedBindingDiscovery.found) {
@@ -1784,7 +1788,7 @@ export const removeDangerousCodeWithOxc = (
       const exportProtection = findExportedBindingProtection(
         node,
         ancestors,
-        reExportedLocalNames
+        exportedLocalNames
       );
       if (exportProtection) {
         replacements.push(exportProtection);


### PR DESCRIPTION
## Summary

- preserve top-level bindings referenced by default and named exports during preevaluation
- replace forbidden alias initializers with `undefined` instead of removing their exported declarations
- add regression coverage for default, detached named, detached default, and direct named export forms

## Root cause

Export protection only collected local names from `ExportNamedDeclaration` specifiers and skipped a declarator when the offending identifier was its entire initializer. Preevaluation could therefore remove the alias declaration while leaving the export statement behind, causing an ESM `ReferenceError`.

## Validation

- `bun run check`
- end-to-end CLI reproduction: 2.1.5 fails with `Core_Button is not defined`; the patched branch extracts CSS successfully

Closes #355
