### PR TITLE
fix(transform): keep execute strategy evaluator-owned

### DIFF
--- a/.changeset/execute-evaluator-preval.md
+++ b/.changeset/execute-evaluator-preval.md
@@ -1,0 +1,5 @@
+---
+'@wyw-in-js/transform': patch
+---
+
+Keep interpolation values evaluator-owned when `eval.strategy` is set to `execute`.

--- a/packages/transform/src/__tests__/oxc-collect-runtime.test.ts
+++ b/packages/transform/src/__tests__/oxc-collect-runtime.test.ts
@@ -407,6 +407,7 @@ export const whiteColor = '#fff';`);
           prevalPayload: createPrevalPayload({
             evalValues: new Map([['_exp', 'red']]),
             filename,
+            strategy: 'hybrid',
           }),
         },
         null
@@ -491,6 +492,7 @@ export const whiteColor = '#fff';`);
           prevalPayload: createPrevalPayload({
             evalValues: new Map([['_exp', 'red']]),
             filename,
+            strategy: 'hybrid',
           }),
         },
         null

--- a/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
+++ b/packages/transform/src/__tests__/oxc-preeval-stage.test.ts
@@ -94,7 +94,7 @@ describe('runOxcPreevalStage', () => {
     expect(result.code).not.toContain('__wywPreval = { _exp: _exp }');
   });
 
-  it('keeps static local values in __wywPreval when eval.strategy uses execute', () => {
+  it('keeps execute dependencies evaluator-owned after finalization', () => {
     const result = runOxcPreevalStage(
       `
         import { css } from 'test-package';
@@ -114,6 +114,13 @@ describe('runOxcPreevalStage', () => {
     );
 
     expect(result.staticValueCache.has('_exp')).toBe(false);
+    expect(result.dependencyNames).toEqual(['_exp']);
+    expect(result.code).toContain('__wywPreval = { _exp: _exp }');
+
+    result.finalizeEvaltimeReplacements?.(result.staticValueCache);
+
+    expect(result.staticValueCache).toEqual(new Map());
+    expect(result.staticValueCandidates).toEqual([]);
     expect(result.dependencyNames).toEqual(['_exp']);
     expect(result.code).toContain('__wywPreval = { _exp: _exp }');
   });

--- a/packages/transform/src/__tests__/transform.static-import-values.test.ts
+++ b/packages/transform/src/__tests__/transform.static-import-values.test.ts
@@ -5198,6 +5198,60 @@ describe('transform static import value inlining', () => {
     }
   });
 
+  it('evaluates same-file styled selector chains with eval.strategy execute', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
+    const entryFile = join(root, 'entry.js');
+    const cache = new TransformCacheCollection();
+    const perf = createPerfEventRecorder();
+
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'app' }));
+    writeFileSync(
+      entryFile,
+      dedent`
+        import { styled } from 'test-styled-processor';
+
+        const Base = styled.div\`
+          color: red;
+        \`;
+
+        export const Root = styled(Base)\`
+          font-size: 12px;
+        \`;
+
+        export const Wrapper = styled.div\`
+          & > ${'${Root}'} {
+            color: blue;
+          }
+        \`;
+      `
+    );
+
+    try {
+      const result = await runTransform(
+        root,
+        entryFile,
+        cache,
+        perf.eventEmitter,
+        {
+          eval: { strategy: 'execute' },
+        }
+      );
+
+      expect(result.cssText).toContain('color:red');
+      expect(result.cssText).toContain('font-size:12px');
+      expect(result.cssText).toContain('color:blue');
+      expect(result.cssText).toMatch(
+        /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\s*\{[^}]*font-size:12px;[^}]*\}/s
+      );
+      expect(result.cssText).toMatch(
+        />\s*\.[A-Za-z0-9_-]+\s*\{[^}]*color:blue;[^}]*\}/s
+      );
+      expect(perf.counts.get('transform:evalFile') ?? 0).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('inlines same-file styled base metadata without eval', async () => {
     const root = mkdtempSync(join(tmpdir(), 'wyw-static-import-'));
     const entryFile = join(root, 'entry.js');

--- a/packages/transform/src/transform/__tests__/prevalPayload.test.ts
+++ b/packages/transform/src/transform/__tests__/prevalPayload.test.ts
@@ -8,6 +8,7 @@ describe('createPrevalPayload', () => {
   const originalNodeEnv = process.env.NODE_ENV;
 
   afterEach(() => {
+    jest.restoreAllMocks();
     if (originalNodeEnv === undefined) {
       delete process.env.NODE_ENV;
     } else {
@@ -18,6 +19,7 @@ describe('createPrevalPayload', () => {
   it('creates a static-only payload when eval is skipped', () => {
     const payload = createPrevalPayload({
       filename,
+      strategy: 'static',
       staticDependencies: ['/project/src/tokens.ts'],
       staticValues: new Map([['_exp', 'red']]),
     });
@@ -27,7 +29,49 @@ describe('createPrevalPayload', () => {
     expect(payload.sources).toEqual(new Map([['_exp', 'static']]));
   });
 
-  it('overlays static values after eval values and records per-name sources', () => {
+  it.each(['test', 'staging', 'production'])(
+    'uses evaluated values and dependencies exclusively for execute with NODE_ENV=%s',
+    (nodeEnv) => {
+      process.env.NODE_ENV = nodeEnv;
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const payload = createPrevalPayload({
+        evalDependencies: ['/project/src/eval-only.ts'],
+        evalValues: new Map([['_exp', 'eval-red']]),
+        filename,
+        staticDependencies: ['/project/src/static-only.ts'],
+        staticValues: new Map([
+          ['_exp', 'static-red'],
+          ['_exp2', 'static-blue'],
+        ]),
+        strategy: 'execute',
+      });
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(payload.dependencies).toEqual(['/project/src/eval-only.ts']);
+      expect(payload.values).toEqual(new Map([['_exp', 'eval-red']]));
+      expect(payload.sources).toEqual(new Map([['_exp', 'eval']]));
+    }
+  );
+
+  it('uses static values and dependencies exclusively for static', () => {
+    const payload = createPrevalPayload({
+      evalDependencies: ['/project/src/eval-only.ts'],
+      evalValues: new Map([
+        ['_exp', 'eval-red'],
+        ['_exp2', 'eval-blue'],
+      ]),
+      filename,
+      staticDependencies: ['/project/src/static-only.ts'],
+      staticValues: new Map([['_exp2', 'static-blue']]),
+      strategy: 'static',
+    });
+
+    expect(payload.dependencies).toEqual(['/project/src/static-only.ts']);
+    expect(payload.values).toEqual(new Map([['_exp2', 'static-blue']]));
+    expect(payload.sources).toEqual(new Map([['_exp2', 'static']]));
+  });
+
+  it('combines hybrid values and records static precedence on overlap', () => {
     const payload = createPrevalPayload({
       evalDependencies: ['/project/src/eval-only.ts'],
       evalValues: new Map([
@@ -40,6 +84,7 @@ describe('createPrevalPayload', () => {
         '/project/src/eval-only.ts',
       ],
       staticValues: new Map([['_exp2', 'eval-blue']]),
+      strategy: 'hybrid',
     });
 
     expect(payload.dependencies).toEqual([
@@ -60,7 +105,7 @@ describe('createPrevalPayload', () => {
     );
   });
 
-  it('throws on static/eval disagreement outside production', () => {
+  it('throws on hybrid disagreement outside production', () => {
     process.env.NODE_ENV = 'test';
 
     expect(() =>
@@ -68,11 +113,12 @@ describe('createPrevalPayload', () => {
         evalValues: new Map([['_exp', 'eval-red']]),
         filename,
         staticValues: new Map([['_exp', 'static-red']]),
+        strategy: 'hybrid',
       })
     ).toThrow('[wyw-in-js] PrevalPayload disagreement');
   });
 
-  it('warns and keeps static precedence on disagreement in production', () => {
+  it('warns and keeps static precedence on hybrid disagreement in production', () => {
     process.env.NODE_ENV = 'production';
     const warnings: string[] = [];
     const payload = createPrevalPayload({
@@ -80,11 +126,23 @@ describe('createPrevalPayload', () => {
       evalValues: new Map([['_exp', 'eval-red']]),
       filename,
       staticValues: new Map([['_exp', 'static-red']]),
+      strategy: 'hybrid',
     });
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain('PrevalPayload disagreement');
     expect(payload.values).toEqual(new Map([['_exp', 'static-red']]));
     expect(payload.sources).toEqual(new Map([['_exp', 'static']]));
+  });
+
+  it('deduplicates selected dependencies in hybrid mode', () => {
+    const payload = createPrevalPayload({
+      evalDependencies: ['/project/src/shared.ts'],
+      filename,
+      staticDependencies: ['/project/src/shared.ts'],
+      strategy: 'hybrid',
+    });
+
+    expect(payload.dependencies).toEqual(['/project/src/shared.ts']);
   });
 });

--- a/packages/transform/src/transform/generators/__tests__/workflow.metadata.test.ts
+++ b/packages/transform/src/transform/generators/__tests__/workflow.metadata.test.ts
@@ -16,6 +16,7 @@ const evalPayload = createPrevalPayload({
   evalDependencies: ['/dep.ts'],
   evalValues: new Map(),
   filename: '/src/entry.tsx',
+  strategy: 'hybrid',
 });
 
 describe('workflow metadata output', () => {

--- a/packages/transform/src/transform/generators/evalFile.ts
+++ b/packages/transform/src/transform/generators/evalFile.ts
@@ -18,11 +18,14 @@ export async function* evalFile(
     entrypoint.loadedAndParsed.evaluator === 'ignored'
       ? entrypoint.name
       : entrypoint.loadedAndParsed.evalConfig.filename ?? entrypoint.name;
+  const strategy =
+    this.services.options.pluginOptions.eval?.strategy ?? 'hybrid';
 
   if (preevalResult && (preevalResult.dependencyNames?.length ?? 0) === 0) {
     const prevalPayload = createPrevalPayload({
       emitWarning: this.services.emitWarning,
       filename,
+      strategy,
       staticDependencies: preevalResult.staticDependencies,
       staticValues: preevalResult.staticValueCache,
     });
@@ -63,6 +66,7 @@ export async function* evalFile(
     evalDependencies: evaluated.dependencies,
     evalValues: evaluated.values,
     filename,
+    strategy,
     staticDependencies: preevalResult?.staticDependencies,
     staticValues: preevalResult?.staticValueCache,
   });

--- a/packages/transform/src/transform/prevalPayload.ts
+++ b/packages/transform/src/transform/prevalPayload.ts
@@ -1,4 +1,5 @@
 import type { ValueCache } from '@wyw-in-js/processor-utils';
+import type { EvalStrategy } from '@wyw-in-js/shared';
 import { isDeepStrictEqual } from 'util';
 
 export type PrevalPayloadSource = 'eval' | 'static';
@@ -14,6 +15,7 @@ export type CreatePrevalPayloadInput = {
   evalDependencies?: readonly string[];
   evalValues?: Map<string, unknown> | null;
   filename: string;
+  strategy: EvalStrategy;
   staticDependencies?: readonly string[];
   staticValues?: Map<string, unknown> | null;
 };
@@ -64,6 +66,7 @@ export const createPrevalPayload = ({
   evalDependencies = [],
   evalValues,
   filename,
+  strategy,
   staticDependencies = [],
   staticValues,
 }: CreatePrevalPayloadInput): PrevalPayload => {
@@ -71,30 +74,35 @@ export const createPrevalPayload = ({
   const sources = new Map<string, PrevalPayloadSource>();
   const values: ValueCache = new Map();
 
-  evalDependencies.forEach((dependency) => addUnique(dependencies, dependency));
-  staticDependencies.forEach((dependency) =>
-    addUnique(dependencies, dependency)
-  );
+  if (strategy !== 'static') {
+    evalDependencies.forEach((dependency) =>
+      addUnique(dependencies, dependency)
+    );
+    evalValues?.forEach((value, name) => {
+      values.set(name, value);
+      sources.set(String(name), 'eval');
+    });
+  }
 
-  evalValues?.forEach((value, name) => {
-    values.set(name, value);
-    sources.set(String(name), 'eval');
-  });
+  if (strategy !== 'execute') {
+    staticDependencies.forEach((dependency) =>
+      addUnique(dependencies, dependency)
+    );
+    staticValues?.forEach((value, name) => {
+      if (values.has(name) && !isDeepStrictEqual(values.get(name), value)) {
+        handleDisagreement(
+          filename,
+          String(name),
+          values.get(name),
+          value,
+          emitWarning
+        );
+      }
 
-  staticValues?.forEach((value, name) => {
-    if (values.has(name) && !isDeepStrictEqual(values.get(name), value)) {
-      handleDisagreement(
-        filename,
-        String(name),
-        values.get(name),
-        value,
-        emitWarning
-      );
-    }
-
-    values.set(name, value);
-    sources.set(String(name), 'static');
-  });
+      values.set(name, value);
+      sources.set(String(name), 'static');
+    });
+  }
 
   return {
     dependencies,

--- a/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
+++ b/packages/transform/src/utils/applyOxcProcessors/applyOxcProcessors.ts
@@ -341,6 +341,13 @@ export const applyOxcProcessors = (
     byLocal: Map<string, unknown>;
     values: OxcStaticValue[];
   } => {
+    if (!collectStaticExpressionValues) {
+      return {
+        byLocal: new Map(),
+        values: [],
+      };
+    }
+
     const availableStaticValues =
       collectAvailableStaticValues(staticValueCache);
     const byLocal = collectSameFileProcessorStaticValuesByLocal(


### PR DESCRIPTION
## Summary

- prevent deferred processor finalization from materializing static interpolation values in `execute` mode
- select preval values and dependencies according to `eval.strategy`
- preserve the existing disagreement detection for `hybrid`
- add regression coverage for same-file styled-component selector chains
- add a patch changeset

## Root cause

`execute` initially disabled static expression evaluation, but deferred processor callback finalization repopulated the static cache with same-file styled metadata. `createPrevalPayload` then merged those values after the evaluator output, allowing static values to override evaluator-owned values and triggering a disagreement when their shapes differed.

## Validation

- `bun test packages/transform/src` — 1520 passed, 0 failed
- `bun run --filter @wyw-in-js/transform build:types`
- `bun run --filter @wyw-in-js/transform lint`
- Prettier check
- `git diff --check`

Closes #367
