### PR TITLE
feat(transform): preeval-call manifest semantics

### DIFF
--- a/.changeset/preeval-call-semantics.md
+++ b/.changeset/preeval-call-semantics.md
@@ -1,0 +1,24 @@
+---
+'@wyw-in-js/transform': minor
+---
+
+Processor manifests can now declare `preeval-call` semantics: the manifest
+points at the package's own preeval module and export, and when every call
+input is statically known the transform invokes that function with the
+resolved arguments — the processor's static value becomes the exact value
+the eval path would have produced.
+
+    "semantics": {
+      "kind": "preeval-call",
+      "module": "./preeval-runtime.js",
+      "export": "preevalCss"
+    }
+
+This keeps processors with dual-domain values (a runtime class string vs a
+structured eval-time descriptor) on a single source of truth instead of
+re-encoding their value logic in the engine's declarative vocabulary. The
+module resolves relative to the manifest, results must be plain
+serializable data, and any load failure, thrown error, or non-serializable
+result falls back to the eval path with full diagnostics. Older engines
+treat the unknown kind as no semantics and stay on the JS implementation
+path.

--- a/packages/transform/src/__tests__/transform.preeval-call-semantics.test.ts
+++ b/packages/transform/src/__tests__/transform.preeval-call-semantics.test.ts
@@ -1,0 +1,348 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
+
+import dedent from 'dedent';
+
+import { TransformCacheCollection } from '../cache';
+import { transform } from '../transform';
+import type { PluginOptions } from '../types';
+import { EventEmitter } from '../utils/EventEmitter';
+
+const processorFile = join(__dirname, '__fixtures__', 'test-css-processor.js');
+
+const PREEVAL_EXPORT = 'preevalStyleValue';
+
+const preevalModuleSource = dedent`
+  exports.${PREEVAL_EXPORT} = (shape, options) => {
+    if (shape === null || typeof shape !== 'object') {
+      throw new Error('fixture-preeval: shape must be an object');
+    }
+
+    const tone = options && typeof options.tone === 'string' ? options.tone : 'base';
+    if (tone === 'broken') {
+      return { onResolve: () => tone };
+    }
+
+    return {
+      __wyw_meta: { className: 'fx-' + tone, extends: null },
+      className: 'fx-' + tone,
+      tokens: Object.fromEntries(
+        Object.keys(shape).map((key) => [key, 'var(--fx-' + tone + '-' + key + ')'])
+      ),
+    };
+  };
+`;
+
+const preevalCallProcessorSource = (packageName: string) => dedent`
+  const { createRequire } = require('module');
+  const workspaceRequire = createRequire(${JSON.stringify(processorFile)});
+  const { BaseProcessor } = workspaceRequire('@wyw-in-js/processor-utils');
+
+  class PreevalCallFixtureProcessor extends BaseProcessor {
+    constructor(params, ...args) {
+      super([params[0]], ...args);
+      const callParam = params.find((param) => param[0] === 'call');
+      this.expressions = callParam ? callParam.slice(1) : [];
+      this.dependencies.push(
+        ...this.expressions.filter((expression) => expression.ex.type === 'Identifier')
+      );
+    }
+
+    get asSelector() {
+      return \`.\${this.className}\`;
+    }
+
+    get value() {
+      return this.astService.callExpression(
+        this.astService.identifier('__fixturePreevalStyleValue'),
+        this.expressions.map((expression) => expression.ex)
+      );
+    }
+
+    build() {}
+
+    doEvaltimeReplacement() {
+      this.replacer(
+        () =>
+          this.astService.callExpression(
+            this.astService.addNamedImport(
+              ${JSON.stringify(PREEVAL_EXPORT)},
+              '${packageName}/dist/preeval-fixture.cjs',
+              ${JSON.stringify(PREEVAL_EXPORT)}
+            ),
+            this.expressions.map((expression) =>
+              // Lazy values are hoisted thunks and must be called; const
+              // expressions are inlined as-is (ValueType.CONST === 2).
+              expression.kind === 2
+                ? expression.ex
+                : this.astService.callExpression(expression.ex, [])
+            )
+          ),
+        false
+      );
+    }
+
+    doRuntimeReplacement() {
+      this.replacer(this.astService.stringLiteral(this.className), false);
+    }
+  }
+
+  module.exports = { default: PreevalCallFixtureProcessor };
+`;
+
+let packageId = 0;
+
+const writePreevalProcessorPackage = (root: string): string => {
+  packageId += 1;
+  const packageName = `preeval-call-fixture-${process.pid}-${packageId}`;
+  const packageRoot = join(root, 'node_modules', packageName);
+  const distRoot = join(packageRoot, 'dist');
+
+  mkdirSync(distRoot, { recursive: true });
+  writeFileSync(
+    join(packageRoot, 'package.json'),
+    JSON.stringify(
+      {
+        name: packageName,
+        main: './index.js',
+        'wyw-in-js': {
+          tags: {
+            fxStyle: './dist/fxStyle.processor.json',
+          },
+        },
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(join(packageRoot, 'index.js'), 'module.exports = {};\n');
+  writeFileSync(
+    join(distRoot, 'fxStyle-processor.js'),
+    preevalCallProcessorSource(packageName)
+  );
+  writeFileSync(join(distRoot, 'preeval-fixture.cjs'), preevalModuleSource);
+  writeFileSync(
+    join(distRoot, 'fxStyle.processor.json'),
+    JSON.stringify(
+      {
+        version: 1,
+        name: packageName,
+        implementation: './fxStyle-processor.js',
+        tags: ['fxStyle'],
+        semantics: {
+          kind: 'preeval-call',
+          module: './preeval-fixture.cjs',
+          export: PREEVAL_EXPORT,
+        },
+      },
+      null,
+      2
+    )
+  );
+
+  return packageName;
+};
+
+const createPerfEventRecorder = () => {
+  const counts = new Map<string, number>();
+  const eventEmitter = new EventEmitter(
+    (labels, type) => {
+      if (type !== 'start' || typeof labels.method !== 'string') {
+        return;
+      }
+
+      counts.set(labels.method, (counts.get(labels.method) ?? 0) + 1);
+    },
+    () => 0,
+    () => {}
+  );
+
+  return { counts, eventEmitter };
+};
+
+const runTransform = async (
+  root: string,
+  entryFile: string,
+  eventEmitter?: EventEmitter,
+  pluginOptions: Partial<PluginOptions> = {}
+) =>
+  transform(
+    {
+      cache: new TransformCacheCollection(),
+      eventEmitter,
+      options: {
+        filename: entryFile,
+        root,
+        pluginOptions: {
+          configFile: false,
+          tagResolver: (source, tag) => {
+            if (source === 'test-css-processor' && tag === 'css') {
+              return processorFile;
+            }
+
+            return null;
+          },
+          ...pluginOptions,
+        } as Partial<PluginOptions>,
+      },
+    },
+    readFileSync(entryFile, 'utf8'),
+    async (what: string, importer: string) => {
+      if (what === 'test-css-processor') {
+        return processorFile;
+      }
+
+      if (what.startsWith('.')) {
+        return resolve(dirname(importer), what);
+      }
+
+      const packageSubpath = join(root, 'node_modules', what);
+      if (what.includes('/') && existsSync(packageSubpath)) {
+        return packageSubpath;
+      }
+
+      const packageMain = join(root, 'node_modules', what, 'index.js');
+      return existsSync(packageMain) ? packageMain : null;
+    }
+  );
+
+describe('preeval-call manifest semantics', () => {
+  it('computes same-file values through the manifest preeval module', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-preeval-call-'));
+    const packageName = writePreevalProcessorPackage(root);
+    const entryFile = join(root, 'entry.js');
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { fxStyle } from '${packageName}';
+        import { css } from 'test-css-processor';
+
+        const sheet = fxStyle({ color: null, gap: null }, { tone: 'brand' });
+
+        export const className = css\`
+          color: ${'${sheet.tokens.color}'};
+          gap: ${'${sheet.tokens.gap}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, perf.eventEmitter);
+
+      expect(result.cssText).toContain('color:var(--fx-brand-color)');
+      expect(result.cssText).toContain('gap:var(--fx-brand-gap)');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('computes cross-file exported values without evaluating the module', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-preeval-call-'));
+    const packageName = writePreevalProcessorPackage(root);
+    const entryFile = join(root, 'entry.js');
+    const sheetFile = join(root, 'sheet.js');
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      sheetFile,
+      dedent`
+        import { fxStyle } from '${packageName}';
+
+        export const sheet = fxStyle({ accent: null }, { tone: 'shared' });
+      `
+    );
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { css } from 'test-css-processor';
+        import { sheet } from './sheet.js';
+
+        export const className = css\`
+          color: ${'${sheet.tokens.accent}'};
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, perf.eventEmitter);
+
+      expect(result.cssText).toContain('color:var(--fx-shared-accent)');
+      expect(result.code).not.toContain('./sheet.js');
+      expect(result.dependencies).toContain(sheetFile);
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to eval when the preeval module throws, keeping its diagnostic', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-preeval-call-'));
+    const packageName = writePreevalProcessorPackage(root);
+    const entryFile = join(root, 'entry.js');
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { fxStyle } from '${packageName}';
+        import { css } from 'test-css-processor';
+
+        const sheet = fxStyle(42, { tone: 'brand' });
+
+        export const className = css\`
+          color: ${'${sheet.tokens ? sheet.tokens.color : "red"}'};
+        \`;
+      `
+    );
+
+    try {
+      await expect(
+        runTransform(root, entryFile, perf.eventEmitter)
+      ).rejects.toThrow('fixture-preeval: shape must be an object');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to eval for non-serializable preeval results', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-preeval-call-'));
+    const packageName = writePreevalProcessorPackage(root);
+    const entryFile = join(root, 'entry.js');
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { fxStyle } from '${packageName}';
+        import { css } from 'test-css-processor';
+
+        const sheet = fxStyle({ color: null }, { tone: 'broken' });
+
+        export const className = css\`
+          content: "${'${typeof sheet.onResolve}'}";
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(root, entryFile, perf.eventEmitter);
+
+      expect(result.cssText).toContain('content:"function"');
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/transform/src/processors/__tests__/manifest.test.ts
+++ b/packages/transform/src/processors/__tests__/manifest.test.ts
@@ -110,6 +110,7 @@ describe('processor manifest loader', () => {
         version: 1,
         name: '@wyw-in-js/test-css',
         implementation: './throws-if-required.js',
+        dir: distDir,
         tags: ['css'],
         semantics: {
           kind: 'css-template',
@@ -230,6 +231,7 @@ describe('processor manifest loader', () => {
         version: 1,
         name: '@wyw-in-js/test-styled',
         implementation: './styled-processor.js',
+        dir: root,
         tags: ['styled'],
         semantics: {
           kind: 'styled-target',

--- a/packages/transform/src/processors/declarativeSemantics.ts
+++ b/packages/transform/src/processors/declarativeSemantics.ts
@@ -1,3 +1,6 @@
+import { createRequire } from 'module';
+import { isAbsolute, resolve as resolvePath } from 'path';
+
 import type {
   BaseProcessor,
   CallParam,
@@ -7,6 +10,8 @@ import type {
   ProcessorStaticValue,
 } from '@wyw-in-js/processor-utils';
 import type { ExpressionValue } from '@wyw-in-js/shared';
+
+const nodeRequire = createRequire(import.meta.url);
 
 type CssTemplateOutput = 'class-name' | 'css-text';
 type RuntimeDependencyMode = 'explicit';
@@ -45,9 +50,16 @@ export type ClassNameCallSemantics = {
   kind: 'class-name-call';
 };
 
+export type PreevalCallSemantics = {
+  exportName: string;
+  kind: 'preeval-call';
+  modulePath: string;
+};
+
 export type DeclarativeProcessorCallSemantics =
   | ClassNameCallSemantics
   | CssVarCallSemantics
+  | PreevalCallSemantics
   | StyleObjectCallSemantics
   | TokenContractCallSemantics;
 
@@ -130,10 +142,50 @@ const readString = (value: unknown, fallback: string): string | null => {
 };
 
 export const normalizeDeclarativeProcessorSemantics = (
-  semantics: unknown
+  semantics: unknown,
+  manifestDir?: string | null
 ): DeclarativeProcessorSemantics | null => {
   if (!isRecord(semantics)) {
     return null;
+  }
+
+  if (semantics.kind === 'preeval-call') {
+    // Normalization must be idempotent: the processor factory re-normalizes
+    // the already-normalized shape stored on the defined processor.
+    if (
+      typeof semantics.modulePath === 'string' &&
+      isAbsolute(semantics.modulePath) &&
+      typeof semantics.exportName === 'string' &&
+      semantics.exportName.length > 0
+    ) {
+      return {
+        exportName: semantics.exportName,
+        kind: 'preeval-call',
+        modulePath: semantics.modulePath,
+      };
+    }
+
+    const moduleSpecifier =
+      typeof semantics.module === 'string' && semantics.module.length > 0
+        ? semantics.module
+        : null;
+    const exportName =
+      typeof semantics.export === 'string' && semantics.export.length > 0
+        ? semantics.export
+        : null;
+
+    // The module is resolved against the manifest location; without a known
+    // manifest directory the semantics cannot be anchored and the processor
+    // stays on its JS implementation path.
+    if (!moduleSpecifier || !exportName || !manifestDir) {
+      return null;
+    }
+
+    return {
+      exportName,
+      kind: 'preeval-call',
+      modulePath: resolvePath(manifestDir, moduleSpecifier),
+    };
   }
 
   if (semantics.kind === 'css-template') {
@@ -478,6 +530,96 @@ const resolveTokenContractCall = (
   };
 };
 
+const preevalModuleCache = new Map<string, Record<string, unknown> | null>();
+
+const loadPreevalCallTarget = (
+  semantics: PreevalCallSemantics
+): ((...args: unknown[]) => unknown) | null => {
+  let preevalModule = preevalModuleCache.get(semantics.modulePath);
+  if (preevalModule === undefined) {
+    try {
+      preevalModule = nodeRequire(semantics.modulePath) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      preevalModule = null;
+    }
+    preevalModuleCache.set(semantics.modulePath, preevalModule);
+  }
+
+  const target = preevalModule?.[semantics.exportName];
+  return typeof target === 'function'
+    ? (target as (...args: unknown[]) => unknown)
+    : null;
+};
+
+const isSerializablePreevalValue = (value: unknown): boolean => {
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every(isSerializablePreevalValue);
+  }
+
+  if (typeof value === 'object') {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return false;
+    }
+
+    return Object.values(value).every(isSerializablePreevalValue);
+  }
+
+  return false;
+};
+
+// Values produced by a manifest's preeval module are the processor's
+// authoritative eval-domain values. Downstream caches may serve them even
+// when they structurally resemble processor artifacts (e.g. carry
+// `__wyw_meta`), so their provenance is tracked here.
+const preevalCallValues = new WeakSet<object>();
+
+export const isDeclarativePreevalValue = (value: unknown): boolean =>
+  typeof value === 'object' && value !== null && preevalCallValues.has(value);
+
+const resolvePreevalCall = (
+  semantics: PreevalCallSemantics,
+  args: unknown[]
+): ProcessorStaticValue | null => {
+  const target = loadPreevalCallTarget(semantics);
+  if (!target) {
+    return null;
+  }
+
+  let value: unknown;
+  try {
+    value = target(...args);
+  } catch {
+    // The eval path calls the same function through the real module graph and
+    // surfaces its diagnostics with full context; the static shortcut simply
+    // steps aside.
+    return null;
+  }
+
+  if (!isSerializablePreevalValue(value)) {
+    return null;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    preevalCallValues.add(value);
+  }
+
+  return { kind: 'serializable', value };
+};
+
 export const resolveDeclarativeProcessorStaticValue = (
   processor: BaseProcessor,
   resolveInput: (expression: ExpressionValue) => DeclarativeCallInputResolution
@@ -502,6 +644,10 @@ export const resolveDeclarativeProcessorStaticValue = (
 
   if (state.semantics.kind === 'token-contract-call') {
     return resolveTokenContractCall(state.semantics, args);
+  }
+
+  if (state.semantics.kind === 'preeval-call') {
+    return resolvePreevalCall(state.semantics, args);
   }
 
   return null;

--- a/packages/transform/src/processors/manifest.ts
+++ b/packages/transform/src/processors/manifest.ts
@@ -14,6 +14,8 @@ export type ProcessorManifest = {
   version: 1;
   name: string;
   implementation: string;
+  /** Directory of the manifest file; anchors relative module references. */
+  dir: string;
   tags?: string[];
   semantics?: unknown;
 };
@@ -159,6 +161,7 @@ export const loadProcessorManifest = (
     version,
     name,
     implementation,
+    dir: dirname(manifestPath),
   };
 
   if (tags) {

--- a/packages/transform/src/transform/generators/resolveStaticOxcValues/processorStaticExport.ts
+++ b/packages/transform/src/transform/generators/resolveStaticOxcValues/processorStaticExport.ts
@@ -7,6 +7,7 @@ import {
   evaluateOxcStaticExpressionAt,
   isOxcStaticSerializableValue,
 } from '../../../utils/collectOxcTemplateDependencies';
+import { isDeclarativePreevalValue } from '../../../processors/declarativeSemantics';
 import type { ITransformAction, SyncScenarioFor } from '../../types';
 import { getStaticMetadataPreevalResult } from './cache';
 import {
@@ -223,6 +224,7 @@ export function* resolveProcessorStaticExport(
   ) {
     const cachedValue = preevalResult.staticValueCache.get(exportedLocalName);
     if (
+      isDeclarativePreevalValue(cachedValue) ||
       !isProcessorArtifactValue(cachedValue, processors, processorClassNames)
     ) {
       debugStaticResolve(action, {

--- a/packages/transform/src/transform/static-plan/buildStaticPlan.ts
+++ b/packages/transform/src/transform/static-plan/buildStaticPlan.ts
@@ -107,7 +107,10 @@ const discoverProcessorImports = ({
     processorImports.push({
       imported: tagSource.imported,
       local,
-      semantics: normalizeDeclarativeProcessorSemantics(manifest?.semantics),
+      semantics: normalizeDeclarativeProcessorSemantics(
+        manifest?.semantics,
+        manifest?.dir
+      ),
       source: tagSource.source,
     });
   });

--- a/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
@@ -108,7 +108,8 @@ export const applyOxcProcessors = (
               tagSource,
               {
                 declarativeSemantics: normalizeDeclarativeProcessorSemantics(
-                  manifest?.semantics
+                  manifest?.semantics,
+                  manifest?.dir
                 ),
               },
             ]);


### PR DESCRIPTION
## Summary

Declarative call semantics cover processors whose value is a simple
projection (a class name, a css var, a token contract). Processors with
richer eval-time values — e.g. a runtime class *string* whose eval-time
counterpart is a structured descriptor with composition metadata — could
not be expressed declaratively without re-encoding their value logic in
the engine.

`preeval-call` closes that gap by delegation: the manifest names a module
and export from the processor's own package, and when every call input is
statically known the transform calls it with the resolved arguments. The
static value is therefore computed by the same code the eval path runs.

```json
"semantics": {
  "kind": "preeval-call",
  "module": "./preeval-runtime.js",
  "export": "preevalCss"
}
```

## Safety

- The module resolves relative to the manifest file; manifests now carry
  their directory.
- Results must be plain serializable data; load failures, thrown errors,
  and non-serializable results fall back to the eval path, keeping
  diagnostics with full context.
- Values produced this way are trusted by the cross-file export cache even
  when they structurally resemble processor artifacts (e.g. carry
  `__wyw_meta`) — they are the authoritative eval-domain values.
- Older engines treat the unknown kind as no semantics (JS implementation
  path), so processor packages can adopt manifests without a hard engine
  floor.

## Testing

- New suite: same-file and cross-file static resolution (zero `evalFile`
  actions), eval fallback on thrown errors with preserved diagnostics,
  eval fallback on non-serializable results; the fixture value carries
  `__wyw_meta` to pin the export-cache trust path.
- `packages/transform`: 847 pass / 0 fail; lint and size guards green.
- Validated against a real-world consumer: the dx-styles suite is green
  with `css()`/`createTheme()` on `preeval-call` manifests, including a
  static-vs-eval parity matrix over composition shapes; css-in-css
  composition fan-out (1 base + 20 consumers) drops from ~96 ms / 20 evals
  to ~12 ms / 0 evals locally.
