### PR TITLE
fix(transform): preserve React Refresh imports after processor replacements

### DIFF
--- a/.changeset/fix-react-refresh-import-offsets.md
+++ b/.changeset/fix-react-refresh-import-offsets.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Preserve valid Vite React Fast Refresh modules when processor replacements add build-time imports.

--- a/packages/transform/src/__tests__/applyOxcProcessors.test.ts
+++ b/packages/transform/src/__tests__/applyOxcProcessors.test.ts
@@ -847,6 +847,37 @@ describe('applyOxcProcessors', () => {
     );
   });
 
+  it('inserts deferred processor imports using offsets from the replaced code', () => {
+    const result = applyOxcProcessors(
+      `
+        import { makeStyles } from 'test-package';
+        export const useStyles = makeStyles({});
+        import * as RefreshRuntime from "/@react-refresh";
+        export function Foo() {
+          return null;
+        }
+      `,
+      {
+        ...fileContext,
+        filename: path.join(__dirname, 'react-refresh.tsx'),
+      },
+      options(addedImportCallProcessorPath, 'makeStyles'),
+      (processor) => processor.doRuntimeReplacement(),
+      false,
+      true
+    );
+
+    result.finalizeProcessorCallbacks?.();
+
+    expect(result.code).toContain(
+      'import * as RefreshRuntime from "/@react-refresh";'
+    );
+    expect(result.code).toContain('import { __styles } from "@griffel/react";');
+    expect(result.code).toContain(
+      "export const useStyles = /*#__PURE__*/__styles('x');"
+    );
+  });
+
   it('throws when it cannot derive a display name from ownership or filename', () => {
     expect(() =>
       applyOxcProcessors(

--- a/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
@@ -364,7 +364,7 @@ export const applyOxcProcessors = (
     const nextReplacedCode = applyOxcReplacements(workingCode, replacements);
     const codeWithAddedImports = insertAddedImports(
       nextReplacedCode,
-      program,
+      filename,
       addedImports
     );
 

--- a/packages/transform/src/utils/applyOxcProcessors/shared.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/shared.ts
@@ -19,13 +19,14 @@ export const parseOxc = (code: string, filename: string): Program => {
 
 export const insertAddedImports = (
   code: string,
-  program: Program,
+  filename: string,
   addedImports: AddedImport[]
 ): string => {
   if (addedImports.length === 0) {
     return code;
   }
 
+  const program = parseOxc(code, filename);
   const uniqueImports = [
     ...new Map(
       addedImports.map((item) => [


### PR DESCRIPTION
## Summary

- calculate added-import insertion points from the post-replacement module
- add regression coverage for deferred processor callbacks followed by React Refresh imports

## Root cause

Deferred processor replacements could change source length after the module AST was parsed. Added imports then used stale offsets, which could splice an import into the `/@react-refresh` string and make Oxc report `Unterminated string`.

## Validation

- `bun run --filter @wyw-in-js/transform test`
- `bun run --filter @wyw-in-js/transform lint`
- `bun run --filter @wyw-in-js/transform build:types`
- `bun run --filter @wyw-in-js/transform build:esm`
- reproduced `dx-styles/dx-styles#25` before the fix and verified the affected Vite TSX module returns HTTP 200 after the fix

Closes dx-styles/dx-styles#25
