### PR TITLE
fix(transform): handle fileReporter stream errors without crashing

### DIFF
--- a/packages/transform/src/__tests__/fileReporter.test.ts
+++ b/packages/transform/src/__tests__/fileReporter.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -309,6 +309,51 @@ describe('createFileReporter', () => {
         true
       );
     } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns once and keeps other streams alive when a stream fails to open', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wyw-file-reporter-'));
+    // A directory at the target path makes the async open fail
+    // deterministically (EISDIR), like the flaky EINVAL seen in the wild.
+    mkdirSync(join(dir, 'eval-files.jsonl'));
+
+    const warnings: unknown[][] = [];
+    // eslint-disable-next-line no-console
+    const originalWarn = console.warn;
+    // eslint-disable-next-line no-console
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+
+    try {
+      const reporter = createFileReporter({ dir });
+
+      await waitFor(() => warnings.length > 0);
+
+      reporter.emitter.single({ evalSeq: 1, type: 'eval-file' });
+      reporter.emitter.single({ evalSeq: 2, type: 'eval-file' });
+
+      reporter.emitter.single({
+        filename: join(dir, 'foo.ts'),
+        phase: 'export',
+        reason: 'unsupported-expression',
+        status: 'rejected',
+        type: 'staticResolve',
+      });
+
+      reporter.onDone(dir);
+
+      const target = join(dir, 'static-resolve.jsonl');
+      await waitFor(() => hasJsonlLines(target, 1));
+
+      expect(readJsonl(target)).toHaveLength(1);
+      expect(warnings).toHaveLength(1);
+      expect(String(warnings[0][0])).toContain('eval-files.jsonl');
+    } finally {
+      // eslint-disable-next-line no-console
+      console.warn = originalWarn;
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/packages/transform/src/debug/fileReporter.ts
+++ b/packages/transform/src/debug/fileReporter.ts
@@ -90,7 +90,34 @@ function printTimings(timings: Timings, startedAt: number, sourceRoot: string) {
 }
 
 const writeJSONl = (stream: NodeJS.WritableStream, data: unknown) => {
+  if (!stream.writable) {
+    return;
+  }
+
   stream.write(`${JSON.stringify(data, replacer)}\n`);
+};
+
+const createReportStream = (dir: string, filename: string) => {
+  const stream = createWriteStream(path.join(dir, filename));
+
+  // Without an 'error' listener a failed async open (or any later write
+  // error) is an unhandled 'error' event that crashes the process. Reporting
+  // is best-effort debug output: warn once, then drop records for this
+  // stream — it is destroyed on error, so the `writable` guards skip writes.
+  let errorReported = false;
+  stream.on('error', (err) => {
+    if (errorReported) {
+      return;
+    }
+
+    errorReported = true;
+    console.warn(
+      `[wyw-in-js] fileReporter: failed to write ${filename}; further records for this stream will be dropped.`,
+      err.message
+    );
+  });
+
+  return stream;
 };
 
 const isPerfFinishEvent = (event: unknown): event is PerfFinishEvent => {
@@ -142,33 +169,25 @@ export const createFileReporter = (
     throw new Error(`Could not create directory ${options.dir}`);
   }
 
-  const actionStream = createWriteStream(
-    path.join(options.dir, 'actions.jsonl')
+  const actionStream = createReportStream(options.dir, 'actions.jsonl');
+
+  const dependenciesStream = createReportStream(
+    options.dir,
+    'dependencies.jsonl'
   );
 
-  const dependenciesStream = createWriteStream(
-    path.join(options.dir, 'dependencies.jsonl')
+  const entrypointStream = createReportStream(options.dir, 'entrypoints.jsonl');
+
+  const staticResolveStream = createReportStream(
+    options.dir,
+    'static-resolve.jsonl'
   );
 
-  const entrypointStream = createWriteStream(
-    path.join(options.dir, 'entrypoints.jsonl')
-  );
+  const staticPlanStream = createReportStream(options.dir, 'static-plan.jsonl');
 
-  const staticResolveStream = createWriteStream(
-    path.join(options.dir, 'static-resolve.jsonl')
-  );
+  const perfSpanStream = createReportStream(options.dir, 'perf-spans.jsonl');
 
-  const staticPlanStream = createWriteStream(
-    path.join(options.dir, 'static-plan.jsonl')
-  );
-
-  const perfSpanStream = createWriteStream(
-    path.join(options.dir, 'perf-spans.jsonl')
-  );
-
-  const evalFilesStream = createWriteStream(
-    path.join(options.dir, 'eval-files.jsonl')
-  );
+  const evalFilesStream = createReportStream(options.dir, 'eval-files.jsonl');
 
   const startedAt = performance.now();
   const timings: Timings = new Map();
@@ -283,6 +302,10 @@ export const createFileReporter = (
     timestamp,
     event
   ) => {
+    if (!entrypointStream.writable) {
+      return;
+    }
+
     entrypointStream.write(
       `${JSON.stringify([emitterId, timestamp, event])}\n`
     );
@@ -299,13 +322,19 @@ export const createFileReporter = (
         console.log('\nMemory usage:', process.memoryUsage());
       }
 
-      actionStream.end();
-      dependenciesStream.end();
-      entrypointStream.end();
-      staticResolveStream.end();
-      staticPlanStream.end();
-      perfSpanStream.end();
-      evalFilesStream.end();
+      [
+        actionStream,
+        dependenciesStream,
+        entrypointStream,
+        staticResolveStream,
+        staticPlanStream,
+        perfSpanStream,
+        evalFilesStream,
+      ].forEach((stream) => {
+        if (stream.writable) {
+          stream.end();
+        }
+      });
       timings.clear();
     },
   };


### PR DESCRIPTION
## Problem

`createFileReporter` opens seven write streams (`actions.jsonl`, `dependencies.jsonl`, `entrypoints.jsonl`, `static-resolve.jsonl`, `static-plan.jsonl`, `perf-spans.jsonl`, `eval-files.jsonl`) without an `'error'` listener. If the async open — or any later write — fails, the stream emits an unhandled `'error'` event: in Node that crashes the whole process, and under `bun test` the error gets attributed to whatever test happens to be running.

Observed in the wild: with 8 parallel runs of `bun test packages/transform/src/__tests__/fileReporter.test.ts` (bun 1.3.5, macOS), one run out of ~96 failed with an unhandled `EINVAL: invalid argument, open '.../eval-files.jsonl'`.

## Fix

The reporter is best-effort debug output, so:

- every stream is created via a `createReportStream` helper that attaches a persistent `'error'` handler — it warns once per stream (`console.warn`) and swallows subsequent errors;
- all writes and the `end()` calls in `onDone` are guarded by `stream.writable`: after an error the stream is destroyed, so its records are silently dropped while the other streams keep working; the guard also covers write-after-end.

No public API changes.

## Tests

Added a deterministic regression test: pre-creating a *directory* named `eval-files.jsonl` makes the async open fail (`EISDIR`) without races. It asserts exactly one warning, silent drops for the broken stream, that `static-resolve.jsonl` still gets written, and that `onDone` doesn't throw.

- `bun test src/__tests__/fileReporter.test.ts`: 8 pass / 0 fail
- stress: 4 rounds × 8 parallel runs = 32/32 green
