### PR TITLE
fix(nextjs): scope webpack handling for App Router

### DIFF
--- a/.changeset/fix-nextjs-webpack-app-router.md
+++ b/.changeset/fix-nextjs-webpack-app-router.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/nextjs': patch
+---
+
+Fix Next.js webpack builds that combine App and Pages Routers by preserving WyW class names in every CSS issuer layer and skipping direct transforms of `node_modules` dependencies.

--- a/packages/nextjs/src/__tests__/withWyw.test.ts
+++ b/packages/nextjs/src/__tests__/withWyw.test.ts
@@ -43,6 +43,15 @@ describe('withWyw', () => {
     return tsRule.loaders[0].options;
   };
 
+  const getWebpackLoaderForResource = (use: any[], resource: string): any => {
+    const resolvedUse = use.flatMap((item) => {
+      const resolved = typeof item === 'function' ? item({ resource }) : item;
+      return Array.isArray(resolved) ? resolved : [resolved];
+    });
+
+    return resolvedUse.find((item) => item?.loader?.includes('webpack-loader'));
+  };
+
   it('injects Turbopack query CSS rules for Next 16.2+', () => {
     const nextConfig = withFakeNextVersion('16.2.4', () => withWyw());
 
@@ -177,6 +186,7 @@ describe('withWyw', () => {
       module: {
         rules: [
           {
+            issuerLayer: 'app-pages-browser',
             use: [{ loader: 'next-swc-loader' }],
           },
         ],
@@ -189,11 +199,28 @@ describe('withWyw', () => {
     const use = (result.module!.rules![0] as RuleSetRule).use as any[];
 
     expect(use).toHaveLength(2);
-    expect(use[1].loader).toContain('webpack-loader');
-    expect(use[1].options.importOverrides).toMatchObject({
+    const localLoader = getWebpackLoaderForResource(
+      use,
+      '/project/app/page.tsx'
+    );
+    expect(localLoader.loader).toContain('webpack-loader');
+    expect(localLoader.options.importOverrides).toMatchObject({
       react: { mock: 'react' },
     });
-    expect(use[1].options).not.toHaveProperty('babelOptions');
+    expect(localLoader.options).not.toHaveProperty('babelOptions');
+
+    expect(
+      getWebpackLoaderForResource(
+        use,
+        '/project/node_modules/swr/dist/index.mjs'
+      )
+    ).toBeUndefined();
+    expect(
+      getWebpackLoaderForResource(
+        use,
+        'C:\\project\\node_modules\\swr\\dist\\index.mjs'
+      )
+    ).toBeUndefined();
   });
 
   it('merges default React importOverrides with user overrides', () => {
@@ -220,8 +247,12 @@ describe('withWyw', () => {
 
     const result = nextConfig.webpack!(config, { dev: true } as any);
     const use = (result.module!.rules![0] as RuleSetRule).use as any[];
+    const localLoader = getWebpackLoaderForResource(
+      use,
+      '/project/pages/index.tsx'
+    );
 
-    expect(use[1].options.importOverrides).toMatchObject({
+    expect(localLoader.options.importOverrides).toMatchObject({
       react: { mock: 'preact/compat' },
       'react/jsx-runtime': { mock: 'react/jsx-runtime' },
       'react/jsx-dev-runtime': { mock: 'react/jsx-dev-runtime' },
@@ -252,15 +283,34 @@ describe('withWyw', () => {
     expect(rule.use).toHaveLength(2);
     expect(rule.use[0].loader).toContain('next-swc-loader');
     expect(rule.use[0].options).toEqual({ some: 'option' });
-    expect(rule.use[1].loader).toContain('webpack-loader');
+    expect(
+      getWebpackLoaderForResource(rule.use, '/project/pages/index.tsx').loader
+    ).toContain('webpack-loader');
   });
 
-  it('keeps generated class names stable in .wyw-in-js.module.css', () => {
+  it('keeps generated class names stable across App and Pages CSS rules', () => {
     const originalGetLocalIdent = (
       _context: unknown,
       _localIdentName: string,
       localName: string
     ) => `hashed_${localName}`;
+
+    const createCssModuleRule = (issuerLayer: string, appDir: boolean) => ({
+      test: /\.module\.css$/,
+      issuerLayer,
+      use: [
+        ...(appDir ? [{ loader: 'next-flight-css-loader' }] : []),
+        {
+          loader: 'css-loader',
+          options: {
+            modules: {
+              mode: 'pure',
+              getLocalIdent: originalGetLocalIdent,
+            },
+          },
+        },
+      ],
+    });
 
     const config: Configuration = {
       module: {
@@ -270,20 +320,8 @@ describe('withWyw', () => {
               {
                 use: [{ loader: 'next-swc-loader' }],
               },
-              {
-                test: /\.module\.css$/,
-                use: [
-                  {
-                    loader: 'css-loader',
-                    options: {
-                      modules: {
-                        mode: 'pure',
-                        getLocalIdent: originalGetLocalIdent,
-                      },
-                    },
-                  },
-                ],
-              },
+              createCssModuleRule('app-pages-browser', true),
+              createCssModuleRule('pages-dir-browser', false),
             ],
           },
         ],
@@ -294,29 +332,52 @@ describe('withWyw', () => {
     nextConfig.webpack!(config, { dev: true } as any);
 
     const rules = (config.module!.rules![0] as RuleSetRule).oneOf! as any[];
-    expect(rules).toHaveLength(3);
+    expect(rules).toHaveLength(5);
 
-    const wywCssRule = rules[1];
-    expect(String(wywCssRule.test)).toContain('wyw-in-js');
-    expect(wywCssRule.sideEffects).toBe(true);
+    const wywCssRules = rules.filter((rule) =>
+      String(rule.test).includes('wyw-in-js')
+    );
+    expect(wywCssRules).toHaveLength(2);
+    expect(wywCssRules.map((rule) => rule.issuerLayer)).toEqual([
+      'app-pages-browser',
+      'pages-dir-browser',
+    ]);
 
-    const { modules } = wywCssRule.use[0].options;
-    expect(modules.mode).toBe('global');
+    wywCssRules.forEach((wywCssRule) => {
+      expect(wywCssRule.sideEffects).toBe(true);
 
-    const patched = modules.getLocalIdent;
+      const cssLoader = wywCssRule.use.find(
+        (item: any) => item.loader === 'css-loader'
+      );
+      const { modules } = cssLoader.options;
+      expect(modules.mode).toBe('global');
+      expect(
+        modules.getLocalIdent(
+          { resourcePath: '/x/file.wyw-in-js.module.css' },
+          'name',
+          'foo'
+        )
+      ).toBe('foo');
+    });
 
-    expect(
-      patched({ resourcePath: '/x/file.wyw-in-js.module.css' }, 'name', 'foo')
-    ).toBe('foo');
+    const originalCssRules = rules.filter(
+      (rule) => String(rule.test) === String(/\.module\.css$/)
+    );
+    originalCssRules.forEach((originalCssRule) => {
+      const cssLoader = originalCssRule.use.find(
+        (item: any) => item.loader === 'css-loader'
+      );
+      expect(
+        cssLoader.options.modules.getLocalIdent(
+          { resourcePath: '/x/file.module.css' },
+          'name',
+          'foo'
+        )
+      ).toBe('hashed_foo');
+    });
 
-    const originalCssRule = rules[2];
-    expect(
-      originalCssRule.use[0].options.modules.getLocalIdent(
-        { resourcePath: '/x/file.module.css' },
-        'name',
-        'foo'
-      )
-    ).toBe('hashed_foo');
+    nextConfig.webpack!(config, { dev: true } as any);
+    expect(rules).toHaveLength(5);
   });
 
   it('rejects non-JSON turbopack loader options', () => {

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -7,11 +7,18 @@ import {
 import type { LoaderOptions as WywTurbopackLoaderOptions } from '@wyw-in-js/turbopack-loader';
 import type { LoaderOptions as WywWebpackLoaderOptions } from '@wyw-in-js/webpack-loader';
 import type { NextConfig } from 'next';
-import type { Configuration, RuleSetRule, RuleSetUseItem } from 'webpack';
+import type {
+  Configuration,
+  RuleSetRule,
+  RuleSetUseFunction,
+  RuleSetUseItem,
+} from 'webpack';
 
 const DEFAULT_EXTENSION = '.wyw-in-js.module.css';
 const CSS_OUTPUT_QUERY = '__wyw_css';
 const CSS_OUTPUT_QUERY_RE = new RegExp(`^\\??${CSS_OUTPUT_QUERY}$`);
+const NODE_MODULES_RE = /[\\/]node_modules[\\/]/;
+const WYW_LOADER_USE = Symbol('wywLoaderUse');
 
 const DEFAULT_TURBO_RULE_KEYS = ['*.js', '*.jsx', '*.ts', '*.tsx'];
 
@@ -35,6 +42,9 @@ type NextVersion = {
   major: number;
   minor: number;
 };
+type WywLoaderUseFunction = RuleSetUseFunction & {
+  [WYW_LOADER_USE]: string;
+};
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -57,10 +67,29 @@ function normalizeUseItems(use: RuleSetRule['use']): RuleSetUseItem[] | null {
   return list.length ? (list as RuleSetUseItem[]) : null;
 }
 
+function isWywLoaderUseFunction(
+  item: RuleSetUseItem
+): item is WywLoaderUseFunction {
+  return typeof item === 'function' && WYW_LOADER_USE in item;
+}
+
 function getLoaderName(item: RuleSetUseItem): string {
   if (typeof item === 'string') return item;
+  if (isWywLoaderUseFunction(item)) return item[WYW_LOADER_USE];
   if (isUseLoaderObject(item)) return item.loader;
   return '';
+}
+
+function createWywLoaderUseFunction(
+  loader: string,
+  loaderItem: RuleSetUseItem
+): WywLoaderUseFunction {
+  const use: RuleSetUseFunction = ({ realResource, resource }) => {
+    const resourcePath = realResource ?? resource;
+    return resourcePath && NODE_MODULES_RE.test(resourcePath) ? [] : loaderItem;
+  };
+
+  return Object.assign(use, { [WYW_LOADER_USE]: loader });
 }
 
 function isWywLoaderPath(loader: string) {
@@ -241,17 +270,6 @@ function ensureWywCssModuleRules(
 
     const expectedTestSource = `${escapeRegExp(extensionSuffix)}$`;
 
-    const alreadyPresent = rule.oneOf.some((candidate) => {
-      if (!candidate || typeof candidate !== 'object') return false;
-
-      const { test } = candidate as RuleSetRule;
-      return test instanceof RegExp && test.source === expectedTestSource;
-    });
-
-    if (alreadyPresent) {
-      return;
-    }
-
     const oneOf = rule.oneOf as unknown[];
     for (let idx = 0; idx < oneOf.length; idx += 1) {
       const candidate = oneOf[idx];
@@ -260,7 +278,9 @@ function ensureWywCssModuleRules(
         const { test } = candidateRule;
 
         const isModuleCssRule =
-          test instanceof RegExp && test.source.includes('\\.module\\.css');
+          test instanceof RegExp &&
+          test.source !== expectedTestSource &&
+          test.source.includes('\\.module\\.css');
 
         if (isModuleCssRule) {
           const use = normalizeUseItems(candidateRule.use);
@@ -269,13 +289,21 @@ function ensureWywCssModuleRules(
               (item) =>
                 isUseLoaderObject(item) && item.loader.includes('css-loader')
             );
-            if (hasCssLoader) {
+            const previous = oneOf[idx - 1];
+            const previousIsWywCssRule =
+              previous !== null &&
+              typeof previous === 'object' &&
+              (previous as RuleSetRule).test instanceof RegExp &&
+              ((previous as RuleSetRule).test as RegExp).source ===
+                expectedTestSource;
+
+            if (hasCssLoader && !previousIsWywCssRule) {
               oneOf.splice(
                 idx,
                 0,
                 createWywCssModuleRule(candidateRule, extensionSuffix)
               );
-              break;
+              idx += 1;
             }
           }
         }
@@ -310,9 +338,10 @@ function injectWywLoader(
     loader,
     options: loaderOptions,
   };
+  const wywLoaderUse = createWywLoaderUseFunction(loader, wywLoaderItem);
 
   traverseRules(config.module?.rules ?? [], (rule) => {
-    convertLoaderRuleToUseRule(rule, wywLoaderItem);
+    convertLoaderRuleToUseRule(rule, wywLoaderUse);
 
     const use = normalizeUseItems(rule.use);
     if (!use) return;
@@ -332,7 +361,7 @@ function injectWywLoader(
     if (!isNextJsTranspileRule) return;
 
     // Loader order is right-to-left. We want WyW to run first, so it should be last.
-    Object.assign(rule, { use: [...use, wywLoaderItem] });
+    Object.assign(rule, { use: [...use, wywLoaderUse] });
   });
 
   ensureWywCssModuleRules(config, extension);


### PR DESCRIPTION
Fixes #369.
Fixes #370.

## Summary

- apply the WyW webpack loader only to project resources while leaving Next.js App Router dependency loaders intact
- create class-name-preserving CSS rules for every App and Pages Router issuer layer
- add regression coverage for mixed-router CSS and `node_modules` ESM dependencies

## Root cause

The Next.js integration appended the WyW loader to App Router transpilation rules that also match dependencies. It also cloned only the first CSS Modules rule, which belongs to the App Router when both routers are present. As a result, dependencies could be transformed directly by WyW and Pages Router sidecar CSS could be renamed by CSS Modules.

## Validation

- `bun run --filter @wyw-in-js/nextjs test`
- `bun run --filter @wyw-in-js/nextjs lint`
- `bun run --filter @wyw-in-js/nextjs build:types`
- both issue reproductions with Next.js 16.2.12 and webpack
