### PR TITLE
test(transform): wait for complete jsonl lines in fileReporter tests

### DIFF
--- a/packages/transform/src/__tests__/fileReporter.test.ts
+++ b/packages/transform/src/__tests__/fileReporter.test.ts
@@ -94,9 +94,7 @@ describe('createFileReporter', () => {
 
       reporter.onDone(dir);
       const target = join(dir, 'static-resolve.jsonl');
-      await waitFor(
-        () => existsSync(target) && readFileSync(target).length > 0
-      );
+      await waitFor(() => hasJsonlLines(target, 2));
 
       const events = readJsonl(target);
       expect(events).toHaveLength(2);
@@ -153,9 +151,7 @@ describe('createFileReporter', () => {
       reporter.onDone(dir);
 
       const target = join(dir, 'eval-files.jsonl');
-      await waitFor(
-        () => existsSync(target) && readFileSync(target).length > 0
-      );
+      await waitFor(() => hasJsonlLines(target, 1));
 
       const events = readJsonl(target);
       expect(events).toHaveLength(1);


### PR DESCRIPTION
## Summary

The "writes staticResolve single events to static-resolve.jsonl" test is flaky under load: it emits two `staticResolve` events, but its `waitFor` condition only checks that the target file has some bytes (`readFileSync(target).length > 0`), i.e. the first flushed line. Under load the second line may not be flushed yet when the test reads the file, and `expect(events).toHaveLength(2)` fails.

The file already has a stricter helper, `hasJsonlLines(file, length)`, which requires the expected number of complete newline-terminated lines and is already used by the perf-span tests. This PR switches the remaining weak waits to it:

- static-resolve wait → `hasJsonlLines(target, 2)`
- eval-files wait → `hasJsonlLines(target, 1)`

Test-only change.

## Verification

`bun test packages/transform/src/__tests__/fileReporter.test.ts` — 15 sequential runs plus 96 runs in 8-way parallel batches (full CPU saturation): the flake did not reproduce.
